### PR TITLE
Petsc make variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 # Must have defined PETSC_DIR and PETSC_ARCH before calling
 # PETSc must be at least version 3.15
 # Copied from $PETSC_DIR/share/petsc/Makefile.basic.user
+# This uses the compilers and flags defined in the PETSc configuration
 # ~~~~~~~~~~~~~~~~~
 
 # Read in the petsc compile/linking variables and makefile rules
@@ -59,6 +60,9 @@ OBJS := $(SRCDIR)/NonBusyWait.o \
 		  $(SRCDIR)/PCAIR.o \
 		  $(SRCDIR)/PCPFLAREINV.o	
 
+# Define a variable containing all the tests
+export TEST_TARGETS = ex12f ex6f ex6f_getcoeffs ex6 adv_1d adv_diff_2d ex6_cf_splitting
+
 # Add the pflare include files
 PETSC_FC_INCLUDES += $(INCLUDE)
 PETSC_CC_INCLUDES += $(INCLUDE)
@@ -84,13 +88,9 @@ $(OUT): $(OBJS)
 
 # Build the tests
 build_tests: $(OUT)
-	$(MAKE) -C tests ex12f
-	$(MAKE) -C tests ex6f
-	$(MAKE) -C tests ex6f_getcoeffs
-	$(MAKE) -C tests ex6
-	$(MAKE) -C tests ex6_cf_splitting
-	$(MAKE) -C tests adv_1d
-	$(MAKE) -C tests adv_diff_2d
+	@for t in $(TEST_TARGETS); do \
+		$(MAKE) -C tests $$t; \
+	done
 
 # Build and run all the tests
 # Only run the tests that load the 32 bit test matrix in /tests/data

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ PFLARE can scalably solve:
 
 ## Building PFLARE
 
-This library depends on MPI, BLAS, LAPACK (>= 3.4) and PETSc (3.15 to 3.22) configured with a graph partitioner (e.g., ParMETIS). Please compile PETSc directly from the source code, as PFLARE requires access to some of the PETSc types only available in the source. PFLARE has been tested with GNU, Intel, LLVM, NVIDIA and Cray compilers.
+This library depends on MPI, BLAS, LAPACK and PETSc (3.15 to 3.22) configured with a graph partitioner (e.g., ParMETIS). Please compile PETSc directly from the source code, as PFLARE requires access to some of the PETSc types only available in the source. PFLARE has been tested with GNU, Intel, LLVM, NVIDIA and Cray compilers.
 
 1) Set `PETSC_DIR` and `PETSC_ARCH` environmental variables.
 2) Call ``make`` in the top level directory to build the PFLARE library.
@@ -406,27 +406,27 @@ Running a test with OpenMP then requires setting the ``OMP_NUM_THREADS`` variabl
 
       [ Set the hex mask which describes the pinning ]
 
-      srun --oversubscribe --distribution=block:block --cpu-bind=mask_cpu:$mask adv_diff_2d.o -pc_type air
+      srun --oversubscribe --distribution=block:block --cpu-bind=mask_cpu:$mask adv_diff_2d -pc_type air
 
 ## GPU support           
 
 If PETSc has been configured with GPU support (e.g., CUDA, HIP, Kokkos) then PCPFLAREINV and PCAIR support GPUs. This relies on the matrix and vector types being set correctly by the user, which is typically done through command line options. By default the setup/solve occurs on the CPU. For example, if we solve the 1D advection problem ``tests/adv_1d`` using a 30th order GMRES polynomial applied matrix-free with the command line options:
 
-``./adv_1d.o -n 1000 -ksp_type richardson -pc_type pflareinv -pc_pflareinv_type arnoldi -pc_pflareinv_matrix_free -pc_pflareinv_order 30``
+``./adv_1d -n 1000 -ksp_type richardson -pc_type pflareinv -pc_pflareinv_type arnoldi -pc_pflareinv_matrix_free -pc_pflareinv_order 30``
 
 the setup/solve will occur on the CPU. If we want to run on GPUs, we must ensure the matrix/vector types match the appropriate GPU types. In both ``tests/adv_1d`` and ``tests/adv_diff_2d``, these types can be set through command line arguments. The types are specified with either ``-mat_type`` and ``-vec_type``, or if set by a DM directly (like in ``tests/adv_diff_2d``), use ``-dm_mat_type`` and ``-dm_vec_type``. 
 
 If using CUDA directly:
 
-``./adv_1d.o -n 1000 -ksp_type richardson -pc_type pflareinv -pc_pflareinv_type arnoldi -pc_pflareinv_matrix_free -pc_pflareinv_order 30 -mat_type aijcusparse -vec_type cuda``
+``./adv_1d -n 1000 -ksp_type richardson -pc_type pflareinv -pc_pflareinv_type arnoldi -pc_pflareinv_matrix_free -pc_pflareinv_order 30 -mat_type aijcusparse -vec_type cuda``
 
 If using HIP directly:
 
