### PR TITLE
Cuda kokkos build flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,11 @@ export LIBDIR := $(CURDIR)/lib
 # Include directories - include top level directory in case compilers output modules there
 INCLUDE := -I$(CURDIR) -I$(INCLUDEDIR)
 
-# These flags need to be before the petsc variable definition so they 
-# get added to the rules (particularly for kokkos)
+# These flags need to be before the petsc variable definitions/rules are included
+# This is because the petsc/conf/rules defines LINK.kokkos.cxx :=
+# so any flags we add after the variable and rules include are ignored
+# and our kokkos tests would fail to link
+CFLAGS = $(INCLUDE)
 CPPFLAGS = $(INCLUDE)
 FPPFLAGS = $(INCLUDE)
 CXXPPFLAGS = $(INCLUDE)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -23,8 +23,11 @@ SYCLC_FLAGS_INPUT := $(SYCLC_FLAGS)
 # Include directories - include top level directory in case compilers output modules there
 INCLUDE := -I$(CURDIR)/../ -I../include
 
-# These flags need to be before the petsc variable definition so they 
-# get added to the rules (particularly for kokkos)
+# These flags need to be before the petsc variable definitions/rules are included
+# This is because the petsc/conf/rules defines LINK.kokkos.cxx :=
+# so any flags we add after the variable and rules include are ignored
+# and our kokkos tests would fail to link
+CFLAGS = $(INCLUDE)
 CPPFLAGS = $(INCLUDE)
 FPPFLAGS = $(INCLUDE)
 CXXPPFLAGS = $(INCLUDE)


### PR DESCRIPTION
CUDA Kokkos builds of the Kokkos tests were failing due to the petsc rules defining the kokkos linking rule at definition time. 