### PR TITLE
3d curved velocity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,20 @@ tests_medium_serial: build_tests
 tests_medium_parallel: build_tests
 	$(MAKE) -C tests run_tests_medium_parallel		
 
+# Default target groups scanned by tests_search.
+# Keep load tests only when PETSc uses 32-bit indices.
+ifeq ($(PETSC_USE_64BIT_INDICES),0)
+FILTER_RUN_TARGETS_DEFAULT := run_tests_load_serial run_tests_load_parallel run_tests_no_load_short_serial run_tests_no_load_short_parallel run_tests_no_load_serial run_tests_no_load_parallel run_tests_medium_serial run_tests_medium_parallel
+else
+FILTER_RUN_TARGETS_DEFAULT := run_tests_no_load_short_serial run_tests_no_load_short_parallel run_tests_no_load_serial run_tests_no_load_parallel run_tests_medium_serial run_tests_medium_parallel
+endif
+
+# Run only tests whose command lines contain TEST_MATCH.
+# Example: make tests_search TEST_MATCH="-curved_velocity"
+.PHONY: tests_search
+tests_search: build_tests
+	$(MAKE) -C tests run_tests_search TEST_MATCH="$(TEST_MATCH)" FILTER_RUN_TARGETS="$(if $(strip $(FILTER_RUN_TARGETS)),$(FILTER_RUN_TARGETS),$(FILTER_RUN_TARGETS_DEFAULT))"
+
 # Very quick tests
 .PHONY: tests_short
 tests_short: build_tests

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1222,3 +1222,35 @@ else
 	@echo "KOKKOS check skipped (PETSc has not been configured with KOKKOS)"	
 
 endif	
+
+# ~~~~~~~~~~~
+# ~~~~~~~~~~~
+
+# Run only test commands containing TEST_MATCH.
+.PHONY: run_tests_search
+run_tests_search:
+	@if [ -z "$(strip $(TEST_MATCH))" ]; then \
+		echo "ERROR: TEST_MATCH is empty. Example: TEST_MATCH='-curved_velocity'"; \
+		exit 2; \
+	fi
+	@if [ -z "$(strip $(FILTER_RUN_TARGETS))" ]; then \
+		echo "ERROR: FILTER_RUN_TARGETS is empty. Use top-level: make tests_with_arg TEST_MATCH='-curved_velocity'"; \
+		exit 2; \
+	fi
+	@echo "Filtering tests for substring: $(TEST_MATCH)"
+	@echo "Scanning targets: $(FILTER_RUN_TARGETS)"
+	@set -e; \
+	commands="$$( $(MAKE) --no-print-directory -n $(FILTER_RUN_TARGETS) | \
+		sed -e ':join' -e '/\\$$/N' -e 's/\\\n[[:space:]]*/ /' -e 't join' -e 's/^[[:space:]]*[@+-][[:space:]]*//' )"; \
+	matches="$$( printf '%s\n' "$$commands" | grep -F -- "$(TEST_MATCH)" | grep -E '(^\./)|([[:space:]]\./)' || true )"; \
+	count="$$(printf '%s\n' "$$matches" | sed '/^[[:space:]]*$$/d' | wc -l | tr -d '[:space:]')"; \
+	if [ "$$count" = "0" ]; then \
+		echo "No matching test commands found."; \
+		exit 0; \
+	fi; \
+	echo "Found $$count matching test command(s):"; \
+	echo "Running matching tests..."; \
+	printf '%s\n' "$$matches" | sed '/^[[:space:]]*$$/d' | while IFS= read -r cmd; do \
+		echo "$$cmd"; \
+		eval "$$cmd" < /dev/null; \
+	done