-``./adv_1d.o -n 1000 -ksp_type richardson -pc_type pflareinv -pc_pflareinv_type arnoldi -pc_pflareinv_matrix_free -pc_pflareinv_order 30 -mat_type aijhipsparse -vec_type hip``
+``./adv_1d -n 1000 -ksp_type richardson -pc_type pflareinv -pc_pflareinv_type arnoldi -pc_pflareinv_matrix_free -pc_pflareinv_order 30 -mat_type aijhipsparse -vec_type hip``
 
 If using KOKKOS (with either the CUDA or HIP back-end):
 
-``./adv_1d.o -n 1000 -ksp_type richardson -pc_type pflareinv -pc_pflareinv_type arnoldi -pc_pflareinv_matrix_free -pc_pflareinv_order 30 -mat_type aijkokkos -vec_type kokkos``
+``./adv_1d -n 1000 -ksp_type richardson -pc_type pflareinv -pc_pflareinv_type arnoldi -pc_pflareinv_matrix_free -pc_pflareinv_order 30 -mat_type aijkokkos -vec_type kokkos``
 
 For both PCPFLAREINV and PCAIR, the entirity of the solve happens on GPUs without any copies between the CPU/GPU if using either CUDA directly, or using KOKKOS with the CUDA or HIP back-end. Using HIP directly incurs copies during the solve so we would not recommend this currently. 
 
@@ -451,11 +451,11 @@ This is based around using the high-order polynomials applied matrix free as a c
 
 For example, on a single NVIDIA GPU with a 2D structured grid advection problem we apply a high order (10th order) Newton polynomial matrix-free as a coarse grid solver:
 
-``./adv_diff_2d.o -da_grid_x 1000 -da_grid_y 1000 -ksp_type richardson -pc_type air -pc_air_coarsest_inverse_type newton -pc_air_coarsest_matrix_free_polys -pc_air_coarsest_poly_order 10 -dm_mat_type aijcusparse -dm_vec_type cuda``
+``./adv_diff_2d -da_grid_x 1000 -da_grid_y 1000 -ksp_type richardson -pc_type air -pc_air_coarsest_inverse_type newton -pc_air_coarsest_matrix_free_polys -pc_air_coarsest_poly_order 10 -dm_mat_type aijcusparse -dm_vec_type cuda``
 
 The hierarchy in this case has 29 levels. If we turn on the auto truncation and set a very large truncation tolerance  
 
-``./adv_diff_2d.o -da_grid_x 1000 -da_grid_y 1000 -ksp_type richardson -pc_type air -pc_air_coarsest_inverse_type newton -pc_air_coarsest_matrix_free_polys -pc_air_coarsest_poly_order 10 -dm_mat_type aijcusparse -dm_vec_type cuda -pc_air_auto_truncate_start_level 1 -pc_air_auto_truncate_tol 1e-1``
+``./adv_diff_2d -da_grid_x 1000 -da_grid_y 1000 -ksp_type richardson -pc_type air -pc_air_coarsest_inverse_type newton -pc_air_coarsest_matrix_free_polys -pc_air_coarsest_poly_order 10 -dm_mat_type aijcusparse -dm_vec_type cuda -pc_air_auto_truncate_start_level 1 -pc_air_auto_truncate_tol 1e-1``
 
 we find that the 10th order polynomials are good enough coarse solvers to enable truncation of the hierarchy at level 11. This gives the same iteration count as without truncation and we see an overall speedup of ~1.47x in the solve on GPUs with this approach.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ PFLARE can scalably solve:
 
 ## Building PFLARE
 
-This library depends on MPI, BLAS, LAPACK and PETSc (3.15 to 3.22) configured with a graph partitioner (e.g., ParMETIS). Please compile PETSc directly from the source code, as PFLARE requires access to some of the PETSc types only available in the source. PFLARE has been tested with GNU, Intel, LLVM, NVIDIA and Cray compilers.
+This library depends on MPI, BLAS, LAPACK and PETSc (3.15 to 3.22) configured with a graph partitioner (e.g., ParMETIS). Please compile PETSc directly from the source code, as PFLARE requires access to some of the PETSc types only available in the source. PFLARE has been tested with GNU, Intel, LLVM, NVIDIA and Cray compilers. PFLARE uses the same compilers and flags used in the PETSc configure.
 
 1) Set `PETSC_DIR` and `PETSC_ARCH` environmental variables.
 2) Call ``make`` in the top level directory to build the PFLARE library.
@@ -65,15 +65,7 @@ Then if desired:
 for the Python interface:
 
 4) Call ``make python`` in the top level directory to build the Python module.
-5) Call ``make tests_python`` in the top level directory to check the Python build worked with some simple Python tests.
-
-Specific compilers (``CC`` and ``FC``) and optimisation flags (``OPT``) can be input on the command line if desired, e.g.,
-
-     make CC=cc FC=ftn OPT="-O2"
-
-along with specific link flags (``BLAS_LIB``, ``LAPACK_LIB``, ``MPI_LIB``, ``MATH_LIB``, ``METIS_LIB`` and ``PARMETIS_LIB``) for the tests
-
-     make tests CC=cc FC=ftn OPT="-O2" BLAS_LIB="-lfblas" LAPACK_LIB="-lflapack"     
+5) Call ``make tests_python`` in the top level directory to check the Python build worked with some simple Python tests.  
 
 An up to date Docker image is also available on Dockerhub which includes a build of PFLARE along with all dependencies. To run this Docker image interactively and run the tests use:
 

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,6 +1,8 @@
 # ~~~~~~~~~~~~~~~~~
 # PFLARE - Steven Dargaville
 # Makefile for python interface
