### PR TITLE
Auto truncate

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,8 @@ A brief description of the available options in PFLARE are given below and their
    | ``-pc_air_print_stats_timings``  |  PCAIRGetPrintStatsTimings  PCAIRSetPrintStatsTimings  | Print out statistics about the multigrid hierarchy and timings | false |       
    | ``-pc_air_max_levels``  |  PCAIRGetMaxLevels  PCAIRSetMaxLevels  | Maximum number of levels in the hierarchy | 300 |
    | ``-pc_air_coarse_eq_limit``  |  PCAIRGetCoarseEqLimit  PCAIRSetCoarseEqLimit  | Minimum number of global unknowns on the coarse grid | 6 |   
+   | ``-pc_air_auto_truncate_start_level``  |  PCAIRGetAutoTruncateStartLevel  PCAIRSetAutoTruncateStartLevel  | Build a coarse solver on each level from this one and use it to determine if we can truncate the hierarchy | -1 |
+   | ``-pc_air_auto_truncate_tol``  |  PCAIRGetAutoTruncateTol  PCAIRSetAutoTruncateTol  | Tolerance used to determine if the coarse solver is good enough to truncate at a given level | 1e-14 | 
    | ``-pc_air_r_drop``  |  PCAIRGetRDrop  PCAIRSetRDrop  | Drop tolerance applied to R on each level after it is built | 0.01 |
    | ``-pc_air_a_drop``  |  PCAIRGetADrop  PCAIRSetADrop  | Drop tolerance applied to the coarse matrix on each level after it is built | 0.001 |
    | ``-pc_air_a_lump``  |  PCAIRSetALump  PCAIRSetALump  | Lump rather than drop for the coarse matrix | false |         

--- a/include/pflare.h
+++ b/include/pflare.h
@@ -56,6 +56,8 @@ PETSC_EXTERN PetscErrorCode PCPFLAREINVSetMatrixFree(PC, PetscBool);
 PETSC_EXTERN PetscErrorCode PCAIRGetPrintStatsTimings(PC, PetscBool *);
 PETSC_EXTERN PetscErrorCode PCAIRGetMaxLevels(PC, PetscInt *);
 PETSC_EXTERN PetscErrorCode PCAIRGetCoarseEqLimit(PC, PetscInt *);
+PETSC_EXTERN PetscErrorCode PCAIRGetAutoTruncateStartLevel(PC, PetscInt *);
+PETSC_EXTERN PetscErrorCode PCAIRGetAutoTruncateTol(PC, PetscReal *);
 PETSC_EXTERN PetscErrorCode PCAIRGetNumLevels(PC, PetscInt *);
 PETSC_EXTERN PetscErrorCode PCAIRGetProcessorAgglom(PC, PetscBool *);
 PETSC_EXTERN PetscErrorCode PCAIRGetProcessorAgglomRatio(PC, PetscReal *);