--- a/tests/adv_dg_upwind.c
+++ b/tests/adv_dg_upwind.c
@@ -122,9 +122,19 @@ typedef struct {
 static inline void GetVelocity(PetscInt dim, const AppCtx *ctx, const PetscReal x[], PetscReal v[])
 {
   if (ctx->curved_velocity) {
-    v[0] = x[1];
-    v[1] = 1.0 - x[0];
-    v[2] = 0.0;
+    if (dim == 2) {
+      v[0] = x[1];
+      v[1] = 1.0 - x[0];
+      v[2] = 0.0;
+    } else {
+      // 3D curved field, symmetric under x<->y:
+      //   u = z
+      //   v = z
+      //   w = 2 - x - y
+      v[0] = x[2];               // u
+      v[1] = x[2];               // v
+      v[2] = 2.0 - x[0] - x[1];  // w
+    }
   } else {
     v[0] = ctx->advection_velocity[0];
     v[1] = ctx->advection_velocity[1];

--- a/tests/adv_diff_cg_supg.c
+++ b/tests/adv_diff_cg_supg.c
@@ -55,9 +55,19 @@ static inline void GetVelocity(PetscInt dim, const PetscScalar constants[], cons
   if (constants[4] == 1.0) {
     // Spatially-varying velocity field: top-left quadrant of a rotating circle (center at 1,0)
     // u(x,y) = y, v(x,y) = 1-x
-    v[0] = x[1];         // u(x,y)
-    v[1] = 1.0 - x[0];   // v(x,y)
-    v[2] = 0.0;          // w (unused in 2D)
+    if (dim == 2) {
+      v[0] = x[1];         // u(x,y)
+      v[1] = 1.0 - x[0];   // v(x,y)
+      v[2] = 0.0;          // w (unused in 2D)
+    } else {
+      // 3D curved field, symmetric under x<->y:
+      //   u = z
+      //   v = z
+      //   w = 2 - x - y
+      v[0] = x[2];               // u
+      v[1] = x[2];               // v
+      v[2] = 2.0 - x[0] - x[1];  // w
+    }
   } else {
     // Constant velocity field
     v[0] = constants[1];

--- a/tests/adv_diff_fd.c
+++ b/tests/adv_diff_fd.c
@@ -35,7 +35,8 @@
        in 2D: bottom (j=0) face; in 3D: bottom (k=0, z=0) face
        all other inflow faces are set to u=0
      Can change default velocity from straight line to curved with -curved_velocity (default false)
-       curved velocity field: u(x,y) = y, v(x,y) = 1-x, w=0 (rotating, always >= 0 on [0,1]^2)
+       2D curved field: u(x,y) = y, v(x,y) = 1-x, w = 0 (rotation about (1,0),
+       3D curved field: u = z, v = z, w = 2-x-y 
      Can normalise velocity with -unit_velocity (default true) so that we have a unit velocity.
        If any of u,v,w are set explicitly then unit velocity will be disabled
      Can control domain size in each direction with -L_x, -L_y, -L_z (default 1.0)
@@ -65,11 +66,21 @@ static inline void GetVelocity(PetscInt dim, PetscReal u_const, PetscReal v_cons
                                PetscReal vel[])
 {
   if (curved_velocity) {
-    // Spatially-varying velocity field: top-left quadrant of a rotating circle (center at 1,0)
-    // u(x,y) = y, v(x,y) = 1-x, w = 0
-    vel[0] = x[1];        // u(x,y) = y
-    vel[1] = 1.0 - x[0]; // v(x,y) = 1-x
-    vel[2] = 0.0;         // w = 0 (curved field defined in 2D plane only)
+    if (dim == 2) {
+      // 2D rotating field around centre (1, 0), always >= 0 on [0,1]^2
+      // Enters through bottom and left, exits through right and top
+      vel[0] = x[1];         // u(x,y) = y
+      vel[1] = 1.0 - x[0];   // v(x,y) = 1-x
+      vel[2] = 0.0;
+    } else {
+      // 3D curved field, symmetric under x<->y:
+      //   u = z
+      //   v = z
+      //   w = (2-x-y)
+      vel[0] = x[2];                               // u
+      vel[1] = x[2];                               // v
+      vel[2] = (2.0 - x[0] - x[1]); // w
+    }
   } else {
     // Constant velocity field
     vel[0] = u_const;


### PR DESCRIPTION
Modified 3D curved velocity tests to have z component. 

Also allow running of only tests that include a matching command line argument, e.g., make tests_search TEST_MATCH="-curved_velocity"