+# Copied from $PETSC_DIR/share/petsc/Makefile.basic.user
+# This uses the compilers and flags defined in the PETSc configuration
 # ~~~~~~~~~~~~~~~~~
 
 # Read in the petsc compile/linking variables and makefile rules

--- a/python/Makefile
+++ b/python/Makefile
@@ -3,6 +3,10 @@
 # Makefile for python interface
 # ~~~~~~~~~~~~~~~~~
 
+# Read in the petsc compile/linking variables and makefile rules
+include ${PETSC_DIR}/lib/petsc/conf/variables
+include ${PETSC_DIR}/lib/petsc/conf/rules
+
 # Required during compilation to tell Cython where to look for libpflare
 # The CC variable has been defined to use the MPI wrapper for the C compiler in the parent Makefile
 export LIBRARY_PATH := $(LIBDIR)
@@ -42,5 +46,5 @@ run_tests:
 	$(MPIEXEC) -n 2 python3 ex2_cf_splitting.py	
 
 # Cleanup
-clean:
+clean::
 	$(RM) *.so; $(RM) pflare.c; $(RM) pflare_defs.c; $(RM) -r build/; $(RM) -r __pycache__/

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,6 +2,7 @@
 # PFLARE - Steven Dargaville
 # Makefile for tests
 # Copied from $PETSC_DIR/share/petsc/Makefile.basic.user
+# This uses the compilers and flags defined in the PETSc configuration
 # ~~~~~~~~~~~~~~~~~
 
 # Read in the petsc compile/linking variables and makefile rules
@@ -20,10 +21,12 @@ PETSC_CC_INCLUDES += $(INCLUDE)
 # Link to pflare
 LDLIBS += -L$(LIBDIR) -lpflare -Wl,-rpath,$(LIBDIR)
 
+clean::
+	$(RM) -f $(TEST_TARGETS)
+
 # ~~~~~~~~~~~
 # Run PFLARE tests
 # ~~~~~~~~~~~
-
 run_tests_load:
 #
 	@echo ""

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,113 +1,65 @@
 # ~~~~~~~~~~~~~~~~~
 # PFLARE - Steven Dargaville
 # Makefile for tests
+# Copied from $PETSC_DIR/share/petsc/Makefile.basic.user
 # ~~~~~~~~~~~~~~~~~
 
-# Have to include the modules in ../include
-INCLUDEDIR := ../include
+# Read in the petsc compile/linking variables and makefile rules
+include ${PETSC_DIR}/lib/petsc/conf/variables
+include ${PETSC_DIR}/lib/petsc/conf/rules
+
+# ~~~~~~~~~~~
+# PFLARE specific changes
+# ~~~~~~~~~~~
 # Include directories - include top level directory in case compilers output modules there
-INCLUDE := -I$(CURDIR)/../ -I$(INCLUDEDIR) -I$(PETSC_DIR)/include -I$(PETSC_DIR)/$(PETSC_ARCH)/include
+INCLUDE := -I$(CURDIR)/../ -I../include
 
-# These are the same in the top level makefile, but we redefine them here rather than use an export
-# in the top level makefile
-# That way we can compile PFLARE with openmp
-# But to build the tests we then reset the CFLAGS and FFLAGS to empty and include 
-# include -lgomp in the LDFLAGS
-# That way we don't link to threaded libraries on cray machines (as that happens automatically
-# if the flags include -fopenmp)
-CFLAGS := ${CFLAGS} $(OPT) -fPIC
-FFLAGS := ${FFLAGS} $(OPT) -fPIC
+# Add the pflare include files
+PETSC_FC_INCLUDES += $(INCLUDE)
+PETSC_CC_INCLUDES += $(INCLUDE)
+# Link to pflare
+LDLIBS += -L$(LIBDIR) -lpflare -Wl,-rpath,$(LIBDIR)
 