@@ -97,6 +99,8 @@ PETSC_EXTERN PetscErrorCode PCAIRGetPolyCoeffs(PC, PetscInt, int, PetscReal **, 
 PETSC_EXTERN PetscErrorCode PCAIRSetPrintStatsTimings(PC, PetscBool);
 PETSC_EXTERN PetscErrorCode PCAIRSetMaxLevels(PC, PetscInt);
 PETSC_EXTERN PetscErrorCode PCAIRSetCoarseEqLimit(PC, PetscInt);
+PETSC_EXTERN PetscErrorCode PCAIRSetAutoTruncateStartLevel(PC, PetscInt);
+PETSC_EXTERN PetscErrorCode PCAIRSetAutoTruncateTol(PC, PetscReal);
 PETSC_EXTERN PetscErrorCode PCAIRSetProcessorAgglom(PC, PetscBool);
 PETSC_EXTERN PetscErrorCode PCAIRSetProcessorAgglomRatio(PC, PetscReal);
 PETSC_EXTERN PetscErrorCode PCAIRSetProcessorAgglomFactor(PC, PetscInt);

--- a/src/AIR_Data_Type.F90
+++ b/src/AIR_Data_Type.F90
@@ -38,8 +38,9 @@ module air_data_type
       ! Minimum number of global unknowns on the coarse grid
       ! -pc_air_coarse_eq_limit
       PetscInt :: coarse_eq_limit = 6
-      ! From this level onwards, evaluate if a coarse grid solver is good enough would be
-      ! and use that to determine if we should truncate on that level
+      ! From this level onwards, build and then evaluate if the coarse grid solver
+      ! is good enough and use that to determine if we should truncate on that level
+      ! -pc_air_auto_truncate_start_level
       integer :: auto_truncate_start_level = -1
       ! What relative tolerance to use to determine if a coarse grid solver is good enough
       ! -pc_air_auto_truncate_tol

--- a/src/AIR_Data_Type.F90
+++ b/src/AIR_Data_Type.F90
@@ -23,6 +23,7 @@ module air_data_type
    ! advection equations (ie purely hyperbolic) on a 2D unstructured
    ! triangular mesh
    ! Can be changed via command line arguments
+   ! These defaults need to match those in destroy_air_data
    type air_options
 
       ! Print out stats and timings
@@ -37,6 +38,12 @@ module air_data_type
       ! Minimum number of global unknowns on the coarse grid
       ! -pc_air_coarse_eq_limit
       PetscInt :: coarse_eq_limit = 6
+      ! From this level onwards, evaluate if a coarse grid solver is good enough would be
+      ! and use that to determine if we should truncate on that level
+      integer :: auto_truncate_start_level = -1
+      ! What relative tolerance to use to determine if a coarse grid solver is good enough
+      ! -pc_air_auto_truncate_tol
+      real :: auto_truncate_tol = 1e-14
 
       ! Perform processor agglomeration throughout the hierarchy
       ! This reduces the number of active MPI ranks as we coarsen

--- a/src/AIR_MG_Setup.F90
+++ b/src/AIR_MG_Setup.F90
@@ -780,7 +780,7 @@ module air_mg_setup
 
       call timer_finish(TIMER_ID_AIR_RESTRICT)      
 
-      call timer_start(TIMER_ID_AIR_IDENTIY)            
+      call timer_start(TIMER_ID_AIR_IDENTITY)            
 
       ! ~~~~~~~~~
       ! Previously in the FC smoothing (see dba0a996be147698d7f9ce07741e7d925001ea66) 
@@ -812,7 +812,7 @@ module air_mg_setup
          end if 
       end if       
       
-      call timer_finish(TIMER_ID_AIR_IDENTIY)            
+      call timer_finish(TIMER_ID_AIR_IDENTITY)            
       
       ! Delete temporary if not reusing
       if (.NOT. air_data%options%reuse_sparsity) then

--- a/src/PCAIR_C_Fortran_Bindings.F90
+++ b/src/PCAIR_C_Fortran_Bindings.F90
@@ -72,6 +72,40 @@ module pcair_c_fortran_bindings
 
 ! -------------------------------------------------------------------------------------------------------------------------------
 
+   subroutine PCAIRGetAutoTruncateStartLevel_c(pc_ptr, start_level) bind(C, name='PCAIRGetAutoTruncateStartLevel_c')
+
+      ! ~~~~~~~~
+      integer(c_long_long), intent(inout) :: pc_ptr
+      PetscInt, intent(out)               :: start_level
+
+      type(tPC)                  :: pc
+      PetscErrorCode         :: ierr
+      ! ~~~~~~~~
+
+      pc%v = pc_ptr
+      call PCAIRGetAutoTruncateStartLevel(pc, start_level, ierr)
+
+   end subroutine PCAIRGetAutoTruncateStartLevel_c   
+
+! -------------------------------------------------------------------------------------------------------------------------------
+
+   subroutine PCAIRGetAutoTruncateTol_c(pc_ptr, tol) bind(C, name='PCAIRGetAutoTruncateTol_c')
+
+      ! ~~~~~~~~
+      integer(c_long_long), intent(inout) :: pc_ptr
+      PetscReal, intent(out)        :: tol
+
+      type(tPC)                  :: pc
+      PetscErrorCode         :: ierr
+      ! ~~~~~~~~
+
+      pc%v = pc_ptr
+      call PCAIRGetAutoTruncateTol(pc, tol, ierr)
+
+   end subroutine PCAIRGetAutoTruncateTol_c   
+
+! -------------------------------------------------------------------------------------------------------------------------------
+
    subroutine PCAIRGetNumLevels_c(pc_ptr, num_levels) bind(C, name='PCAIRGetNumLevels_c')
 
       ! ~~~~~~~~
@@ -833,6 +867,40 @@ module pcair_c_fortran_bindings
       call PCAIRSetCoarseEqLimit(pc, coarse_eq_limit, ierr)
 
    end subroutine PCAIRSetCoarseEqLimit_c   
+   
+! -------------------------------------------------------------------------------------------------------------------------------
+
+   subroutine PCAIRSetAutoTruncateStartLevel_c(pc_ptr, start_level) bind(C, name='PCAIRSetAutoTruncateStartLevel_c')
+
+      ! ~~~~~~~~
+      integer(c_long_long), intent(inout) :: pc_ptr
+      PetscInt, value, intent(in)          :: start_level
+
+      type(tPC)                  :: pc
+      PetscErrorCode         :: ierr
+      ! ~~~~~~~~
+
+      pc%v = pc_ptr
+      call PCAIRSetAutoTruncateStartLevel(pc, start_level, ierr)
+
+   end subroutine PCAIRSetAutoTruncateStartLevel_c   
+
+! -------------------------------------------------------------------------------------------------------------------------------
+
+   subroutine PCAIRSetAutoTruncateTol_c(pc_ptr, tol) bind(C, name='PCAIRSetAutoTruncateTol_c')
+
+      ! ~~~~~~~~
+      integer(c_long_long), intent(inout) :: pc_ptr
+      PetscReal, value, intent(in)         :: tol
+
+      type(tPC)                  :: pc
+      PetscErrorCode         :: ierr
+      ! ~~~~~~~~
+
+      pc%v = pc_ptr
+      call PCAIRSetAutoTruncateTol(pc, tol, ierr)
+
+   end subroutine PCAIRSetAutoTruncateTol_c   
    
 ! -------------------------------------------------------------------------------------------------------------------------------
 

--- a/src/PCAIR_Interfaces.F90
+++ b/src/PCAIR_Interfaces.F90
@@ -155,6 +155,44 @@ module pcair_interfaces
 
 ! -------------------------------------------------------------------------------------------------------------------------------
 
+   subroutine PCAIRGetAutoTruncateStartLevel(pc, start_level, ierr) 
+
+      ! ~~~~~~~~
+      type(tPC), intent(inout)      :: pc
+      PetscInt, intent(out)         :: start_level
+      PetscErrorCode, intent(out)   :: ierr
+
+      type(air_options), pointer :: options
+      ! ~~~~~~~~
+
+      ! Get the options
+      call PCAIRGetOptions(pc, options)    
+      start_level = options%auto_truncate_start_level
+      ierr = 0
+
+   end subroutine PCAIRGetAutoTruncateStartLevel   
+
+! -------------------------------------------------------------------------------------------------------------------------------
+
+   subroutine PCAIRGetAutoTruncateTol(pc, tol, ierr) 
+
+      ! ~~~~~~~~
+      type(tPC), intent(inout)      :: pc
+      PetscReal, intent(out)        :: tol
+      PetscErrorCode, intent(out)   :: ierr
+
+      type(air_options), pointer :: options
+      ! ~~~~~~~~
+
+      ! Get the options
+      call PCAIRGetOptions(pc, options)    
+      tol = options%auto_truncate_tol
+      ierr = 0
+
+   end subroutine PCAIRGetAutoTruncateTol   
+
+! -------------------------------------------------------------------------------------------------------------------------------
+
    subroutine PCAIRGetNumLevels(pc, num_levels, ierr) 
 
       ! ~~~~~~~~
@@ -1155,6 +1193,44 @@ module pcair_interfaces
       ierr = 0
 
    end subroutine PCAIRSetCoarseEqLimit   
+
+! -------------------------------------------------------------------------------------------------------------------------------
+
+   subroutine PCAIRSetAutoTruncateStartLevel(pc, start_level, ierr) 
+
+      ! ~~~~~~~~
+      type(tPC), intent(inout)      :: pc
+      PetscInt, intent(in)          :: start_level
+      PetscErrorCode, intent(out)   :: ierr
+
+      type(air_options), pointer :: options
+      ! ~~~~~~~~
+
+      ! Set the options
+      call PCAIRGetOptions(pc, options)    
+      options%auto_truncate_start_level = int(start_level)
+      ierr = 0
+
+   end subroutine PCAIRSetAutoTruncateStartLevel   
+
+! -------------------------------------------------------------------------------------------------------------------------------
+
+   subroutine PCAIRSetAutoTruncateTol(pc, tol, ierr) 
+
+      ! ~~~~~~~~
+      type(tPC), intent(inout)      :: pc
+      PetscReal, intent(in)         :: tol
+      PetscErrorCode, intent(out)   :: ierr
+
+      type(air_options), pointer :: options
+      ! ~~~~~~~~
+
+      ! Set the options
+      call PCAIRGetOptions(pc, options)    
+      options%auto_truncate_tol = tol
+      ierr = 0
+
+   end subroutine PCAIRSetAutoTruncateTol   
    
 ! -------------------------------------------------------------------------------------------------------------------------------
 

--- a/src/Timers.F90
+++ b/src/Timers.F90
@@ -19,7 +19,7 @@ module timers
                               TIMER_ID_AIR_PROC_AGGLOM = 8, &
                               TIMER_ID_AIR_COARSEN = 9, &
                               TIMER_ID_AIR_CONSTRAIN = 10, &
-                              TIMER_ID_AIR_IDENTIY = 11, &
+                              TIMER_ID_AIR_IDENTITY = 11, &
                               TIMER_ID_AIR_TRUNCATE = 12
 
    public :: timer_start, timer_finish, timer_reset, timer_clear
@@ -49,7 +49,7 @@ subroutine print_timers()
    print *,  "prolong time     :", timer_time(TIMER_ID_AIR_PROLONG)
    print *,  "constrain time   :", timer_time(TIMER_ID_AIR_CONSTRAIN)       
    print *,  "rap time         :", timer_time(TIMER_ID_AIR_RAP)
-   print *,  "identity time    :", timer_time(TIMER_ID_AIR_IDENTIY)
+   print *,  "identity time    :", timer_time(TIMER_ID_AIR_IDENTITY)
    print *,  "drop time        :", timer_time(TIMER_ID_AIR_DROP)
    print *,  "truncate time    :", timer_time(TIMER_ID_AIR_TRUNCATE)
 

--- a/src/Timers.F90
+++ b/src/Timers.F90
@@ -19,7 +19,8 @@ module timers
                               TIMER_ID_AIR_PROC_AGGLOM = 8, &
                               TIMER_ID_AIR_COARSEN = 9, &
                               TIMER_ID_AIR_CONSTRAIN = 10, &
-                              TIMER_ID_AIR_IDENTIY = 11
+                              TIMER_ID_AIR_IDENTIY = 11, &
+                              TIMER_ID_AIR_TRUNCATE = 12
 
    public :: timer_start, timer_finish, timer_reset, timer_clear
 
@@ -50,6 +51,7 @@ subroutine print_timers()
    print *,  "rap time         :", timer_time(TIMER_ID_AIR_RAP)
    print *,  "identity time    :", timer_time(TIMER_ID_AIR_IDENTIY)
    print *,  "drop time        :", timer_time(TIMER_ID_AIR_DROP)
+   print *,  "truncate time    :", timer_time(TIMER_ID_AIR_TRUNCATE)
 
 end subroutine print_timers
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -238,6 +238,12 @@ run_tests:
 	 -pc_pflareinv_matrix_free -pc_pflareinv_order 50
 # 
 	@echo ""
+	@echo "Test auto truncation with matrix-free Newton polynomials as coarse grid solver" 
+	./adv_diff_2d.o -da_grid_x 10 -da_grid_y 10 -ksp_type richardson -pc_type air \
+	 -pc_air_coarsest_inverse_type newton -pc_air_coarsest_poly_order 10 -pc_air_coarsest_matrix_free_polys \
+	 -pc_air_auto_truncate_start_level 1 -pc_air_auto_truncate_tol 1e-2
+# 
+	@echo ""
 	@echo "Test PMISR DDC CF splitting in C"
 	./ex6_cf_splitting.o  -f data/mat_stream_2364
 	@echo "Test PMISR DDC CF splitting in C in parallel"


### PR DESCRIPTION
Can now auto truncate the hierarchy based on the quality of the coarse grid solver. This can be expensive unless using matrix-free polynomials as the coarse grid solver. Can also further decrease the cost of checking if the hierarchy can be truncated by only starting at a certain level in the hierarchy (we can set -pc_air_auto_truncate_start_level to be > 1)

This makes it very easy to improve the parallel scaling given one of the bottlenecks of our slow coarsening is the many levels in the hierarchy. We can now just set a high polynomial order for the coarse grid solver and have the hierarchy automatically truncated.

Experiments with advection problems suggest we can be very aggressive and use a polynomial that only solve the coarse grid to ~1e-2 (-pc_air_auto_truncate_tol 1e-2). 