-# ~~~~~~~~~~~~~~~~~~~~~~~~
-# We currently don't require any compiler specific flags
-# ~~~~~~~~~~~~~~~~~~~~~~~~
-
-# If you want to override these just pass in the values when you call make from the 
-# top level directory
-# e.g., make tests BLAS_LIB="-lfblas" LAPACK_LIB="-lflapack"
-# On a cray machine typically blas/lapack linking are included by the compiler
-# e.g., make tests CC=cc FC=ftn BLAS_LIB="" LAPACK_LIB=""
-BLAS_LIB     := -lblas
-LAPACK_LIB   := -llapack
-# Can override MPI_LIB from the command line too
-MPI_LIB      := -lmpi
-# Can override MATH_LIB from command line too
-MATH_LIB     := -lm
-# Can override METIS_LIB from command line too
-METIS_LIB    := -lmetis
-# Can override PARMETIS_LIB from command line too
-PARMETIS_LIB := -lparmetis
-
-# Get any library flags we have on input
-LDFLAGS_INPUT := $(LDFLAGS)
-# Include pflare in the linking
-LDFLAGS 		:= -L$(LIBDIR) -lpflare -Wl,-rpath,$(LIBDIR)
-# Include petsc
-LDFLAGS     := $(LDFLAGS) -L$(PETSC_DIR)/$(PETSC_ARCH)/lib -lpetsc -Wl,-rpath,$(PETSC_DIR)/$(PETSC_ARCH)/lib
-# Include math library
-LDFLAGS     := $(LDFLAGS) $(MATH_LIB)
-# Have to link to blas, lapack
-LDFLAGS     := $(LDFLAGS) $(BLAS_LIB) $(LAPACK_LIB)
-# Have to link to mpi
-LDFLAGS     := $(LDFLAGS) $(MPI_LIB)
-# Have to link to parmetis and metis - order is important
-LDFLAGS     := $(LDFLAGS) $(PARMETIS_LIB) $(METIS_LIB)
-# Include any input flags we had - these go last as order is important
-LDFLAGS     := $(LDFLAGS) $(LDFLAGS_INPUT)
-
-# Define file extensions
-.SUFFIXES: .F90 .o .mod .c
-
-# Test examples
-OBJS := ex12f.o ex6f.o ex6f_getcoeffs.o ex6.o ex6_cf_splitting.o adv_1d.o adv_diff_2d.o
-
-# Build rules
-all: $(OBJS) 
-
-# Fortran
-%.o: %.F90
-	$(FC) $(FFLAGS) $(INCLUDE) $^ $(LDFLAGS) $(LDLIBS) -o $@
-
-# C
-%.o: %.c
-	$(CC) $(CFLAGS) $(INCLUDE) $^ $(LDFLAGS) $(LDLIBS) -o $@
+# ~~~~~~~~~~~
+# Run PFLARE tests
+# ~~~~~~~~~~~
 
 run_tests_load:
 #
 	@echo ""
 	@echo "Test AIRG with GMRES polynomials for hyperbolic streaming problem"
-	./ex12f.o -f data/mat_stream_2364 -ksp_max_it 5
+	./ex12f -f data/mat_stream_2364 -ksp_max_it 5
 	@echo "Test AIRG with GMRES polynomials for hyperbolic streaming problem, matrix-free smoothing"
-	./ex12f.o -f data/mat_stream_2364 -pc_air_matrix_free_polys -ksp_max_it 5
+	./ex12f -f data/mat_stream_2364 -pc_air_matrix_free_polys -ksp_max_it 5
 #
 	@echo ""
 	@echo "Test AIRG with GMRES polynomials for hyperbolic streaming problem in C"
-	./ex6.o -f data/mat_stream_2364 -ksp_max_it 5
+	./ex6 -f data/mat_stream_2364 -ksp_max_it 5
 	@echo "Test AIRG with GMRES polynomials for hyperbolic streaming problem, matrix-free smoothing in C in parallel"
-	$(MPIEXEC) -n 2 ./ex6.o -f data/mat_stream_2364 -pc_air_matrix_free_polys -ksp_max_it 5
+	$(MPIEXEC) -n 2 ./ex6 -f data/mat_stream_2364 -pc_air_matrix_free_polys -ksp_max_it 5
 #
 	@echo ""
 	@echo "Test lAIR with GMRES polynomial smoothing for hyperbolic streaming problem"
-	./ex12f.o -f data/mat_stream_2364 -pc_air_z_type lair -ksp_max_it 5
+	./ex12f -f data/mat_stream_2364 -pc_air_z_type lair -ksp_max_it 5
 	@echo "Test lAIR with strong R tolerance with GMRES polynomial smoothing for hyperbolic streaming problem"
-	./ex12f.o -f data/mat_stream_2364 -pc_air_z_type lair	-pc_air_strong_r_threshold 0.01 -ksp_max_it 5
+	./ex12f -f data/mat_stream_2364 -pc_air_z_type lair	-pc_air_strong_r_threshold 0.01 -ksp_max_it 5
 # 
 	@echo ""
 	@echo "Test single level GMRES polynomial preconditioning for hyperbolic streaming problem in C"
-	./ex6.o -f data/mat_stream_2364 -pc_type pflareinv -pc_pflareinv_type power -ksp_max_it 21	
+	./ex6 -f data/mat_stream_2364 -pc_type pflareinv -pc_pflareinv_type power -ksp_max_it 21	
 	@echo "Test single level GMRES polynomial preconditioning for hyperbolic streaming problem in C in parallel"
-	$(MPIEXEC) -n 2 ./ex6.o -f data/mat_stream_2364	-pc_type pflareinv -pc_pflareinv_type power -ksp_max_it 21
+	$(MPIEXEC) -n 2 ./ex6 -f data/mat_stream_2364	-pc_type pflareinv -pc_pflareinv_type power -ksp_max_it 21
 # 
 	@echo ""
 	@echo "Test single level GMRES polynomial preconditioning with the Newton basis matrix-free for hyperbolic streaming problem in C"
-	./ex6.o -f data/mat_stream_2364 -pc_type pflareinv -pc_pflareinv_type newton -pc_pflareinv_matrix_free -ksp_max_it 13
+	./ex6 -f data/mat_stream_2364 -pc_type pflareinv -pc_pflareinv_type newton -pc_pflareinv_matrix_free -ksp_max_it 13
 	@echo "Test single level GMRES polynomial preconditioning with the Newton basis matrix-free for hyperbolic streaming problem in C in parallel"
-	$(MPIEXEC) -n 2 ./ex6.o -f data/mat_stream_2364	-pc_type pflareinv -pc_pflareinv_type newton -pc_pflareinv_matrix_free -ksp_max_it 13
+	$(MPIEXEC) -n 2 ./ex6 -f data/mat_stream_2364	-pc_type pflareinv -pc_pflareinv_type newton -pc_pflareinv_matrix_free -ksp_max_it 13
 #
 	@echo ""	 
 	@echo "Test AIRG as an exact solver, truncating hierarchy and using high order mf GMRES poly in the\
 	 Arnoldi basis as a coarse solver for hyperbolic streaming"
-	./ex12f.o -f data/mat_stream_2364 -pc_air_strong_threshold 0.0 -pc_air_a_drop 0.0 -pc_air_r_drop 0.0 \
+	./ex12f -f data/mat_stream_2364 -pc_air_strong_threshold 0.0 -pc_air_a_drop 0.0 -pc_air_r_drop 0.0 \
 	 -pc_air_inverse_type jacobi -mg_coarse_ksp_type richardson -mg_coarse_ksp_max_it 5 -ksp_type richardson -ksp_norm_type unpreconditioned \
 	 -pc_air_max_levels 30 -pc_air_coarsest_poly_order 18 \
 	 -pc_air_coarsest_matrix_free_polys -pc_air_coarsest_inverse_type arnoldi -ksp_max_it 1
@@ -115,162 +67,159 @@ run_tests_load:
 	@echo ""		 
 	@echo "Test AIRG as an exact solver, heavily truncating hierarchy and using high order mf GMRES poly in the\
 	 Newton basis as a coarse solver for hyperbolic streaming"
-	./ex12f.o -f data/mat_stream_2364 -pc_air_strong_threshold 0.0 -pc_air_a_drop 0.0 -pc_air_r_drop 0.0 \
+	./ex12f -f data/mat_stream_2364 -pc_air_strong_threshold 0.0 -pc_air_a_drop 0.0 -pc_air_r_drop 0.0 \
 	 -pc_air_inverse_type jacobi -ksp_type richardson -ksp_norm_type unpreconditioned \
 	 -pc_air_max_levels 10 -pc_air_coarsest_poly_order 60 \
 	 -pc_air_coarsest_matrix_free_polys -pc_air_coarsest_inverse_type newton -pc_air_max_luby_steps 3 -ksp_max_it 1
 	@echo "Test AIRG as an exact solver, heavily truncating hierarchy and using high order mf GMRES poly in the\
 	 Newton basis as a coarse solver for hyperbolic streaming in parallel"
-	$(MPIEXEC) -n 2 ./ex6.o -f data/mat_stream_2364 -pc_air_strong_threshold 0.0 -pc_air_a_drop 0.0 -pc_air_r_drop 0.0 \
+	$(MPIEXEC) -n 2 ./ex6 -f data/mat_stream_2364 -pc_air_strong_threshold 0.0 -pc_air_a_drop 0.0 -pc_air_r_drop 0.0 \
 	 -pc_air_inverse_type jacobi -ksp_type richardson -ksp_norm_type unpreconditioned \
 	 -pc_air_max_levels 10 -pc_air_coarsest_poly_order 60 \
 	 -pc_air_coarsest_matrix_free_polys -pc_air_coarsest_inverse_type newton -pc_air_max_luby_steps 3 -ksp_max_it 1	
 #
 	@echo ""
 	@echo "Test AIRG with GMRES polynomials for hyperbolic streaming problem with coefficients calculated on subcomms"
-	$(MPIEXEC) -n 2 ./ex12f.o -f data/mat_stream_2364 -pc_air_subcomm -pc_air_inverse_type arnoldi -pc_air_coarsest_subcomm \
+	$(MPIEXEC) -n 2 ./ex12f -f data/mat_stream_2364 -pc_air_subcomm -pc_air_inverse_type arnoldi -pc_air_coarsest_subcomm \
 	 -pc_air_coarsest_inverse_type arnoldi -ksp_max_it 5
 # 
 	@echo ""
 	@echo "Test PMISR DDC CF splitting in C"
-	./ex6_cf_splitting.o  -f data/mat_stream_2364
+	./ex6_cf_splitting  -f data/mat_stream_2364
 	@echo "Test PMISR DDC CF splitting in C in parallel"
-	$(MPIEXEC) -n 2 ./ex6_cf_splitting.o  -f data/mat_stream_2364   
+	$(MPIEXEC) -n 2 ./ex6_cf_splitting  -f data/mat_stream_2364   
 
 run_tests_no_load:
 #
 	@echo ""
 	@echo "Test AIRG with GMRES polynomials for 2D finite difference stencil"
-	./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -ksp_max_it 5
+	./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -ksp_max_it 5
 	@echo "Test AIRG with GMRES polynomials Arnoldi basis for 2D finite difference stencil"
-	./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -pc_air_inverse_type arnoldi -pc_air_coarsest_inverse_type arnoldi -ksp_max_it 5
+	./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -pc_air_inverse_type arnoldi -pc_air_coarsest_inverse_type arnoldi -ksp_max_it 5
 	@echo "Test AIRG with GMRES polynomials for 2D finite difference stencil in parallel"
-	$(MPIEXEC) -n 2 ./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -ksp_max_it 5
+	$(MPIEXEC) -n 2 ./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -ksp_max_it 5
 	@echo "Test AIRG with GMRES polynomials Arnoldi basis for 2D finite difference stencil in parallel"
-	$(MPIEXEC) -n 2 ./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -pc_air_inverse_type arnoldi -pc_air_coarsest_inverse_type arnoldi -ksp_max_it 5
+	$(MPIEXEC) -n 2 ./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -pc_air_inverse_type arnoldi -pc_air_coarsest_inverse_type arnoldi -ksp_max_it 5
 	@echo ""
 	@echo "Test lAIR with GMRES polynomial smoothing for 2D finite difference stencil in parallel"
-	$(MPIEXEC) -n 2 ./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -pc_air_z_type lair -ksp_max_it 4
+	$(MPIEXEC) -n 2 ./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -pc_air_z_type lair -ksp_max_it 4
 # 
 	@echo ""
 	@echo "Test single level GMRES polynomial preconditioning for 2D finite difference stencil"
-	./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type pflareinv -pc_pflareinv_type power -ksp_max_it 8
+	./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type pflareinv -pc_pflareinv_type power -ksp_max_it 8
 	@echo "Test single level GMRES polynomial preconditioning for 2D finite difference stencil in parallel"
-	$(MPIEXEC) -n 2 ./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type pflareinv -pc_pflareinv_type power -ksp_max_it 8
+	$(MPIEXEC) -n 2 ./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type pflareinv -pc_pflareinv_type power -ksp_max_it 8
 #
 	@echo ""
 	@echo "Test AIRG with Neumann polynomials for 2D finite difference stencil"
-	./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -pc_air_inverse_type neumann -ksp_max_it 5
+	./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -pc_air_inverse_type neumann -ksp_max_it 5
 	@echo "Test AIRG with Neumann polynomials for 2D finite difference stencil in parallel"
-	$(MPIEXEC) -n 2 ./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air  -pc_air_inverse_type neumann -ksp_max_it 5
+	$(MPIEXEC) -n 2 ./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air  -pc_air_inverse_type neumann -ksp_max_it 5
 	@echo "Test AIRG with Neumann polynomials for 2D finite difference stencil, matrix-free smoothing"
-	./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -pc_air_inverse_type neumann -pc_air_matrix_free_polys -ksp_max_it 5
+	./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -pc_air_inverse_type neumann -pc_air_matrix_free_polys -ksp_max_it 5
 	@echo "Test AIRG with Neumann polynomials for 2D finite difference stencil, matrix-free smoothing in parallel"
-	$(MPIEXEC) -n 2 ./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air  -pc_air_inverse_type neumann -pc_air_matrix_free_polys -ksp_max_it 5
+	$(MPIEXEC) -n 2 ./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air  -pc_air_inverse_type neumann -pc_air_matrix_free_polys -ksp_max_it 5
 #
 	@echo ""
 	@echo "Test AIRG with SAIs for 2D finite difference stencil"
-	./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -pc_air_inverse_type sai -ksp_max_it 5
+	./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -pc_air_inverse_type sai -ksp_max_it 5
 	@echo "Test AIRG with SAI for 2D finite difference stencil in parallel"
-	$(MPIEXEC) -n 2 ./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air  -pc_air_inverse_type sai -ksp_max_it 5
+	$(MPIEXEC) -n 2 ./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air  -pc_air_inverse_type sai -ksp_max_it 5
 # 
 	@echo ""
 	@echo "Test AIRG with ISAIs for 2D finite difference stencil"
-	./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -pc_air_inverse_type isai -ksp_max_it 5
+	./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -pc_air_inverse_type isai -ksp_max_it 5
 	@echo "Test AIRG with ISAIs for 2D finite difference stencil in parallel"
-	$(MPIEXEC) -n 2 ./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air  -pc_air_inverse_type isai -ksp_max_it 5
+	$(MPIEXEC) -n 2 ./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air  -pc_air_inverse_type isai -ksp_max_it 5
 # 
 	@echo ""
 	@echo "Test AIRG with Weighted Jacobi for 2D finite difference stencil"
-	./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -pc_air_inverse_type wjacobi -ksp_max_it 8
+	./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -pc_air_inverse_type wjacobi -ksp_max_it 8
 	@echo "Test AIRG with Weighted Jacobi for 2D finite difference stencil in parallel"
-	$(MPIEXEC) -n 2 ./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air  -pc_air_inverse_type wjacobi -ksp_max_it 8
+	$(MPIEXEC) -n 2 ./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air  -pc_air_inverse_type wjacobi -ksp_max_it 8
 # 
 	@echo ""
 	@echo "Test AIRG with Unweighted Jacobi for 2D finite difference stencil"
-	./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -pc_air_inverse_type jacobi -ksp_max_it 5
+	./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air -pc_air_inverse_type jacobi -ksp_max_it 5
 	@echo "Test AIRG with Unweighted Jacobi for 2D finite difference stencil in parallel"
-	$(MPIEXEC) -n 2 ./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air  -pc_air_inverse_type jacobi -ksp_max_it 5
+	$(MPIEXEC) -n 2 ./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air  -pc_air_inverse_type jacobi -ksp_max_it 5
 # 
 	@echo ""
 	@echo "Test AIRG as an exact solver for 2D finite difference stencil"
-	./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air \
+	./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air \
 	 -pc_air_strong_threshold 0.0 -pc_air_a_drop 0.0 -pc_air_r_drop 0.0 -pc_air_inverse_type jacobi \
 	 -mg_coarse_ksp_type richardson -mg_coarse_ksp_max_it 10 -ksp_type richardson -ksp_norm_type unpreconditioned -ksp_max_it 1
 	@echo "Test AIRG as an exact solver for 2D finite difference stencil in parallel"
-	$(MPIEXEC) -n 2 ./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air \
+	$(MPIEXEC) -n 2 ./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 8 -da_grid_y 8 -pc_type air \
 	 -pc_air_strong_threshold 0.0 -pc_air_a_drop 0.0 -pc_air_r_drop 0.0 -pc_air_inverse_type jacobi \
 	 -mg_coarse_ksp_type richardson -mg_coarse_ksp_max_it 10 -ksp_type richardson -ksp_norm_type unpreconditioned -ksp_max_it 1
 # 
 	@echo ""
 	@echo "Test AIRG with GMRES polynomials with PC reused with no sparsity change"
-	./ex6f.o -m 10 -n 10 -ksp_max_it 10
+	./ex6f -m 10 -n 10 -ksp_max_it 10
 	@echo "Test AIRG with GMRES polynomials with PC regenerated with no sparsity change"
-	./ex6f.o -m 10 -n 10 -regen -pc_air_reuse_sparsity -ksp_max_it 3
+	./ex6f -m 10 -n 10 -regen -pc_air_reuse_sparsity -ksp_max_it 3
 	@echo "Test AIRG with GMRES polynomials with PC regenerated with no sparsity change and strong R threshold"
-	./ex6f.o -m 10 -n 10 -regen -pc_air_reuse_sparsity -pc_air_strong_r_threshold 0.01 -ksp_max_it 3
+	./ex6f -m 10 -n 10 -regen -pc_air_reuse_sparsity -pc_air_strong_r_threshold 0.01 -ksp_max_it 3
 	@echo "Test lAIR with GMRES polynomials with PC regenerated with no sparsity change"
-	./ex6f.o -m 10 -n 10 -regen -pc_air_z_type lair -pc_air_reuse_sparsity -ksp_max_it 3
+	./ex6f -m 10 -n 10 -regen -pc_air_z_type lair -pc_air_reuse_sparsity -ksp_max_it 3
 	@echo "Test lAIR SAI with GMRES polynomials with PC regenerated with no sparsity change"
-	./ex6f.o -m 10 -n 10 -regen -pc_air_z_type lair_sai -pc_air_reuse_sparsity	-ksp_max_it 3
+	./ex6f -m 10 -n 10 -regen -pc_air_z_type lair_sai -pc_air_reuse_sparsity	-ksp_max_it 3
 # 
 	@echo ""
 	@echo "Test AIRG with GMRES polynomials with PC regenerated with no sparsity change and polynomial coeffs stored"
-	./ex6f_getcoeffs.o -m 10 -n 10 -ksp_max_it 3
+	./ex6f_getcoeffs -m 10 -n 10 -ksp_max_it 3
 	@echo "Test AIRG with GMRES polynomials with PC regenerated with no sparsity change and polynomial coeffs stored and lumping"
-	./ex6f_getcoeffs.o -m 10 -n 10 -pc_air_a_lump -ksp_max_it 3
+	./ex6f_getcoeffs -m 10 -n 10 -pc_air_a_lump -ksp_max_it 3
 # 
 	@echo ""
 	@echo "Test single level GMRES polynomials with PC reused with no sparsity change"
-	./ex6f.o -m 10 -n 10 -pc_type pflareinv -ksp_max_it 8
+	./ex6f -m 10 -n 10 -pc_type pflareinv -ksp_max_it 8
 	@echo "Test single level GMRES polynomials with PC regenerated with no sparsity change"
-	./ex6f.o -m 10 -n 10 -pc_type pflareinv -regen -ksp_max_it 8
+	./ex6f -m 10 -n 10 -pc_type pflareinv -regen -ksp_max_it 8
 # 
 	@echo ""
 	@echo "Test solving isotropic diffusion with fast coarsening and near-nullspace"
-	./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 50 -da_grid_y 50 -pc_type air -pc_air_z_type lair \
+	./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 50 -da_grid_y 50 -pc_type air -pc_air_z_type lair \
 	 -pc_air_one_c_smooth -pc_air_symmetric -pc_air_constrain_z \
 	 -pc_air_cf_splitting_type agg -pc_air_a_drop 1e-5 -pc_air_a_lump\
 	 -pc_air_r_drop 0 -ksp_rtol 1e-10 -ksp_pc_side right -ksp_max_it 14
 	@echo "Test solving isotropic diffusion with fast coarsening and near-nullspace in parallel"
-	$(MPIEXEC) -n 4 ./adv_diff_2d.o -u 0 -v 0 -alpha 1.0 -da_grid_x 50 -da_grid_y 50 -pc_type air -pc_air_z_type lair \
+	$(MPIEXEC) -n 4 ./adv_diff_2d -u 0 -v 0 -alpha 1.0 -da_grid_x 50 -da_grid_y 50 -pc_type air -pc_air_z_type lair \
 	 -pc_air_one_c_smooth -pc_air_symmetric -pc_air_constrain_z \
 	 -pc_air_cf_splitting_type agg -pc_air_a_drop 1e-5 -pc_air_a_lump\
 	 -pc_air_r_drop 0 -ksp_rtol 1e-10 -ksp_pc_side right -ksp_max_it 14
 # 
 	@echo ""
 	@echo "Test AIRG on steady 1D advection"
-	./adv_1d.o -n 1000 -ksp_rtol 1e-10 -ksp_atol 1e-50 -ksp_pc_side right \
+	./adv_1d -n 1000 -ksp_rtol 1e-10 -ksp_atol 1e-50 -ksp_pc_side right \
 	 -pc_air_coarsest_inverse_type newton -pc_air_coarsest_poly_order 10 -pc_air_coarsest_matrix_free_polys -ksp_max_it 1
 	@echo "Test AIRG on steady 1D advection in parallel"
-	$(MPIEXEC) -n 2 ./adv_1d.o -n 1000 -ksp_rtol 1e-10 -ksp_atol 1e-50 -ksp_pc_side right \
+	$(MPIEXEC) -n 2 ./adv_1d -n 1000 -ksp_rtol 1e-10 -ksp_atol 1e-50 -ksp_pc_side right \
 	 -pc_air_coarsest_inverse_type newton -pc_air_coarsest_poly_order 10 -pc_air_coarsest_matrix_free_polys -ksp_max_it 10
 # 
 	@echo ""
 	@echo "Test lAIR on steady 2D structured advection"
-	./adv_diff_2d.o -da_grid_x 50 -da_grid_y 50 -pc_type air -ksp_pc_side right \
+	./adv_diff_2d -da_grid_x 50 -da_grid_y 50 -pc_type air -ksp_pc_side right \
 	 -ksp_rtol 1e-10 -ksp_atol 1e-50 -pc_air_a_lump -pc_air_a_drop 1e-4 -pc_air_one_c_smooth \
 	 -pc_air_z_type lair -pc_air_inverse_type wjacobi -ksp_max_it 10
 # 
 	@echo ""
 	@echo "Test AIRG on steady 2D structured advection with 0th order sparsity GMRES poly C smooth and faster coarsening"
-	./adv_diff_2d.o -da_grid_x 50 -da_grid_y 50 -pc_type air -ksp_pc_side right \
+	./adv_diff_2d -da_grid_x 50 -da_grid_y 50 -pc_type air -ksp_pc_side right \
 	 -ksp_rtol 1e-10 -ksp_atol 1e-50 -pc_air_a_lump -pc_air_a_drop 1e-4 -pc_air_one_c_smooth \
 	 -pc_air_c_inverse_sparsity_order 0 -pc_air_strong_threshold 0.99 -pc_air_ddc_fraction 0.0 -ksp_max_it 7
 # 
 	@echo ""
 	@echo "Test high order GMRES polynomials in small linear system"
-	./adv_diff_2d.o -da_grid_x 5 -da_grid_y 5 -pc_type pflareinv -pc_pflareinv_type newton \
+	./adv_diff_2d -da_grid_x 5 -da_grid_y 5 -pc_type pflareinv -pc_pflareinv_type newton \
 	 -pc_pflareinv_matrix_free -pc_pflareinv_order 16 -ksp_max_it 1
 	@echo "Test high order GMRES polynomials in small linear system - slightly bigger"
-	./adv_diff_2d.o -da_grid_x 10 -da_grid_y 10 -pc_type pflareinv -pc_pflareinv_type newton \
+	./adv_diff_2d -da_grid_x 10 -da_grid_y 10 -pc_type pflareinv -pc_pflareinv_type newton \
 	 -pc_pflareinv_matrix_free -pc_pflareinv_order 50 -ksp_max_it 1
 # 
 	@echo ""
 	@echo "Test auto truncation with matrix-free Newton polynomials as coarse grid solver" 
-	./adv_diff_2d.o -da_grid_x 10 -da_grid_y 10 -ksp_type richardson -pc_type air \
+	./adv_diff_2d -da_grid_x 10 -da_grid_y 10 -ksp_type richardson -pc_type air \
 	 -pc_air_coarsest_inverse_type newton -pc_air_coarsest_poly_order 10 -pc_air_coarsest_matrix_free_polys \
 	 -pc_air_auto_truncate_start_level 1 -pc_air_auto_truncate_tol 1e-2 -ksp_max_it 3
-
-clean:
-	$(RM) *.o *.mod *.out


### PR DESCRIPTION
Changes the makefile to use the compilers/flags etc that the petsc configure defines. Makes it easy to include kokkos/cuda/hip code in pflare. 