### PR TITLE
No vendor petsc

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -224,6 +224,24 @@ jobs:
           build-args: |
             ARCH=arch-linux-c-debug
 
+  gnu_debug_kokkos_prefix:
+    runs-on: ubuntu-22.04
+    needs: setup
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Docker image with KOKKOS and debug PETSc with prefix DIR
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64
+          push: false
+          context: .
+          file: ./dockerfiles/Dockerfile_kokkos
+          build-args: |
+            ARCH=
+            PETSC_DIR=/build/petsc_prefix            
+
   gnu_opt_64_bit_kokkos:
     runs-on: ubuntu-22.04
     needs: [setup]

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,6 +1,7 @@
 ARG BASE_IMAGE=stevendargaville/petsc
 
 FROM ${BASE_IMAGE}
+ARG PETSC_DIR=/build/petsc
 # Use the optimised petsc build by default
 ARG ARCH=arch-linux-c-opt
 # Don't use malloc dump by default
@@ -10,6 +11,7 @@ LABEL maintainer="Steven Dargaville"
 LABEL description="PFLARE"
 
 ENV PETSC_ARCH=$ARCH
+ENV PETSC_DIR=$PETSC_DIR
 # -on_error_abort ensures any test failures are caught and the build fails
 # fp trap turns on floating point exception trapping in petsc
 ENV PETSC_OPTIONS="-on_error_abort -fp_trap on"

--- a/dockerfiles/Dockerfile_kokkos
+++ b/dockerfiles/Dockerfile_kokkos
@@ -1,6 +1,7 @@
 ARG BASE_IMAGE=stevendargaville/petsc_kokkos
 
 FROM ${BASE_IMAGE}
+ARG PETSC_DIR=/build/petsc
 # Use the optimised petsc build by default
 ARG ARCH=arch-linux-c-opt
 # Set the number of OpenMP threads to 1 by default
@@ -11,6 +12,7 @@ ARG MALLOC_DUMP=false
 LABEL maintainer="Steven Dargaville"
 LABEL description="PFLARE_kokkos"
 
+ENV PETSC_DIR=$PETSC_DIR
 ENV PETSC_ARCH=$ARCH
 ENV OMP_NUM_THREADS=$OMP_NUM_THREADS
 # This turns on checks between kokkos and cpu versions

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,7 +8,7 @@ Please choose one of the build methods below. If you wish to contribute to PFLAR
 
 ### PETSc configure build
 
-PFLARE has now been added to the PETSc configure as an external package, as of the PETSc 3.25 release. PFLARE can be built by adding ``--download-pflare`` to the PETSc configure. 
+PFLARE is available through the PETSc configure as an external package, since the PETSc 3.25 release. PFLARE can be built by adding ``--download-pflare`` to the PETSc configure. 
 
 The PC types added by PFLARE can then be used as native PETSc PC types through command line arguments without any changes to existing code. The [Linking to PFLARE](#linking-to-pflare) and [Modifying existing code](#modifying-existing-code) sections below can therefore be skipped. 
 
@@ -39,9 +39,7 @@ The full set of tests can be run with:
 
 6) ``make tests`` in the top level directory.
 
-Please use the `main` branch of PETSc and compile PETSc directly from the source code, as PFLARE requires access to some of the PETSc types only available in the source. If PETSc was installed out of place, you should add the `/include` directory from the PETSc source location to `CFLAGS, CXXFLAGS, CPPFLAGS` before calling `make` for PFLARE. 
-
-If you wish to use an older version of PETSc, please see the [PFLARE Spack](https://github.com/PFLAREProject/PFLARE_spack) `package.py` where a list of compatible PFLARE release versions is maintained.
+Please use the `main` branch of PETSc. If you wish to use an older version of PETSc, please see the [PFLARE Spack](https://github.com/PFLAREProject/PFLARE_spack) `package.py` where a list of compatible PFLARE release versions is maintained.
 
 ### Docker
 

--- a/include/kokkos_helper.hpp
+++ b/include/kokkos_helper.hpp
@@ -22,7 +22,6 @@ using PetscIntConstKokkosViewHost = Kokkos::View<const PetscInt *, HostMirrorMem
 using intKokkosViewHost = Kokkos::View<int *, HostMirrorMemorySpace>;
 using intKokkosView = Kokkos::View<int *, Kokkos::DefaultExecutionSpace>;
 using boolKokkosView = Kokkos::View<bool *, Kokkos::DefaultExecutionSpace>;
-using ConstMatRowMapKokkosView = KokkosCsrGraph::row_map_type::const_type;
 
 // Create views using scratch memory space
 typedef Kokkos::DefaultExecutionSpace::scratch_memory_space

--- a/include/kokkos_helper.hpp
+++ b/include/kokkos_helper.hpp
@@ -37,8 +37,8 @@ using ViewPetscIntPtr = std::shared_ptr<PetscIntKokkosView>;
 PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *, int, Mat *);
 PETSC_INTERN void rewrite_j_global_to_local(PetscInt, PetscInt&, PetscIntKokkosView, PetscInt**);
 PETSC_INTERN void create_cf_is_device_kokkos(Mat *input_mat, const int match_cf, PetscIntKokkosView &is_local_d);
-PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, const int max_luby_steps, const int pmis_int, PetscScalarKokkosView &measure_local_d, intKokkosView &cf_markers_d, const int zero_measure_c_point_int);
-PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength_mat, const int max_luby_steps, const int pmis_int, PetscScalarKokkosView &measure_local_d, intKokkosView &cf_markers_d, const int zero_measure_c_point_int);
+PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, PetscSF *sf, Vec *leaf_vec, const int max_luby_steps, const int pmis_int, PetscScalarKokkosView &measure_local_d, intKokkosView &cf_markers_d, const int zero_measure_c_point_int);
+PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength_mat, PetscSF *sf, Vec *leaf_vec, const int max_luby_steps, const int pmis_int, PetscScalarKokkosView &measure_local_d, intKokkosView &cf_markers_d, const int zero_measure_c_point_int);
 PETSC_INTERN void copy_diag_dom_ratio_d2h(PetscReal *diag_dom_ratio_local);
 PETSC_INTERN void delete_device_diag_dom_ratio();
 

--- a/include/kokkos_helper.hpp
+++ b/include/kokkos_helper.hpp
@@ -7,7 +7,6 @@
 #include "petsc.h"
 #include <../src/mat/impls/aij/seq/kokkos/aijkok.hpp>
 #include <Kokkos_StdAlgorithms.hpp>
-#include <../src/vec/vec/impls/seq/kokkos/veckokkosimpl.hpp>
 #include <Kokkos_Random.hpp>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_DualView.hpp>

--- a/include/kokkos_helper.hpp
+++ b/include/kokkos_helper.hpp
@@ -4,16 +4,18 @@
 // petscvec_kokkos.hpp has to go first
 #include <petscvec_kokkos.hpp>
 #include <petscmat_kokkos.hpp>
+#include <petsc_kokkos.hpp>
 #include "petsc.h"
-#include <../src/mat/impls/aij/seq/kokkos/aijkok.hpp>
 #include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Random.hpp>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_DualView.hpp>
 #include <KokkosSparse_spadd.hpp>
+#include <KokkosSparse_CrsMatrix.hpp>
 #include <Kokkos_NestedSort.hpp>
 #include <KokkosBatched_Gesv.hpp>
 #include <KokkosBlas2_team_gemv.hpp>
+#include <petsc/private/kokkosimpl.hpp>
 
 using DefaultExecutionSpace = Kokkos::DefaultExecutionSpace;
 using DefaultMemorySpace    = Kokkos::DefaultExecutionSpace::memory_space;
@@ -31,6 +33,8 @@ using ScratchScalarView = Kokkos::View<PetscScalar*, ScratchSpace, Kokkos::Memor
 using Scratch2DIntView = Kokkos::View<PetscInt**, ScratchSpace, Kokkos::MemoryUnmanaged>;
 using Scratch2DScalarView = Kokkos::View<PetscScalar**, ScratchSpace, Kokkos::MemoryUnmanaged>;
 using ViewPetscIntPtr = std::shared_ptr<PetscIntKokkosView>;
+using KokkosTeamMemberType = Kokkos::TeamPolicy<DefaultExecutionSpace>::member_type;
+using KokkosCsrMatrix = KokkosSparse::CrsMatrix<PetscScalar, PetscInt, DefaultMemorySpace, void, PetscInt>;
 
 PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *, int, Mat *);
 PETSC_INTERN void rewrite_j_global_to_local(PetscInt, PetscInt&, PetscIntKokkosView, PetscInt**);

--- a/src/C_PETSc_Interfaces.F90
+++ b/src/C_PETSc_Interfaces.F90
@@ -17,15 +17,16 @@ module c_petsc_interfaces
    ! -------------------------------------------------------------------------------------------------------------------------------
    ! -------------------------------------------------------------------------------------------------------------------------------      
 
-   interface   
-      
+   interface
+
       subroutine ShellSetVecType_c(A_array, B_array) &
          bind(c, name="ShellSetVecType_c")
          use iso_c_binding
          integer(c_long_long) :: A_array, B_array
-      end subroutine ShellSetVecType_c         
- 
-   end interface     
+      end subroutine ShellSetVecType_c
+
+   end interface
+
 
    interface   
        
@@ -39,109 +40,86 @@ module c_petsc_interfaces
 
    end interface
 
-   interface   
-      
-      subroutine vecscatter_mat_begin_c(A_array, vec_long, cf_markers_nonlocal) &
+   interface
+
+      subroutine vecscatter_mat_begin_c(sf_array, vec_long, leaf_vec_array) &
          bind(c, name="vecscatter_mat_begin_c")
          use iso_c_binding
-         integer(c_long_long) :: A_array, vec_long
-         type(c_ptr) :: cf_markers_nonlocal
+         integer(c_long_long) :: sf_array, vec_long, leaf_vec_array
 
-      end subroutine vecscatter_mat_begin_c         
- 
-   end interface   
-   
-   interface   
-      
-      subroutine vecscatter_mat_end_c(A_array, vec_long, cf_markers_nonlocal) &
+      end subroutine vecscatter_mat_begin_c
+
+   end interface
+
+   interface
+
+      subroutine vecscatter_mat_end_c(sf_array, vec_long, leaf_vec_array, cf_markers_nonlocal) &
          bind(c, name="vecscatter_mat_end_c")
          use iso_c_binding
-         integer(c_long_long) :: A_array, vec_long
+         integer(c_long_long) :: sf_array, vec_long, leaf_vec_array
          type(c_ptr) :: cf_markers_nonlocal
 
-      end subroutine vecscatter_mat_end_c         
- 
-   end interface     
+      end subroutine vecscatter_mat_end_c
 
-   interface   
-      
-      subroutine boolscatter_mat_begin_c(A_array, assigned_local, assigned_nonlocal) &
+   end interface
+
+   interface
+
+      subroutine boolscatter_mat_begin_c(sf_array, assigned_local, assigned_nonlocal) &
          bind(c, name="boolscatter_mat_begin_c")
          use iso_c_binding
-         integer(c_long_long) :: A_array
+         integer(c_long_long) :: sf_array
          type(c_ptr), value :: assigned_local, assigned_nonlocal
 
-      end subroutine boolscatter_mat_begin_c         
- 
-   end interface   
-   
-   interface   
-      
-      subroutine boolscatter_mat_end_c(A_array, assigned_local, assigned_nonlocal) &
+      end subroutine boolscatter_mat_begin_c
+
+   end interface
+
+   interface
+
+      subroutine boolscatter_mat_end_c(sf_array, assigned_local, assigned_nonlocal) &
          bind(c, name="boolscatter_mat_end_c")
          use iso_c_binding
-         integer(c_long_long) :: A_array
+         integer(c_long_long) :: sf_array
          type(c_ptr), value :: assigned_local, assigned_nonlocal
-      end subroutine boolscatter_mat_end_c         
- 
-   end interface     
+      end subroutine boolscatter_mat_end_c
 
-   interface   
-      
-      subroutine boolscatter_mat_reverse_begin_c(A_array, assigned_local, assigned_nonlocal) &
+   end interface
+
+   interface
+
+      subroutine boolscatter_mat_reverse_begin_c(sf_array, assigned_local, assigned_nonlocal) &
          bind(c, name="boolscatter_mat_reverse_begin_c")
          use iso_c_binding
-         integer(c_long_long) :: A_array
+         integer(c_long_long) :: sf_array
          type(c_ptr), value :: assigned_local, assigned_nonlocal
 
-      end subroutine boolscatter_mat_reverse_begin_c         
- 
-   end interface   
-   
-   interface   
-      
-      subroutine boolscatter_mat_reverse_end_c(A_array, assigned_local, assigned_nonlocal) &
+      end subroutine boolscatter_mat_reverse_begin_c
+
+   end interface
+
+   interface
+
+      subroutine boolscatter_mat_reverse_end_c(sf_array, assigned_local, assigned_nonlocal) &
          bind(c, name="boolscatter_mat_reverse_end_c")
          use iso_c_binding
-         integer(c_long_long) :: A_array
+         integer(c_long_long) :: sf_array
          type(c_ptr), value :: assigned_local, assigned_nonlocal
-      end subroutine boolscatter_mat_reverse_end_c         
- 
-   end interface      
+      end subroutine boolscatter_mat_reverse_end_c
 
-   interface      
-      
-      subroutine vecscatter_mat_restore_c(A_array, cf_markers_nonlocal) &
+   end interface
+
+   interface
+
+      subroutine vecscatter_mat_restore_c(leaf_vec_array, cf_markers_nonlocal) &
          bind(c, name="vecscatter_mat_restore_c")
          use iso_c_binding
-         integer(c_long_long) :: A_array
+         integer(c_long_long) :: leaf_vec_array
          type(c_ptr) :: cf_markers_nonlocal
 
-      end subroutine vecscatter_mat_restore_c         
- 
-   end interface  
-   
-   interface   
-      
-      subroutine vecscatter_mat_reverse_begin_c(A_array, vec_long) &
-         bind(c, name="vecscatter_mat_reverse_begin_c")
-         use iso_c_binding
-         integer(c_long_long) :: A_array, vec_long
+      end subroutine vecscatter_mat_restore_c
 
-      end subroutine vecscatter_mat_reverse_begin_c         
- 
-   end interface   
-   
-   interface   
-      
-      subroutine vecscatter_mat_reverse_end_c(A_array, vec_long) &
-         bind(c, name="vecscatter_mat_reverse_end_c")
-         use iso_c_binding
-         integer(c_long_long) :: A_array, vec_long
-
-      end subroutine vecscatter_mat_reverse_end_c         
- 
-   end interface    
+   end interface
    
    interface   
       
@@ -393,22 +371,22 @@ module c_petsc_interfaces
 
    interface   
       
-      subroutine pmisr_kokkos(A_array, max_luby_steps, pmis_int, measure_local, zero_meaure_c_point_int) &
+      subroutine pmisr_kokkos(A_array, sf_array, leaf_vec_array, max_luby_steps, pmis_int, measure_local, zero_meaure_c_point_int) &
          bind(c, name="pmisr_kokkos")
          use iso_c_binding
-         integer(c_long_long) :: A_array
+         integer(c_long_long) :: A_array, sf_array, leaf_vec_array
          type(c_ptr), value :: measure_local
          integer(c_int), value :: max_luby_steps, pmis_int, zero_meaure_c_point_int
-      end subroutine pmisr_kokkos         
+      end subroutine pmisr_kokkos
  
    end interface     
 
    interface   
       
-      subroutine MatDiagDomRatio_kokkos(A_array, max_dd_ratio_achieved, local_rows_aff) &
+      subroutine MatDiagDomRatio_kokkos(A_array, sf_array, leaf_vec_array, max_dd_ratio_achieved, local_rows_aff) &
          bind(c, name="MatDiagDomRatio_kokkos")
          use iso_c_binding
-         integer(c_long_long) :: A_array
+         integer(c_long_long) :: A_array, sf_array, leaf_vec_array
          real(PFLARE_PETSCREAL_C_KIND) :: max_dd_ratio_achieved
          integer(PFLARE_PETSCINT_C_KIND) :: local_rows_aff
       end subroutine MatDiagDomRatio_kokkos
@@ -418,7 +396,7 @@ module c_petsc_interfaces
    interface   
       
       subroutine ddc_kokkos(A_array, fraction_swap, max_dd_ratio, max_dd_ratio_achieved, Aff_array, &
-            random_numbers_ptr) &
+            aff_sf_array, aff_leaf_vec_array, random_numbers_ptr) &
          bind(c, name="ddc_kokkos")
          use iso_c_binding
          integer(c_long_long) :: A_array
@@ -426,8 +404,9 @@ module c_petsc_interfaces
          real(PFLARE_PETSCREAL_C_KIND), value :: max_dd_ratio
          real(PFLARE_PETSCREAL_C_KIND), value :: max_dd_ratio_achieved
          integer(c_long_long) :: Aff_array
+         integer(c_long_long) :: aff_sf_array, aff_leaf_vec_array
          type(c_ptr), value :: random_numbers_ptr
-      end subroutine ddc_kokkos         
+      end subroutine ddc_kokkos
  
    end interface 
    
@@ -592,12 +571,12 @@ module c_petsc_interfaces
    
    interface   
       
-      subroutine MatCreateSubMatrix_kokkos(A_array, is_row, is_col, &
+      subroutine MatCreateSubMatrix_kokkos(A_array, sf_array, leaf_vec_array, is_row, is_col, &
                      reuse_int, B_array, &
                      our_level, is_row_fine_int, is_col_fine_int) &
          bind(c, name="MatCreateSubMatrix_kokkos")
          use iso_c_binding
-         integer(c_long_long) :: A_array
+         integer(c_long_long) :: A_array, sf_array, leaf_vec_array
          integer(c_long_long) :: B_array
          integer(c_long_long) :: is_row, is_col
          integer(c_int), value :: our_level, is_row_fine_int, is_col_fine_int, reuse_int

--- a/src/C_PETSc_Routines.c
+++ b/src/C_PETSc_Routines.c
@@ -4,10 +4,9 @@
 
 // Include the petsc header files
 #include <petsc.h>
-#include <../src/mat/impls/aij/mpi/mpiaij.h>
 #include <petsc/private/pcimpl.h>
 
-// Set shell vec type - need this for the r, b and rhs it creates during 
+// Set shell vec type - need this for the r, b and rhs it creates during
 // the mg setup
 PETSC_INTERN void ShellSetVecType_c(Mat *matrix, Mat *shellmatrix)
 {
@@ -17,99 +16,53 @@ PETSC_INTERN void ShellSetVecType_c(Mat *matrix, Mat *shellmatrix)
    return;
 }
 
-// Does a vecscatter according to the pattern in the given Mat
-// Have to do this in C as there is no fortran interface to MatGetCommunicationStructs
-PETSC_INTERN void vecscatter_mat_begin_c(Mat *matrix, Vec *vec_long, double **nonlocal_vals)
+// Forward scatter using a caller-owned PetscSF + leaf Vec.
+PETSC_INTERN void vecscatter_mat_begin_c(PetscSF *sf, Vec *vec_long, Vec *leaf_vec)
 {
-
-   Mat_MPIAIJ *a = (Mat_MPIAIJ *)((*matrix)->data);
-
-   // Do the scatter
-   PetscCallVoid(VecScatterBegin(a->Mvctx, *vec_long, a->lvec, INSERT_VALUES, SCATTER_FORWARD));
+   PetscCallVoid(VecScatterBegin(*sf, *vec_long, *leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
 }
 
-// End the scatter started in vecscatter_mat_begin_c and return a pointer
-// Have to call vecscatter_mat_restore_c on the pointer when done
-PETSC_INTERN void vecscatter_mat_end_c(Mat *matrix, Vec *vec_long, double **nonlocal_vals)
+// End the scatter started in vecscatter_mat_begin_c and hand back a raw pointer
+// into leaf_vec for the Fortran caller. Pair with vecscatter_mat_restore_c.
+PETSC_INTERN void vecscatter_mat_end_c(PetscSF *sf, Vec *vec_long, Vec *leaf_vec, double **nonlocal_vals)
 {
-
-   Mat_MPIAIJ *a = (Mat_MPIAIJ *)((*matrix)->data);
-   PetscCallVoid(VecScatterEnd(a->Mvctx, *vec_long, a->lvec, INSERT_VALUES, SCATTER_FORWARD));
-
-   // lvec will now have the updated nonlocal values in it
-   // and so we will just return a pointer to the values in that vec
-   // these correspond to the numbering in Ao, with the local to global map for the columns
-   // in colmap
-   PetscCallVoid(VecGetArray(a->lvec, nonlocal_vals));
-   // Have to call a restore once you're done
+   PetscCallVoid(VecScatterEnd(*sf, *vec_long, *leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
+   PetscCallVoid(VecGetArray(*leaf_vec, nonlocal_vals));
 }
 
-// Does a vecscatter according to the pattern in the given Mat
-// Have to do this in C as there is no fortran interface to MatGetCommunicationStructs
-PETSC_INTERN void boolscatter_mat_begin_c(Mat *matrix, bool *local_vals, bool *nonlocal_vals)
+PETSC_INTERN void vecscatter_mat_restore_c(Vec *leaf_vec, double **nonlocal_vals)
 {
-
-   Mat_MPIAIJ *a = (Mat_MPIAIJ *)((*matrix)->data);
-
-   // Do the scatter
-   PetscCallVoid(PetscSFBcastBegin(a->Mvctx, MPI_C_BOOL, local_vals, nonlocal_vals, MPI_REPLACE));
+   PetscCallVoid(VecRestoreArray(*leaf_vec, nonlocal_vals));
 }
 
-// End the scatter started in boolscatter_mat_begin_c and return a pointer
-PETSC_INTERN void boolscatter_mat_end_c(Mat *matrix, bool *local_vals, bool *nonlocal_vals)
+// Bool scatter / reduce on the same caller-owned PetscSF.
+PETSC_INTERN void boolscatter_mat_begin_c(PetscSF *sf, bool *local_vals, bool *nonlocal_vals)
 {
-   Mat_MPIAIJ *a = (Mat_MPIAIJ *)((*matrix)->data);
-   PetscCallVoid(PetscSFBcastEnd(a->Mvctx, MPI_C_BOOL, local_vals, nonlocal_vals, MPI_REPLACE));
+   PetscCallVoid(PetscSFBcastBegin(*sf, MPI_C_BOOL, local_vals, nonlocal_vals, MPI_REPLACE));
 }
 
-PETSC_INTERN void vecscatter_mat_restore_c(Mat *matrix, double **nonlocal_vals)
+PETSC_INTERN void boolscatter_mat_end_c(PetscSF *sf, bool *local_vals, bool *nonlocal_vals)
 {
-
-   Mat_MPIAIJ *a = (Mat_MPIAIJ *)((*matrix)->data);
-   PetscCallVoid(VecRestoreArray(a->lvec, nonlocal_vals));
+   PetscCallVoid(PetscSFBcastEnd(*sf, MPI_C_BOOL, local_vals, nonlocal_vals, MPI_REPLACE));
 }
 
-// Does a reverse scatter
-// Must have updated the values in lvec before calling this
-PETSC_INTERN void vecscatter_mat_reverse_begin_c(Mat *matrix, Vec *vec_long)
+PETSC_INTERN void boolscatter_mat_reverse_begin_c(PetscSF *sf, bool *local_vals, bool *nonlocal_vals)
 {
-
-   Mat_MPIAIJ *a = (Mat_MPIAIJ *)((*matrix)->data);
-   // Could call this but can just access them directly
-   //MatGetCommunicationStructs(*matrix, &lvec, PetscInt *colmap[], &multScatter)
-
-   // Do the reverse scatter - has to be an add
-   PetscCallVoid(VecScatterBegin(a->Mvctx, a->lvec, *vec_long, ADD_VALUES, SCATTER_REVERSE));
+   PetscCallVoid(PetscSFReduceBegin(*sf, MPI_C_BOOL, nonlocal_vals, local_vals, MPI_LOR));
 }
 
-PETSC_INTERN void vecscatter_mat_reverse_end_c(Mat *matrix, Vec *vec_long)
+PETSC_INTERN void boolscatter_mat_reverse_end_c(PetscSF *sf, bool *local_vals, bool *nonlocal_vals)
 {
-
-   Mat_MPIAIJ *a = (Mat_MPIAIJ *)((*matrix)->data);
-   PetscCallVoid(VecScatterEnd(a->Mvctx, a->lvec, *vec_long, ADD_VALUES, SCATTER_REVERSE));
+   PetscCallVoid(PetscSFReduceEnd(*sf, MPI_C_BOOL, nonlocal_vals, local_vals, MPI_LOR));
 }
 
-PETSC_INTERN void boolscatter_mat_reverse_begin_c(Mat *matrix, bool *local_vals, bool *nonlocal_vals)
-{
-
-   Mat_MPIAIJ *a = (Mat_MPIAIJ *)((*matrix)->data);
-
-   // Do the scatter
-   PetscCallVoid(PetscSFReduceBegin(a->Mvctx, MPI_C_BOOL, nonlocal_vals, local_vals, MPI_LOR));
-}
-
-PETSC_INTERN void boolscatter_mat_reverse_end_c(Mat *matrix, bool *local_vals, bool *nonlocal_vals)
-{
-   Mat_MPIAIJ *a = (Mat_MPIAIJ *)((*matrix)->data);
-   PetscCallVoid(PetscSFReduceEnd(a->Mvctx, MPI_C_BOOL, nonlocal_vals, local_vals, MPI_LOR));
-}
-
-// Annoying as the fortran pointer returned by MatSeqAIJGetArrayF90 seems to be 
-// the wrong size and that can break things sometimes
+// Returns a raw pointer to the SeqAIJ value array. The Fortran-side
+// MatSeqAIJGetArrayF90 has historically returned a wrong-sized pointer on
+// some PETSc versions; this thin wrapper hands back the same C pointer
+// MatSeqAIJGetArray returns.
 PETSC_INTERN void MatSeqAIJGetArrayF90_mine(Mat *matrix, double **array)
 {
-   Mat_SeqAIJ *a = (Mat_SeqAIJ*)((*matrix)->data);
-   *array = a->a;
+   PetscCallVoid(MatSeqAIJGetArray(*matrix, array));
    return;
 }
 
@@ -606,18 +559,36 @@ PETSC_INTERN PetscErrorCode MatGetDiagonalOnly_c(Mat *A, int *diag_only)
      mat_local = *A;
   } 
 
-  Mat_SeqAIJ *a = (Mat_SeqAIJ *)mat_local->data;
   PetscCall(MatGetLocalSize(*A, &local_rows, &local_cols));
   *diag_only = 0;
 
+  // Use MatGetRowIJ to read the SeqAIJ nnz count without touching the private struct.
+  PetscInt local_nnz = 0, nonlocal_nnz = 0;
+  {
+     PetscInt n;
+     PetscBool symmetric = PETSC_FALSE, inodecompressed = PETSC_FALSE, done;
+     const PetscInt *ad_ia;
+     PetscCall(MatGetRowIJ(mat_local, 0, symmetric, inodecompressed, &n, &ad_ia, NULL, &done));
+     local_nnz = ad_ia[n];
+     PetscCall(MatRestoreRowIJ(mat_local, 0, symmetric, inodecompressed, &n, &ad_ia, NULL, &done));
+  }
+
   if (size != 1)
   {
-      Mat_SeqAIJ *b = (Mat_SeqAIJ *)mat_nonlocal->data;
       PetscBool diagDense;
+
+      {
+         PetscInt n;
+         PetscBool symmetric = PETSC_FALSE, inodecompressed = PETSC_FALSE, done;
+         const PetscInt *ao_ia;
+         PetscCall(MatGetRowIJ(mat_nonlocal, 0, symmetric, inodecompressed, &n, &ao_ia, NULL, &done));
+         nonlocal_nnz = ao_ia[n];
+         PetscCall(MatRestoreRowIJ(mat_nonlocal, 0, symmetric, inodecompressed, &n, &ao_ia, NULL, &done));
+      }
 
       // In parallel also have to check the nonlocal has nothing in it
       PetscCall(MatGetDiagonalMarkers_SeqAIJ(mat_local, NULL, &diagDense));
-      if (diagDense && local_rows == a->nz && b->nz == 0)
+      if (diagDense && local_rows == local_nnz && nonlocal_nnz == 0)
       {
          rank_diag_serial++;
       }
@@ -629,12 +600,12 @@ PETSC_INTERN PetscErrorCode MatGetDiagonalOnly_c(Mat *A, int *diag_only)
   {
       PetscBool diagDense;
       PetscCall(MatGetDiagonalMarkers_SeqAIJ(*A, NULL, &diagDense));
-      // In serial easy 
-      if (diagDense && local_rows == a->nz)
+      // In serial easy
+      if (diagDense && local_rows == local_nnz)
       {
          rank_diag++;
       }
-  }   
+  }
 
   // If every rank is diagonal only, the entire matrix is diagonal
   if (rank_diag == size)

--- a/src/C_PETSc_Routines.c
+++ b/src/C_PETSc_Routines.c
@@ -533,7 +533,7 @@ PETSC_INTERN PetscErrorCode MatGetNNZs_both_c(Mat *A, PetscInt *nnzs_local, Pets
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-extern PetscErrorCode MatGetDiagonalMarkers_SeqAIJ(Mat, const PetscInt **, PetscBool *);
+PETSC_EXTERN PetscErrorCode MatGetDiagonalMarkers_SeqAIJ(Mat, const PetscInt **, PetscBool *);
 // Returns true if a matrix is only the diagonal
 PETSC_INTERN PetscErrorCode MatGetDiagonalOnly_c(Mat *A, int *diag_only)
 {

--- a/src/Constrain_Z_or_W.F90
+++ b/src/Constrain_Z_or_W.F90
@@ -3,7 +3,7 @@ module constrain_z_or_w
    use iso_c_binding
    use petscksp
    use c_petsc_interfaces, only: vecscatter_mat_begin_c, vecscatter_mat_end_c, vecscatter_mat_restore_c
-   use petsc_helper, only: pseudo_inv
+   use petsc_helper, only: pseudo_inv, build_aij_nonlocal_sf_and_leaf
 
 #include "petsc/finclude/petscksp.h"
 
@@ -240,7 +240,10 @@ module constrain_z_or_w
       type(tMat) :: new_z_or_w
       type(c_ptr) :: b_c_nonlocal_c_ptr
       integer(c_long_long) :: A_array, vec_long
+      integer(c_long_long) :: sf_array, leaf_vec_array
       type(tMat) :: Ad, Ao
+      type(tVec) :: leaf_vec
+      type(tPetscSF) :: sf
       PetscInt, dimension(:), pointer :: colmap
       real(c_double), pointer :: b_c_nonlocal(:)
       PetscScalar, dimension(:), pointer :: b_c_local, b_f_vals
@@ -333,16 +336,21 @@ module constrain_z_or_w
          deallocate(b_c_nonlocal_alloc)
          allocate(b_c_nonlocal_alloc(cols_ao, size(null_vecs_c)))
 
+         ! Build the PetscSF + leaf Vec once for row_mat and reuse across every
+         ! null-vec iteration: every null_vecs_c(i) shares the column layout of
+         ! row_mat, so a single SF drives all the scatters.
+         call build_aij_nonlocal_sf_and_leaf(row_mat, sf, leaf_vec)
+         sf_array = sf%v
+         leaf_vec_array = leaf_vec%v
+
          ! Loop over all the near nullspace vectors and get the nonlocal components
          do null_vec = 1, size(null_vecs_c)
-         
+
             ! We want the nonlocal values in B_c
             vec_long = null_vecs_c(null_vec)%v
 
-            ! Do the comms
-            ! Have to call restore after we're done with lvec (ie null_vecs_c(null_vec))
-            call vecscatter_mat_begin_c(A_array, vec_long, b_c_nonlocal_c_ptr)
-            call vecscatter_mat_end_c(A_array, vec_long, b_c_nonlocal_c_ptr)
+            call vecscatter_mat_begin_c(sf_array, vec_long, leaf_vec_array)
+            call vecscatter_mat_end_c(sf_array, vec_long, leaf_vec_array, b_c_nonlocal_c_ptr)
             ! Nonlocal vals only pointer
             ! b_c_nonlocal now contains all the nonlocal values of B_c we need for all the nonlocal columns
             ! in every local row
@@ -351,10 +359,13 @@ module constrain_z_or_w
             ! Copy the values
             b_c_nonlocal_alloc(:, null_vec) = b_c_nonlocal
             ! Make sure to restore as soon as we're done with it
-            call vecscatter_mat_restore_c(A_array, b_c_nonlocal_c_ptr)
+            call vecscatter_mat_restore_c(leaf_vec_array, b_c_nonlocal_c_ptr)
 
          end do
-         
+
+         call PetscSFDestroy(sf, ierr)
+         call VecDestroy(leaf_vec, ierr)
+
       ! In serial this is simple
       else
 

--- a/src/DDC_Module.F90
+++ b/src/DDC_Module.F90
@@ -2,7 +2,8 @@ module ddc_module
 
    use iso_c_binding
    use petscmat
-   use petsc_helper, only: kokkos_debug, remove_small_from_sparse, MatCreateSubMatrixWrapper
+   use petsc_helper, only: kokkos_debug, remove_small_from_sparse, MatCreateSubMatrixWrapper, &
+         build_aij_nonlocal_sf_and_leaf
       use c_petsc_interfaces, only: copy_cf_markers_d2h, copy_diag_dom_ratio_d2h, ddc_kokkos, &
          MatDiagDomRatio_kokkos, create_cf_is_kokkos, &
          vecscatter_mat_begin_c, vecscatter_mat_end_c, vecscatter_mat_restore_c, MatSeqAIJGetArrayF90_mine
@@ -44,11 +45,17 @@ module ddc_module
       PetscInt :: local_rows, local_cols
       PetscReal :: max_dd_ratio_achieved
       integer :: seed_size_ddc, comm_rank_ddc, errorcode_ddc, i_loc
+      integer :: comm_size
       integer, dimension(:), allocatable :: seed_ddc
       PetscReal, dimension(:), allocatable :: diag_dom_ratio
       PetscReal, dimension(:), allocatable, target :: diag_dom_ratio_random
       type(c_ptr) :: random_numbers_ptr
       MPIU_Comm :: MPI_COMM_MATRIX
+      ! Aff PetscSF + leaf Vec built once when trigger_dd_ratio_compute_local
+      ! is true; shared by ddc_kokkos and ddc_cpu (-> pmisr_existing_measure_implicit_transpose).
+      integer(c_long_long) :: aff_sf_array, aff_leaf_vec_array
+      type(tPetscSF) :: aff_sf
+      type(tVec) :: aff_leaf_vec
 
 #if defined(PETSC_HAVE_KOKKOS)
       integer(c_long_long) :: A_array, Aff_array, is_fine_array, is_coarse_array
@@ -68,6 +75,10 @@ module ddc_module
          return
       end if
 
+      call PetscObjectGetComm(input_mat, MPI_COMM_MATRIX, ierr)
+      call MPI_Comm_rank(MPI_COMM_MATRIX, comm_rank_ddc, errorcode_ddc)      
+      call MPI_Comm_size(MPI_COMM_MATRIX, comm_size, errorcode_ddc)
+
       ! Compute the diagonal dominance ratio - either returned in diag_dom_ratio
       ! or stored in a device copy for kokkos
       ! max_dd_ratio_achieved is always returned and is the max diag dom ratio across
@@ -86,8 +97,6 @@ module ddc_module
       random_numbers_ptr = c_null_ptr
       if (trigger_dd_ratio_compute_local) then
          
-         call PetscObjectGetComm(input_mat, MPI_COMM_MATRIX, ierr)
-         call MPI_Comm_rank(MPI_COMM_MATRIX, comm_rank_ddc, errorcode_ddc)
          call MatGetLocalSize(input_mat, local_rows, local_cols, ierr)
          ! We allocate randoms here to be the size of input, rather than 
          ! just F points as if we are on the device the is_fine won't be allocated
@@ -141,9 +150,22 @@ module ddc_module
             cf_markers_local_two = cf_markers_local
          end if
 
+         ! Build the PetscSF + leaf Vec for Aff_ddc once before ddc_kokkos.
+         ! Both ddc_kokkos and (in the kokkos_debug fall-through) ddc_cpu
+         ! reuse this SF, which then propagates down through
+         ! pmisr_existing_measure_implicit_transpose so the SF is never
+         ! re-created at lower call levels.
+         aff_sf_array = 0
+         aff_leaf_vec_array = 0
+         if (trigger_dd_ratio_compute_local .AND. comm_size /= 1) then
+            call build_aij_nonlocal_sf_and_leaf(Aff_ddc, aff_sf, aff_leaf_vec)
+            aff_sf_array = aff_sf%v
+            aff_leaf_vec_array = aff_leaf_vec%v
+         end if
+
          ! Modifies the existing device cf_markers created by the pmisr
          call ddc_kokkos(A_array, fraction_swap, max_dd_ratio, max_dd_ratio_achieved, Aff_array, &
-            random_numbers_ptr)
+            aff_sf_array, aff_leaf_vec_array, random_numbers_ptr)
 
          ! If debugging do a comparison between CPU and Kokkos results
          if (kokkos_debug()) then
@@ -153,7 +175,9 @@ module ddc_module
             call copy_cf_markers_d2h(cf_markers_local_ptr)
             if (trigger_dd_ratio_compute_local) then
                call ddc_cpu(input_mat, is_fine, fraction_swap, max_dd_ratio, max_dd_ratio_achieved, &
-                  diag_dom_ratio, cf_markers_local_two, Aff=Aff_ddc, &
+                  diag_dom_ratio, cf_markers_local_two, &
+                  aff_sf_array=aff_sf_array, aff_leaf_vec_array=aff_leaf_vec_array, &
+                  Aff=Aff_ddc, &
                   diag_dom_ratio_random=diag_dom_ratio_random)
             else
                call ddc_cpu(input_mat, is_fine, fraction_swap, max_dd_ratio, max_dd_ratio_achieved, &
@@ -175,6 +199,10 @@ module ddc_module
 
          ! Cleanup
          if (trigger_dd_ratio_compute_local) then
+            if (comm_size /= 1) then
+               call PetscSFDestroy(aff_sf, ierr)
+               call VecDestroy(aff_leaf_vec, ierr)
+            end if
             call MatDestroy(Aff_ddc, ierr)
          end if
 
@@ -184,10 +212,22 @@ module ddc_module
             call MatCreateSubMatrix(input_mat, &
                   is_fine, is_fine, MAT_INITIAL_MATRIX, &
                   Aff_ddc, ierr)
+            aff_sf_array = 0
+            aff_leaf_vec_array = 0
+            if (comm_size /= 1) then
+               call build_aij_nonlocal_sf_and_leaf(Aff_ddc, aff_sf, aff_leaf_vec)
+               aff_sf_array = aff_sf%v
+               aff_leaf_vec_array = aff_leaf_vec%v
+            end if
             call ddc_cpu(input_mat, is_fine, fraction_swap, max_dd_ratio, max_dd_ratio_achieved, &
                diag_dom_ratio, cf_markers_local, &
+                  aff_sf_array=aff_sf_array, aff_leaf_vec_array=aff_leaf_vec_array, &
                   Aff=Aff_ddc, &
                   diag_dom_ratio_random=diag_dom_ratio_random)
+            if (comm_size /= 1) then
+               call PetscSFDestroy(aff_sf, ierr)
+               call VecDestroy(aff_leaf_vec, ierr)
+            end if
             call MatDestroy(Aff_ddc, ierr)
          else
             call ddc_cpu(input_mat, is_fine, fraction_swap, max_dd_ratio, max_dd_ratio_achieved, &
@@ -200,10 +240,22 @@ module ddc_module
          call MatCreateSubMatrix(input_mat, &
                is_fine, is_fine, MAT_INITIAL_MATRIX, &
                Aff_ddc, ierr)
+         aff_sf_array = 0
+         aff_leaf_vec_array = 0
+         if (comm_size /= 1) then
+            call build_aij_nonlocal_sf_and_leaf(Aff_ddc, aff_sf, aff_leaf_vec)
+            aff_sf_array = aff_sf%v
+            aff_leaf_vec_array = aff_leaf_vec%v
+         end if
          call ddc_cpu(input_mat, is_fine, fraction_swap, max_dd_ratio, max_dd_ratio_achieved, &
                diag_dom_ratio, cf_markers_local, &
+               aff_sf_array=aff_sf_array, aff_leaf_vec_array=aff_leaf_vec_array, &
                Aff=Aff_ddc, &
                diag_dom_ratio_random=diag_dom_ratio_random)
+         if (comm_size /= 1) then
+            call PetscSFDestroy(aff_sf, ierr)
+            call VecDestroy(aff_leaf_vec, ierr)
+         end if
          call MatDestroy(Aff_ddc, ierr)
       else
             call ddc_cpu(input_mat, is_fine, fraction_swap, max_dd_ratio, max_dd_ratio_achieved, &
@@ -219,7 +271,7 @@ module ddc_module
 ! -------------------------------------------------------------------------------------------------------------------------------
 
       subroutine ddc_cpu(input_mat, is_fine, fraction_swap, max_dd_ratio, max_dd_ratio_achieved, diag_dom_ratio, &
-         cf_markers_local, Aff, diag_dom_ratio_random)
+         cf_markers_local, aff_sf_array, aff_leaf_vec_array, Aff, diag_dom_ratio_random)
 
       ! Second pass diagonal dominance cleanup
       ! Flips the F definitions to C based on least diagonally dominant local rows
@@ -228,6 +280,11 @@ module ddc_module
       !  for swapping C to F based on row-wise diagonal dominance (ie alpha_diag)
       ! If fraction_swap > 0 it uses fraction_swap as the local fraction of worst C points to swap to F
       !  though it won't hit that fraction exactly as we bin the diag dom ratios for speed, it will be close to the fraction
+      !
+      ! aff_sf_array / aff_leaf_vec_array are the PetscSF + leaf Vec built once
+      ! by the caller (ddc dispatcher) for Aff and forwarded to
+      ! pmisr_existing_measure_implicit_transpose. Required when Aff is present
+      ! and the trigger path runs in parallel.
 
       ! ~~~~~~
       type(tMat), target, intent(in)      :: input_mat
@@ -237,6 +294,7 @@ module ddc_module
       PetscReal, intent(in)               :: max_dd_ratio_achieved
       PetscReal, dimension(:), intent(in) :: diag_dom_ratio
       integer, dimension(:), allocatable, intent(inout) :: cf_markers_local
+      integer(c_long_long), intent(in), optional :: aff_sf_array, aff_leaf_vec_array
       type(tMat), intent(in), optional    :: Aff
       PetscReal, dimension(:), intent(in), optional :: diag_dom_ratio_random
 
@@ -382,7 +440,8 @@ module ddc_module
          ! Uses the implicit transpose version which takes Aff directly
          ! and handles Aff+Aff^T internally without forming the explicit sum
          max_luby_steps = -1
-         call pmisr_existing_measure_implicit_transpose(Aff, max_luby_steps, .FALSE., &
+         call pmisr_existing_measure_implicit_transpose(Aff, aff_sf_array, aff_leaf_vec_array, &
+                  max_luby_steps, .FALSE., &
                   diag_dom_ratio_measure, cf_markers_local_aff)
 
          ! Let's go and swap the badly diagonally dominant rows to F points

--- a/src/DDC_Modulek.kokkos.cxx
+++ b/src/DDC_Modulek.kokkos.cxx
@@ -2,7 +2,6 @@
 #include "kokkos_helper.hpp"
 #include <iostream>
 #include <../src/mat/impls/aij/seq/aij.h>
-#include <../src/mat/impls/aij/mpi/mpiaij.h>
 
 // The definition of the device copy of the cf markers on a given level 
 // is stored in Device_Datak.kokkos.cxx and imported as extern from 
@@ -13,7 +12,7 @@
 // ddc cleanup but on the device - uses the global variable cf_markers_local_d
 // This no longer copies back to the host pointer cf_markers_local at the end
 // You have to explicitly call copy_cf_markers_d2h(cf_markers_local) to do this
-PETSC_INTERN void ddc_kokkos(Mat *input_mat, const PetscReal fraction_swap, const PetscReal max_dd_ratio, const PetscReal max_dd_ratio_achieved, Mat *aff, PetscReal *random_numbers)
+PETSC_INTERN void ddc_kokkos(Mat *input_mat, const PetscReal fraction_swap, const PetscReal max_dd_ratio, const PetscReal max_dd_ratio_achieved, Mat *aff, PetscSF *aff_sf, Vec *aff_leaf_vec, PetscReal *random_numbers)
 {
    // Can't use the global directly within the parallel 
    // regions on the device
@@ -101,7 +100,7 @@ PETSC_INTERN void ddc_kokkos(Mat *input_mat, const PetscReal fraction_swap, cons
 
          // Call PMISR with implicit transpose - takes Aff directly, handles Aff+Aff^T internally
          // pmis_int=0 means PMISR, zero_measure_c_point_int=0
-         pmisr_existing_measure_implicit_transpose_kokkos(aff, -1, 0, measure_d, cf_markers_aff_d, 0);
+         pmisr_existing_measure_implicit_transpose_kokkos(aff, aff_sf, aff_leaf_vec, -1, 0, measure_d, cf_markers_aff_d, 0);  // aff_sf and aff_leaf_vec are already PetscSF* and Vec* from the caller
 
          // Swap F-tagged points back into cf_markers_d
          Kokkos::parallel_for(

--- a/src/DDC_Modulek.kokkos.cxx
+++ b/src/DDC_Modulek.kokkos.cxx
@@ -1,7 +1,6 @@
 // Our petsc kokkos definitions - has to go first
 #include "kokkos_helper.hpp"
 #include <iostream>
-#include <../src/mat/impls/aij/seq/aij.h>
 
 // The definition of the device copy of the cf markers on a given level 
 // is stored in Device_Datak.kokkos.cxx and imported as extern from 

--- a/src/Device_Datak.kokkos.cxx
+++ b/src/Device_Datak.kokkos.cxx
@@ -1,7 +1,6 @@
 // Our petsc kokkos definitions - has to go first
 #include "kokkos_helper.hpp"
 #include <iostream>
-#include <../src/mat/impls/aij/seq/aij.h>
 
 // This is a device copy of the cf markers on a given level
 // to save having to copy it to/from the host between pmisr and ddc calls

--- a/src/Device_Datak.kokkos.cxx
+++ b/src/Device_Datak.kokkos.cxx
@@ -2,7 +2,6 @@
 #include "kokkos_helper.hpp"
 #include <iostream>
 #include <../src/mat/impls/aij/seq/aij.h>
-#include <../src/mat/impls/aij/mpi/mpiaij.h>
 
 // This is a device copy of the cf markers on a given level
 // to save having to copy it to/from the host between pmisr and ddc calls

--- a/src/Gmres_Polyk.kokkos.cxx
+++ b/src/Gmres_Polyk.kokkos.cxx
@@ -159,28 +159,39 @@ PETSC_INTERN void mat_mult_powers_share_sparsity_kokkos(Mat *input_mat, const in
    PetscCallVoid(MatShift(*output_mat, coefficients[0]));
 
    // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
+   // Get pointers to the i,j on the device and Kokkos views to the values
    // This should happen after all the (potentially) host matscale, mataxpy and matshift above
    // ~~~~~~~~~~~~
    const PetscInt *device_submat_i = nullptr, *device_submat_j = nullptr;
    PetscMemType mtype;
-   PetscScalar *device_submat_vals = nullptr;  
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(submatrices[0], &device_submat_i, &device_submat_j, &device_submat_vals, &mtype));  
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(submatrices[0], &device_submat_i, &device_submat_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_submat_vals;
+   PetscCallVoid(MatSeqAIJGetKokkosView(submatrices[0], &device_submat_vals));
 
    const PetscInt *device_local_i_input = nullptr, *device_local_j_input = nullptr, *device_nonlocal_i_input = nullptr, *device_nonlocal_j_input = nullptr;
-   PetscScalar *device_local_vals_input = nullptr, *device_nonlocal_vals_input = nullptr;  
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_input, &device_local_i_input, &device_local_j_input, &device_local_vals_input, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_input, &device_nonlocal_i_input, &device_nonlocal_j_input, &device_nonlocal_vals_input, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_input, &device_local_i_input, &device_local_j_input, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_input, &device_nonlocal_i_input, &device_nonlocal_j_input, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals_input;
+   Kokkos::View<const PetscScalar *> device_nonlocal_vals_input;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local_input, &device_local_vals_input));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal_input, &device_nonlocal_vals_input));
 
    const PetscInt *device_local_i_sparsity = nullptr, *device_local_j_sparsity = nullptr, *device_nonlocal_i_sparsity = nullptr, *device_nonlocal_j_sparsity = nullptr;
-   PetscScalar *device_local_vals_sparsity = nullptr, *device_nonlocal_vals_sparsity = nullptr;  
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_sparsity, &device_local_i_sparsity, &device_local_j_sparsity, &device_local_vals_sparsity, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_sparsity, &device_nonlocal_i_sparsity, &device_nonlocal_j_sparsity, &device_nonlocal_vals_sparsity, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_sparsity, &device_local_i_sparsity, &device_local_j_sparsity, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_sparsity, &device_nonlocal_i_sparsity, &device_nonlocal_j_sparsity, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals_sparsity;
+   Kokkos::View<const PetscScalar *> device_nonlocal_vals_sparsity;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local_sparsity, &device_local_vals_sparsity));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal_sparsity, &device_nonlocal_vals_sparsity));
 
    const PetscInt *device_local_i_output = nullptr, *device_local_j_output = nullptr, *device_nonlocal_i_output = nullptr, *device_nonlocal_j_output = nullptr;
-   PetscScalar *device_local_vals_output = nullptr, *device_nonlocal_vals_output = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, &device_local_j_output, &device_local_vals_output, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_output, &device_nonlocal_j_output, &device_nonlocal_vals_output, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, &device_local_j_output, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_output, &device_nonlocal_j_output, NULL, &mtype));
+   // Output values are accumulated into via += so we need read-write access
+   Kokkos::View<PetscScalar *> device_local_vals_output;
+   Kokkos::View<PetscScalar *> device_nonlocal_vals_output;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local_output, &device_local_vals_output));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal_output, &device_nonlocal_vals_output));
 
    // ~~~~~~~~~~~~~~
    // Build a mapping from the input matrix's nonlocal column indices to the 
@@ -347,12 +358,12 @@ PETSC_INTERN void mat_mult_powers_share_sparsity_kokkos(Mat *input_mat, const in
          // Fill vals_prev
          if (j < local_cols_row_i)
          {
-            vals_prev[j] = device_local_vals_sparsity[device_local_i_sparsity[i] + j];
+            vals_prev[j] = device_local_vals_sparsity(device_local_i_sparsity[i] + j);
          }
          // Nonlocal part
          else
          {
-            vals_prev[j] = device_nonlocal_vals_sparsity[device_nonlocal_i_sparsity[i] + (j - local_cols_row_i)];
+            vals_prev[j] = device_nonlocal_vals_sparsity(device_nonlocal_i_sparsity[i] + (j - local_cols_row_i));
          }
       });
       
@@ -485,16 +496,16 @@ PETSC_INTERN void mat_mult_powers_share_sparsity_kokkos(Mat *input_mat, const in
                      {
                         if (idx_col_of_row_j < local_cols_row_of_col_j)
                         {
-                           val_target = device_local_vals_input[device_local_i_input[row_of_col_j] + idx_col_of_row_j];
+                           val_target = device_local_vals_input(device_local_i_input[row_of_col_j] + idx_col_of_row_j);
                         }
                         else
                         {
-                           val_target = device_nonlocal_vals_input[device_nonlocal_i_input[row_of_col_j] + idx_col_of_row_j - local_cols_row_of_col_j];
+                           val_target = device_nonlocal_vals_input(device_nonlocal_i_input[row_of_col_j] + idx_col_of_row_j - local_cols_row_of_col_j);
                         }
                      }
                      else
                      {
-                        val_target = device_submat_vals[device_submat_i[row_of_col_j] + idx_col_of_row_j];
+                        val_target = device_submat_vals(device_submat_i[row_of_col_j] + idx_col_of_row_j);
                      }
 
                      // Has to be atomic! Potentially lots of contention so maybe not 
@@ -534,12 +545,12 @@ PETSC_INTERN void mat_mult_powers_share_sparsity_kokkos(Mat *input_mat, const in
                   {
                      diag_increm = 1;
                   }
-                  device_local_vals_output[device_local_i_output[i] + j + diag_increm] += coeff_term * vals_temp[j];
+                  device_local_vals_output(device_local_i_output[i] + j + diag_increm) += coeff_term * vals_temp[j];
                }
                // Nonlocal part
                else
                {
-                  device_nonlocal_vals_output[device_nonlocal_i_output[i] + (j - local_cols_row_i)] += coeff_term * vals_temp[j];
+                  device_nonlocal_vals_output(device_nonlocal_i_output[i] + (j - local_cols_row_i)) += coeff_term * vals_temp[j];
                }
             }
 
@@ -552,27 +563,19 @@ PETSC_INTERN void mat_mult_powers_share_sparsity_kokkos(Mat *input_mat, const in
       }
    });
     
-   Mat_SeqAIJKokkos *aijkok_local_output = static_cast<Mat_SeqAIJKokkos *>(mat_local_output->spptr);
-   Mat_SeqAIJKokkos *aijkok_nonlocal_output = NULL;
-   if (mpi) aijkok_nonlocal_output = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_output->spptr);   
-
    Kokkos::fence();
 
-   // Have to specify we've modifed data on the device
-   // Want to call MatSeqAIJKokkosModifyDevice but its PETSC_INTERN
-   aijkok_local_output->a_dual.clear_sync_state();
-   aijkok_local_output->a_dual.modify_device();
-   aijkok_local_output->transpose_updated = PETSC_FALSE;
-   aijkok_local_output->hermitian_updated = PETSC_FALSE;
-   // Invalidate diagonals
-   if (mpi)
-   {
-      aijkok_nonlocal_output->a_dual.clear_sync_state();
-      aijkok_nonlocal_output->a_dual.modify_device();
-      aijkok_nonlocal_output->transpose_updated = PETSC_FALSE;
-      aijkok_nonlocal_output->hermitian_updated = PETSC_FALSE;
-   }      
-   PetscCallVoid(PetscObjectStateIncrease((PetscObject)(*output_mat)));   
+   // Restore the read-only input/sparsity/submat views
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(submatrices[0], &device_submat_vals));
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local_input, &device_local_vals_input));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal_input, &device_nonlocal_vals_input));
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local_sparsity, &device_local_vals_sparsity));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal_sparsity, &device_nonlocal_vals_sparsity));
+
+   // The matching restore handles MatSeqAIJKokkosModifyDevice (clears sync state,
+   // marks device modified, invalidates transpose/hermitian, bumps object state).
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local_output, &device_local_vals_output));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal_output, &device_nonlocal_vals_output));
 
    for (int i = 1; i < poly_sparsity_order; i++)
    {

--- a/src/Grid_Transferk.kokkos.cxx
+++ b/src/Grid_Transferk.kokkos.cxx
@@ -589,20 +589,12 @@ PETSC_INTERN void compute_P_from_W_kokkos(Mat *input_mat, PetscInt global_row_st
       Mat_SeqAIJKokkos *aijkok_nonlocal_output = NULL;
       if (mpi) aijkok_nonlocal_output = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_output->spptr);
 
-      // Annoying we can't just call MatSeqAIJGetKokkosView
-      a_local_d = aijkok_local_output->a_dual.view_device();
-      if (mpi) a_nonlocal_d = aijkok_nonlocal_output->a_dual.view_device();
-
-      // Annoyingly there isn't currently the ability to get views for i (or j)
-      const PetscInt *device_local_i_output = nullptr, *device_nonlocal_i_ouput = nullptr;
+      // Get device pointers for the existing i and a arrays
+      const PetscInt *device_local_i_output = nullptr, *device_nonlocal_i_output = nullptr;
+      PetscScalar *device_local_a_output = nullptr, *device_nonlocal_a_output = nullptr;
       PetscMemType mtype;
-      PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, NULL, NULL, &mtype));  
-      if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_ouput, NULL, NULL, &mtype));  
-
-      // Have these point at the existing i pointers - we don't need j if we're reusing
-      ConstMatRowMapKokkosView i_local_const_d = ConstMatRowMapKokkosView(device_local_i_output, local_rows+1);
-      ConstMatRowMapKokkosView i_nonlocal_const_d;
-      if (mpi) i_nonlocal_const_d = ConstMatRowMapKokkosView(device_nonlocal_i_ouput, local_rows+1);        
+      PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, NULL, &device_local_a_output, &mtype));
+      if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_output, NULL, &device_nonlocal_a_output, &mtype));
 
       // Only have to write W as the identity block cannot change
       // Loop over the rows of W - annoying we have const views as this is just the same loop as above
@@ -616,31 +608,31 @@ PETSC_INTERN void compute_P_from_W_kokkos(Mat *input_mat, PetscInt global_row_st
             // Convert to global fine index into a local index in the full matrix
             PetscInt row_index = fine_view_d(i) - global_row_start;
             // Still using i here (the local index into W)
-            const PetscInt ncols_local = device_local_i[i + 1] - device_local_i[i];         
+            const PetscInt ncols_local = device_local_i[i + 1] - device_local_i[i];
 
             // For over local columns - copy in W
             Kokkos::parallel_for(
                Kokkos::TeamThreadRange(t, ncols_local), [&](const PetscInt j) {
 
-               a_local_d(i_local_const_d(row_index) + j) = device_local_vals[device_local_i[i] + j];
-                     
-            });     
+               device_local_a_output[device_local_i_output[row_index] + j] = device_local_vals[device_local_i[i] + j];
+
+            });
 
             // For over nonlocal columns - copy in W
             if (mpi)
             {
-               PetscInt ncols_nonlocal = device_nonlocal_i[i + 1] - device_nonlocal_i[i];         
+               PetscInt ncols_nonlocal = device_nonlocal_i[i + 1] - device_nonlocal_i[i];
 
                Kokkos::parallel_for(
                   Kokkos::TeamThreadRange(t, ncols_nonlocal), [&](const PetscInt j) {
 
                   // We keep the existing local indices in the off-diagonal blocl here
                   // we have all the same columns as W and hence the same garray
-                  a_nonlocal_d(i_nonlocal_const_d(row_index) + j) = device_nonlocal_vals[device_nonlocal_i[i] + j];
-                        
-               });          
+                  device_nonlocal_a_output[device_nonlocal_i_output[row_index] + j] = device_nonlocal_vals[device_nonlocal_i[i] + j];
+
+               });
             }
-      });   
+      });
 
       Kokkos::fence();
 
@@ -1063,23 +1055,14 @@ PETSC_INTERN void compute_R_from_Z_kokkos(Mat *input_mat, PetscInt global_row_st
       Mat_SeqAIJKokkos *aijkok_nonlocal_output = NULL;
       if (mpi) aijkok_nonlocal_output = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_output->spptr);
 
-      // Annoying we can't just call MatSeqAIJGetKokkosView
-      a_local_d = aijkok_local_output->a_dual.view_device();
-      if (mpi) a_nonlocal_d = aijkok_nonlocal_output->a_dual.view_device();
-
-      // Annoyingly there isn't currently the ability to get views for i (or j)
-      const PetscInt *device_local_i_output = nullptr, *device_local_j_output = nullptr, *device_nonlocal_i_ouput = nullptr;
+      // Get device pointers for the existing i, j, and a arrays
+      const PetscInt *device_local_i_output = nullptr, *device_local_j_output = nullptr, *device_nonlocal_i_output = nullptr;
+      PetscScalar *device_local_a_output = nullptr, *device_nonlocal_a_output = nullptr;
       PetscMemType mtype;
-      PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, &device_local_j_output, NULL, &mtype));  
-      if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_ouput, NULL, NULL, &mtype));  
+      PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, &device_local_j_output, &device_local_a_output, &mtype));
+      if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_output, NULL, &device_nonlocal_a_output, &mtype));
 
-      // Have these point at the existing i pointers - we only need the local j
-      ConstMatRowMapKokkosView i_local_const_d = ConstMatRowMapKokkosView(device_local_i_output, local_rows_z+1);
-      ConstMatRowMapKokkosView j_local_const_d = ConstMatRowMapKokkosView(device_local_j_output, aijkok_local_output->csrmat.nnz());
-      ConstMatRowMapKokkosView i_nonlocal_const_d;
-      if (mpi) i_nonlocal_const_d = ConstMatRowMapKokkosView(device_nonlocal_i_ouput, local_rows_z+1);        
-
-      // Only have to write Z but have to be careful as we have the identity mixed 
+      // Only have to write Z but have to be careful as we have the identity mixed
       // in there
       // Loop over the rows of Z - annoying we have const views as this is just the same loop as above
       Kokkos::parallel_for(
@@ -1092,7 +1075,7 @@ PETSC_INTERN void compute_R_from_Z_kokkos(Mat *input_mat, PetscInt global_row_st
             // Simple row index
             PetscInt row_index = i;
             // Still using i here (the local index into Z)
-            const PetscInt ncols_local = device_local_i[i + 1] - device_local_i[i];         
+            const PetscInt ncols_local = device_local_i[i + 1] - device_local_i[i];
 
             // For over local columns - copy in Z
             // We have to skip over the identity entries, which we know are always C points
@@ -1103,25 +1086,25 @@ PETSC_INTERN void compute_R_from_Z_kokkos(Mat *input_mat, PetscInt global_row_st
 
                // If we're at or after the C point identity, our index into R gets a +1
                // so we skip over writing to that index in R
-               if (j_local_const_d(i_local_const_d(row_index) + j) >= coarse_view_d(i) - global_row_start) offset = 1;
-               a_local_d(i_local_const_d(row_index) + j + offset) = device_local_vals[device_local_i[i] + j];
-            });     
+               if (device_local_j_output[device_local_i_output[row_index] + j] >= coarse_view_d(i) - global_row_start) offset = 1;
+               device_local_a_output[device_local_i_output[row_index] + j + offset] = device_local_vals[device_local_i[i] + j];
+            });
 
             // For over nonlocal columns - copy in Z - identical structure in the off-diag block
             if (mpi)
             {
-               PetscInt ncols_nonlocal = device_nonlocal_i[i + 1] - device_nonlocal_i[i];         
+               PetscInt ncols_nonlocal = device_nonlocal_i[i + 1] - device_nonlocal_i[i];
 
                Kokkos::parallel_for(
                   Kokkos::TeamThreadRange(t, ncols_nonlocal), [&](const PetscInt j) {
 
                   // We keep the existing local indices in the off-diagonal block here
                   // we have all the same columns as Z and hence the same garray
-                  a_nonlocal_d(i_nonlocal_const_d(row_index) + j) = device_nonlocal_vals[device_nonlocal_i[i] + j];
-                        
-               });          
+                  device_nonlocal_a_output[device_nonlocal_i_output[row_index] + j] = device_nonlocal_vals[device_nonlocal_i[i] + j];
+
+               });
             }
-      });   
+      });
 
       Kokkos::fence();
 

--- a/src/Grid_Transferk.kokkos.cxx
+++ b/src/Grid_Transferk.kokkos.cxx
@@ -54,13 +54,16 @@ PETSC_INTERN void generate_one_point_with_one_entry_from_sparse_kokkos(Mat *inpu
    PetscCallVoid(MatGetOwnershipRangeColumn(*input_mat, &global_col_start, &global_col_end_plus_one));
 
    // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
+   // Get pointers to the i,j on the device and Kokkos views to the values
    // ~~~~~~~~~~~~
    const PetscInt *device_local_i = nullptr, *device_local_j = nullptr, *device_nonlocal_i = nullptr, *device_nonlocal_j = nullptr;
    PetscMemType mtype;
-   PetscScalar *device_local_vals = nullptr, *device_nonlocal_vals = nullptr;  
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, &device_local_vals, &mtype));  
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, &device_nonlocal_vals, &mtype));          
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals;
+   Kokkos::View<const PetscScalar *> device_nonlocal_vals;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    // ~~~~~~~~~~~~
    // Get the number of nnzs
@@ -100,8 +103,8 @@ PETSC_INTERN void generate_one_point_with_one_entry_from_sparse_kokkos(Mat *inpu
          [&](const PetscInt j, ReduceDataMaxRow& thread_data) {
 
             // If it's the biggest value keep it
-            if (Kokkos::abs(device_local_vals[device_local_i[i] + j]) > thread_data.val) {
-               thread_data.val = Kokkos::abs(device_local_vals[device_local_i[i] + j]);
+            if (Kokkos::abs(device_local_vals(device_local_i[i] + j)) > thread_data.val) {
+               thread_data.val = Kokkos::abs(device_local_vals(device_local_i[i] + j));
                thread_data.col = device_local_j[device_local_i[i] + j];
             }
          }, local_row_result
@@ -115,8 +118,8 @@ PETSC_INTERN void generate_one_point_with_one_entry_from_sparse_kokkos(Mat *inpu
             [&](const PetscInt j, ReduceDataMaxRow& thread_data) {
 
                // If it's the biggest value keep it
-               if (Kokkos::abs(device_nonlocal_vals[device_nonlocal_i[i] + j]) > thread_data.val) {
-                  thread_data.val = Kokkos::abs(device_nonlocal_vals[device_nonlocal_i[i] + j]);
+               if (Kokkos::abs(device_nonlocal_vals(device_nonlocal_i[i] + j)) > thread_data.val) {
+                  thread_data.val = Kokkos::abs(device_nonlocal_vals(device_nonlocal_i[i] + j));
                   // Set the global index
                   thread_data.col = colmap_input_d(device_nonlocal_j[device_nonlocal_i[i] + j]);
                }
@@ -290,11 +293,14 @@ PETSC_INTERN void generate_one_point_with_one_entry_from_sparse_kokkos(Mat *inpu
       // We can now create our MPI matrix
       PetscCallVoid(MatCreateMPIAIJWithSeqAIJ(MPI_COMM_MATRIX, global_rows, global_cols, output_mat_local, output_mat_nonlocal, garray_host, output_mat));
    }     
-   // If in serial 
+   // If in serial
    else
    {
       *output_mat = output_mat_local;
    }
+
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    return;
 }
@@ -373,13 +379,16 @@ PETSC_INTERN void compute_P_from_W_kokkos(Mat *input_mat, PetscInt global_row_st
    PetscCallVoid(PetscObjectGetComm((PetscObject)*input_mat, &MPI_COMM_MATRIX));
 
    // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
+   // Get pointers to the i,j on the device and Kokkos views to the values
    // ~~~~~~~~~~~~
    const PetscInt *device_local_i = nullptr, *device_local_j = nullptr, *device_nonlocal_i = nullptr, *device_nonlocal_j = nullptr;
    PetscMemType mtype;
-   PetscScalar *device_local_vals = nullptr, *device_nonlocal_vals = nullptr;  
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, &device_local_vals, &mtype));  
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, &device_nonlocal_vals, &mtype));          
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals;
+   Kokkos::View<const PetscScalar *> device_nonlocal_vals;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    PetscIntKokkosView nnz_match_local_row_d;
    PetscIntKokkosView nnz_match_nonlocal_row_d;
@@ -552,14 +561,14 @@ PETSC_INTERN void compute_P_from_W_kokkos(Mat *input_mat, PetscInt global_row_st
                Kokkos::TeamThreadRange(t, ncols_local), [&](const PetscInt j) {
 
                j_local_d(i_local_d(row_index) + j) = device_local_j[device_local_i[i] + j];
-               a_local_d(i_local_d(row_index) + j) = device_local_vals[device_local_i[i] + j];
-                     
-            });     
+               a_local_d(i_local_d(row_index) + j) = device_local_vals(device_local_i[i] + j);
+
+            });
 
             // For over nonlocal columns - copy in W
             if (mpi)
             {
-               PetscInt ncols_nonlocal = device_nonlocal_i[i + 1] - device_nonlocal_i[i];         
+               PetscInt ncols_nonlocal = device_nonlocal_i[i + 1] - device_nonlocal_i[i];
 
                Kokkos::parallel_for(
                   Kokkos::TeamThreadRange(t, ncols_nonlocal), [&](const PetscInt j) {
@@ -567,7 +576,7 @@ PETSC_INTERN void compute_P_from_W_kokkos(Mat *input_mat, PetscInt global_row_st
                   // We keep the existing local indices in the off-diagonal block here
                   // we have all the same columns as W and hence the same garray
                   j_nonlocal_d(i_nonlocal_d(row_index) + j) = device_nonlocal_j[device_nonlocal_i[i] + j];
-                  a_nonlocal_d(i_nonlocal_d(row_index) + j) = device_nonlocal_vals[device_nonlocal_i[i] + j];
+                  a_nonlocal_d(i_nonlocal_d(row_index) + j) = device_nonlocal_vals(device_nonlocal_i[i] + j);
                         
                });          
             }
@@ -585,16 +594,17 @@ PETSC_INTERN void compute_P_from_W_kokkos(Mat *input_mat, PetscInt global_row_st
       {
          mat_local_output = *output_mat;
       }     
-      Mat_SeqAIJKokkos *aijkok_local_output = static_cast<Mat_SeqAIJKokkos *>(mat_local_output->spptr);
-      Mat_SeqAIJKokkos *aijkok_nonlocal_output = NULL;
-      if (mpi) aijkok_nonlocal_output = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_output->spptr);
-
-      // Get device pointers for the existing i and a arrays
+      // Get device pointers for the existing i array
       const PetscInt *device_local_i_output = nullptr, *device_nonlocal_i_output = nullptr;
-      PetscScalar *device_local_a_output = nullptr, *device_nonlocal_a_output = nullptr;
       PetscMemType mtype;
-      PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, NULL, &device_local_a_output, &mtype));
-      if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_output, NULL, &device_nonlocal_a_output, &mtype));
+      PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, NULL, NULL, &mtype));
+      if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_output, NULL, NULL, &mtype));
+
+      // Read-write Kokkos views to the values - we only update the W block, the identity block is preserved
+      Kokkos::View<PetscScalar *> device_local_a_output;
+      Kokkos::View<PetscScalar *> device_nonlocal_a_output;
+      PetscCallVoid(MatSeqAIJGetKokkosView(mat_local_output, &device_local_a_output));
+      if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal_output, &device_nonlocal_a_output));
 
       // Only have to write W as the identity block cannot change
       // Loop over the rows of W - annoying we have const views as this is just the same loop as above
@@ -614,7 +624,7 @@ PETSC_INTERN void compute_P_from_W_kokkos(Mat *input_mat, PetscInt global_row_st
             Kokkos::parallel_for(
                Kokkos::TeamThreadRange(t, ncols_local), [&](const PetscInt j) {
 
-               device_local_a_output[device_local_i_output[row_index] + j] = device_local_vals[device_local_i[i] + j];
+               device_local_a_output(device_local_i_output[row_index] + j) = device_local_vals(device_local_i[i] + j);
 
             });
 
@@ -628,7 +638,7 @@ PETSC_INTERN void compute_P_from_W_kokkos(Mat *input_mat, PetscInt global_row_st
 
                   // We keep the existing local indices in the off-diagonal blocl here
                   // we have all the same columns as W and hence the same garray
-                  device_nonlocal_a_output[device_nonlocal_i_output[row_index] + j] = device_nonlocal_vals[device_nonlocal_i[i] + j];
+                  device_nonlocal_a_output(device_nonlocal_i_output[row_index] + j) = device_nonlocal_vals(device_nonlocal_i[i] + j);
 
                });
             }
@@ -636,21 +646,10 @@ PETSC_INTERN void compute_P_from_W_kokkos(Mat *input_mat, PetscInt global_row_st
 
       Kokkos::fence();
 
-      // Have to specify we've modifed data on the device
-      // Want to call MatSeqAIJKokkosModifyDevice but its PETSC_INTERN
-      aijkok_local_output->a_dual.clear_sync_state();
-      aijkok_local_output->a_dual.modify_device();
-      aijkok_local_output->transpose_updated = PETSC_FALSE;
-      aijkok_local_output->hermitian_updated = PETSC_FALSE;
-      // Invalidate diagonals
-      if (mpi)
-      {
-         aijkok_nonlocal_output->a_dual.clear_sync_state();
-         aijkok_nonlocal_output->a_dual.modify_device();
-         aijkok_nonlocal_output->transpose_updated = PETSC_FALSE;
-         aijkok_nonlocal_output->hermitian_updated = PETSC_FALSE;
-      }      
-      PetscCallVoid(PetscObjectStateIncrease((PetscObject)(*output_mat)));
+      // The matching restore handles MatSeqAIJKokkosModifyDevice (clears sync state,
+      // marks device modified, invalidates transpose/hermitian, bumps object state).
+      PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local_output, &device_local_a_output));
+      if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal_output, &device_nonlocal_a_output));
 
    }
 
@@ -708,6 +707,9 @@ PETSC_INTERN void compute_P_from_W_kokkos(Mat *input_mat, PetscInt global_row_st
 
    PetscCallVoid(ISRestoreIndices(*is_fine, &fine_indices_ptr));
    PetscCallVoid(ISRestoreIndices(*is_coarse, &coarse_indices_ptr));
+
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    return;
 }
@@ -850,16 +852,19 @@ PETSC_INTERN void compute_R_from_Z_kokkos(Mat *input_mat, PetscInt global_row_st
    PetscCallVoid(PetscLogCpuToGpu(bytes));        
    Kokkos::deep_copy(exec, orig_view_d, orig_view_h); 
    bytes = orig_view_h.extent(0) * sizeof(PetscInt);
-   PetscCallVoid(PetscLogCpuToGpu(bytes));       
+   PetscCallVoid(PetscLogCpuToGpu(bytes));
 
    // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
+   // Get pointers to the i,j on the device and Kokkos views to the values
    // ~~~~~~~~~~~~
    const PetscInt *device_local_i = nullptr, *device_local_j = nullptr, *device_nonlocal_i = nullptr, *device_nonlocal_j = nullptr;
    PetscMemType mtype;
-   PetscScalar *device_local_vals = nullptr, *device_nonlocal_vals = nullptr;  
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, &device_local_vals, &mtype));  
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, &device_nonlocal_vals, &mtype));          
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals;
+   Kokkos::View<const PetscScalar *> device_nonlocal_vals;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    PetscIntKokkosView nnz_match_local_row_d;
    PetscIntKokkosView nnz_match_nonlocal_row_d;
@@ -1006,7 +1011,7 @@ PETSC_INTERN void compute_R_from_Z_kokkos(Mat *input_mat, PetscInt global_row_st
                // Want the local col indices for the local block
                // The orig_view_d contains the global indices for the original full matrix
                j_local_d(i_local_d(row_index) + j) = orig_view_d(device_local_j[device_local_i[i] + j]) - global_row_start;
-               a_local_d(i_local_d(row_index) + j) = device_local_vals[device_local_i[i] + j];
+               a_local_d(i_local_d(row_index) + j) = device_local_vals(device_local_i[i] + j);
                      
             });     
 
@@ -1022,7 +1027,7 @@ PETSC_INTERN void compute_R_from_Z_kokkos(Mat *input_mat, PetscInt global_row_st
                   // we have all the same non-local local column indices as Z (as the identity added is always local)
                   // The garray is the same size, its just the global indices that have changed
                   j_nonlocal_d(i_nonlocal_d(row_index) + j) = device_nonlocal_j[device_nonlocal_i[i] + j];
-                  a_nonlocal_d(i_nonlocal_d(row_index) + j) = device_nonlocal_vals[device_nonlocal_i[i] + j];
+                  a_nonlocal_d(i_nonlocal_d(row_index) + j) = device_nonlocal_vals(device_nonlocal_i[i] + j);
                         
                });          
             }
@@ -1051,16 +1056,17 @@ PETSC_INTERN void compute_R_from_Z_kokkos(Mat *input_mat, PetscInt global_row_st
       {
          mat_local_output = *output_mat;
       }     
-      Mat_SeqAIJKokkos *aijkok_local_output = static_cast<Mat_SeqAIJKokkos *>(mat_local_output->spptr);
-      Mat_SeqAIJKokkos *aijkok_nonlocal_output = NULL;
-      if (mpi) aijkok_nonlocal_output = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_output->spptr);
-
-      // Get device pointers for the existing i, j, and a arrays
+      // Get device pointers for the existing i and j arrays
       const PetscInt *device_local_i_output = nullptr, *device_local_j_output = nullptr, *device_nonlocal_i_output = nullptr;
-      PetscScalar *device_local_a_output = nullptr, *device_nonlocal_a_output = nullptr;
       PetscMemType mtype;
-      PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, &device_local_j_output, &device_local_a_output, &mtype));
-      if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_output, NULL, &device_nonlocal_a_output, &mtype));
+      PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, &device_local_j_output, NULL, &mtype));
+      if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_output, NULL, NULL, &mtype));
+
+      // Read-write Kokkos views to the values - we update the Z block, the identity entries are preserved
+      Kokkos::View<PetscScalar *> device_local_a_output;
+      Kokkos::View<PetscScalar *> device_nonlocal_a_output;
+      PetscCallVoid(MatSeqAIJGetKokkosView(mat_local_output, &device_local_a_output));
+      if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal_output, &device_nonlocal_a_output));
 
       // Only have to write Z but have to be careful as we have the identity mixed
       // in there
@@ -1087,7 +1093,7 @@ PETSC_INTERN void compute_R_from_Z_kokkos(Mat *input_mat, PetscInt global_row_st
                // If we're at or after the C point identity, our index into R gets a +1
                // so we skip over writing to that index in R
                if (device_local_j_output[device_local_i_output[row_index] + j] >= coarse_view_d(i) - global_row_start) offset = 1;
-               device_local_a_output[device_local_i_output[row_index] + j + offset] = device_local_vals[device_local_i[i] + j];
+               device_local_a_output(device_local_i_output[row_index] + j + offset) = device_local_vals(device_local_i[i] + j);
             });
 
             // For over nonlocal columns - copy in Z - identical structure in the off-diag block
@@ -1100,7 +1106,7 @@ PETSC_INTERN void compute_R_from_Z_kokkos(Mat *input_mat, PetscInt global_row_st
 
                   // We keep the existing local indices in the off-diagonal block here
                   // we have all the same columns as Z and hence the same garray
-                  device_nonlocal_a_output[device_nonlocal_i_output[row_index] + j] = device_nonlocal_vals[device_nonlocal_i[i] + j];
+                  device_nonlocal_a_output(device_nonlocal_i_output[row_index] + j) = device_nonlocal_vals(device_nonlocal_i[i] + j);
 
                });
             }
@@ -1108,21 +1114,10 @@ PETSC_INTERN void compute_R_from_Z_kokkos(Mat *input_mat, PetscInt global_row_st
 
       Kokkos::fence();
 
-      // Have to specify we've modifed data on the device
-      // Want to call MatSeqAIJKokkosModifyDevice but its PETSC_INTERN
-      aijkok_local_output->a_dual.clear_sync_state();
-      aijkok_local_output->a_dual.modify_device();
-      aijkok_local_output->transpose_updated = PETSC_FALSE;
-      aijkok_local_output->hermitian_updated = PETSC_FALSE;
-      // Invalidate diagonals
-      if (mpi)
-      {
-         aijkok_nonlocal_output->a_dual.clear_sync_state();
-         aijkok_nonlocal_output->a_dual.modify_device();
-         aijkok_nonlocal_output->transpose_updated = PETSC_FALSE;
-         aijkok_nonlocal_output->hermitian_updated = PETSC_FALSE;
-      }        
-      PetscCallVoid(PetscObjectStateIncrease((PetscObject)(*output_mat)));
+      // The matching restore handles MatSeqAIJKokkosModifyDevice (clears sync state,
+      // marks device modified, invalidates transpose/hermitian, bumps object state).
+      PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local_output, &device_local_a_output));
+      if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal_output, &device_nonlocal_a_output));
 
     }
 
@@ -1173,6 +1168,9 @@ PETSC_INTERN void compute_R_from_Z_kokkos(Mat *input_mat, PetscInt global_row_st
    PetscCallVoid(ISRestoreIndices(*is_fine, &fine_indices_ptr));
    PetscCallVoid(ISRestoreIndices(*is_coarse, &coarse_indices_ptr));
    PetscCallVoid(ISRestoreIndices(*orig_fine_col_indices, &is_pointer_orig_fine_col));
+
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    return;
 }

--- a/src/MatDiagDom.F90
+++ b/src/MatDiagDom.F90
@@ -2,7 +2,7 @@ module matdiagdom
 
    use iso_c_binding
    use petscmat
-   use petsc_helper, only: kokkos_debug
+   use petsc_helper, only: kokkos_debug, build_aij_nonlocal_sf_and_leaf
       use c_petsc_interfaces, only: copy_diag_dom_ratio_d2h, MatDiagDomRatio_kokkos, &
          vecscatter_mat_begin_c, vecscatter_mat_end_c, vecscatter_mat_restore_c, MatSeqAIJGetArrayF90_mine
    use pflare_parameters, only: C_POINT, F_POINT
@@ -35,6 +35,10 @@ module matdiagdom
 
       PetscErrorCode :: ierr
       MPIU_Comm :: MPI_COMM_MATRIX
+      integer :: comm_size, errcode
+      integer(c_long_long) :: sf_array, leaf_vec_array
+      type(tPetscSF) :: sf
+      type(tVec) :: leaf_vec
 
 #if defined(PETSC_HAVE_KOKKOS)
       integer :: errorcode, ifree
@@ -48,6 +52,17 @@ module matdiagdom
 #endif
 
       call PetscObjectGetComm(input_mat, MPI_COMM_MATRIX, ierr)
+      call MPI_Comm_size(MPI_COMM_MATRIX, comm_size, errcode)
+
+      ! Build the PetscSF + leaf Vec once (replacing Mat_MPIAIJ::Mvctx/lvec)
+      ! and share across both the Kokkos and CPU implementations below.
+      sf_array = 0
+      leaf_vec_array = 0
+      if (comm_size /= 1) then
+         call build_aij_nonlocal_sf_and_leaf(input_mat, sf, leaf_vec)
+         sf_array = sf%v
+         leaf_vec_array = leaf_vec%v
+      end if
 
 #if defined(PETSC_HAVE_KOKKOS)
       call MatGetType(input_mat, mat_type, ierr)
@@ -57,7 +72,8 @@ module matdiagdom
          A_array = input_mat%v
          local_rows_aff_kokkos = 0
          max_dd_ratio_achieved = 0d0
-         call MatDiagDomRatio_kokkos(A_array, max_dd_ratio_achieved, local_rows_aff_kokkos)
+
+         call MatDiagDomRatio_kokkos(A_array, sf_array, leaf_vec_array, max_dd_ratio_achieved, local_rows_aff_kokkos)
 
          if (kokkos_debug()) then
             allocate(diag_dom_ratio(local_rows_aff_kokkos))
@@ -66,7 +82,8 @@ module matdiagdom
                call copy_diag_dom_ratio_d2h(diag_dom_ratio_ptr)
             end if
 
-            call MatDiagDomRatio_cpu(input_mat, is_fine, cf_markers_local, diag_dom_ratio_cpu, max_dd_ratio_cpu)
+            call MatDiagDomRatio_cpu(input_mat, sf_array, leaf_vec_array, is_fine, cf_markers_local, &
+                                     diag_dom_ratio_cpu, max_dd_ratio_cpu)
 
             tol = dd_ratio_abs_tol + dd_ratio_rel_tol * max(abs(max_dd_ratio_cpu), abs(max_dd_ratio_achieved))
             if (abs(max_dd_ratio_cpu - max_dd_ratio_achieved) > tol) then
@@ -86,26 +103,39 @@ module matdiagdom
             deallocate(diag_dom_ratio_cpu)
          end if
       else
-         call MatDiagDomRatio_cpu(input_mat, is_fine, cf_markers_local, diag_dom_ratio, max_dd_ratio_achieved)
+         call MatDiagDomRatio_cpu(input_mat, sf_array, leaf_vec_array, is_fine, cf_markers_local, &
+                                  diag_dom_ratio, max_dd_ratio_achieved)
       end if
 #else
-      call MatDiagDomRatio_cpu(input_mat, is_fine, cf_markers_local, diag_dom_ratio, max_dd_ratio_achieved)
+      call MatDiagDomRatio_cpu(input_mat, sf_array, leaf_vec_array, is_fine, cf_markers_local, &
+                               diag_dom_ratio, max_dd_ratio_achieved)
 #endif
+
+      if (comm_size /= 1) then
+         call PetscSFDestroy(sf, ierr)
+         call VecDestroy(leaf_vec, ierr)
+      end if
 
    end subroutine MatDiagDomRatio
 
 ! -------------------------------------------------------------------------------------------------------------------------------
 
-   subroutine MatDiagDomRatio_cpu(input_mat, is_fine, cf_markers_local, diag_dom_ratio, max_dd_ratio_achieved)
+   subroutine MatDiagDomRatio_cpu(input_mat, sf_array, leaf_vec_array, is_fine, cf_markers_local, &
+                                  diag_dom_ratio, max_dd_ratio_achieved)
 
       ! Compute diagonal dominance ratio over local fine rows of input_mat
       ! without extracting Aff. This mirrors the Kokkos MatDiagDomRatio path:
       ! sum abs(F-neighbour off-diagonals) / abs(F-diagonal), with nonlocal
       ! F markers obtained from the matrix halo scatter.
+      !
+      ! sf_array / leaf_vec_array are the PetscSF + leaf Vec built once by the
+      ! caller (MatDiagDomRatio dispatcher) and shared with the kokkos path.
+      ! Both are zero in serial.
 
       ! ~~~~~~
 
       type(tMat), target, intent(in)      :: input_mat
+      integer(c_long_long), intent(in)    :: sf_array, leaf_vec_array
       type(tIS), intent(in)               :: is_fine
       integer, dimension(:), intent(in)   :: cf_markers_local
       PetscReal, dimension(:), allocatable, intent(out) :: diag_dom_ratio
@@ -120,7 +150,7 @@ module matdiagdom
       PetscErrorCode :: ierr
       integer :: errorcode, comm_size
       MPIU_Comm :: MPI_COMM_MATRIX
-      integer(c_long_long) :: A_array, vec_long, Ad_array, Ao_array
+      integer(c_long_long) :: vec_long, Ad_array, Ao_array
       type(tMat) :: Ad, Ao
       type(tVec) :: cf_markers_vec
       PetscInt, dimension(:), pointer :: is_pointer => null(), colmap => null()
@@ -189,10 +219,11 @@ module matdiagdom
 
          call VecCreateMPIWithArray(MPI_COMM_MATRIX, one, local_rows, global_rows, &
                cf_markers_local_real, cf_markers_vec, ierr)
-         A_array = input_mat%v
          vec_long = cf_markers_vec%v
-         call vecscatter_mat_begin_c(A_array, vec_long, cf_markers_nonlocal_ptr)
-         call vecscatter_mat_end_c(A_array, vec_long, cf_markers_nonlocal_ptr)
+
+         ! Use the caller-supplied SF + leaf Vec for the single halo scatter.
+         call vecscatter_mat_begin_c(sf_array, vec_long, leaf_vec_array)
+         call vecscatter_mat_end_c(sf_array, vec_long, leaf_vec_array, cf_markers_nonlocal_ptr)
          call c_f_pointer(cf_markers_nonlocal_ptr, cf_markers_nonlocal, shape=[cols_ao])
       end if
 
@@ -235,7 +266,7 @@ module matdiagdom
 
       ! Cleanup for halo scatter resources.
       if (mpi) then
-         call vecscatter_mat_restore_c(A_array, cf_markers_nonlocal_ptr)
+         call vecscatter_mat_restore_c(leaf_vec_array, cf_markers_nonlocal_ptr)
          call VecDestroy(cf_markers_vec, ierr)
          deallocate(cf_markers_local_real)
       end if

--- a/src/MatDiagDomk.kokkos.cxx
+++ b/src/MatDiagDomk.kokkos.cxx
@@ -2,7 +2,6 @@
 #include "kokkos_helper.hpp"
 #include <iostream>
 #include <../src/mat/impls/aij/seq/aij.h>
-#include <../src/mat/impls/aij/mpi/mpiaij.h>
 
 // The definition of the device copy of the cf markers on a given level 
 // is stored in Device_Datak.kokkos.cxx and imported as extern from 
@@ -12,7 +11,7 @@
 
 // Computes the diagonal dominance ratio of the input matrix over fine points in global variable cf_markers_local_d
 // This code is very similar to MatCreateSubMatrix_kokkos
-PETSC_INTERN void MatDiagDomRatio_kokkos(Mat *input_mat, PetscReal *max_dd_ratio_achieved, PetscInt *local_rows_aff)
+PETSC_INTERN void MatDiagDomRatio_kokkos(Mat *input_mat, PetscSF *sf, Vec *leaf_vec, PetscReal *max_dd_ratio_achieved, PetscInt *local_rows_aff)
 {
    PetscInt local_rows, local_cols;
 
@@ -25,20 +24,18 @@ PETSC_INTERN void MatDiagDomRatio_kokkos(Mat *input_mat, PetscReal *max_dd_ratio
    PetscCallVoid(PetscObjectGetComm((PetscObject)*input_mat, &MPI_COMM_MATRIX));
    PetscCallVoid(MatGetLocalSize(*input_mat, &local_rows, &local_cols)); 
 
-   Mat_MPIAIJ *mat_mpi = nullptr;
-   Mat mat_local = NULL, mat_nonlocal = NULL;   
+   Mat mat_local = NULL, mat_nonlocal = NULL;
 
    PetscInt rows_ao, cols_ao;
    if (mpi)
    {
-      mat_mpi = (Mat_MPIAIJ *)(*input_mat)->data;
-      PetscCallVoid(MatMPIAIJGetSeqAIJ(*input_mat, &mat_local, &mat_nonlocal, NULL));      
+      PetscCallVoid(MatMPIAIJGetSeqAIJ(*input_mat, &mat_local, &mat_nonlocal, NULL));
       PetscCallVoid(MatGetSize(mat_nonlocal, &rows_ao, &cols_ao));
    }
    else
    {
       mat_local = *input_mat;
-   }   
+   }
 
    // Can't use the global directly within the parallel 
    // regions on the device
@@ -83,10 +80,10 @@ PETSC_INTERN void MatDiagDomRatio_kokkos(Mat *input_mat, PetscReal *max_dd_ratio
       }
 
       // Start comms, then overlap with local-only work below.
-      // Mvctx must have only one active comm at a time.
+      // The SF must have only one active comm at a time.
       // Ensure send/receive buffers are stable before Begin.
-      Kokkos::fence();      
-      PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, scatter_root_vec, mat_mpi->lvec, INSERT_VALUES, SCATTER_FORWARD));
+      Kokkos::fence();
+      PetscCallVoid(VecScatterBegin(*sf, scatter_root_vec, *leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
    }
 
    // ~~~~~~~~~~~~~~~
@@ -158,15 +155,15 @@ PETSC_INTERN void MatDiagDomRatio_kokkos(Mat *input_mat, PetscReal *max_dd_ratio
    // Finish the in-flight scatter and only then read from the receive buffer.
    if (mpi)
    {
-      PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, scatter_root_vec, mat_mpi->lvec, INSERT_VALUES, SCATTER_FORWARD));
+      PetscCallVoid(VecScatterEnd(*sf, scatter_root_vec, *leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
       {
          ConstPetscScalarKokkosView lvec_scalar_d;
-         PetscCallVoid(VecGetKokkosView(mat_mpi->lvec, &lvec_scalar_d));
+         PetscCallVoid(VecGetKokkosView(*leaf_vec, &lvec_scalar_d));
          Kokkos::parallel_for(
             Kokkos::RangePolicy<>(exec, 0, cols_ao), KOKKOS_LAMBDA(PetscInt i) {
                cf_markers_nonlocal_d(i) = (int)lvec_scalar_d(i);
          });
-         PetscCallVoid(VecRestoreKokkosView(mat_mpi->lvec, &lvec_scalar_d));
+         PetscCallVoid(VecRestoreKokkosView(*leaf_vec, &lvec_scalar_d));
       }
       PetscCallVoid(VecDestroy(&scatter_root_vec));
       Kokkos::fence();

--- a/src/MatDiagDomk.kokkos.cxx
+++ b/src/MatDiagDomk.kokkos.cxx
@@ -1,7 +1,6 @@
 // Our petsc kokkos definitions - has to go first
 #include "kokkos_helper.hpp"
 #include <iostream>
-#include <../src/mat/impls/aij/seq/aij.h>
 
 // The definition of the device copy of the cf markers on a given level 
 // is stored in Device_Datak.kokkos.cxx and imported as extern from 

--- a/src/PCAIR.c
+++ b/src/PCAIR.c
@@ -198,6 +198,10 @@ PETSC_EXTERN void compute_cf_splitting(Mat input_mat, int symmetric_int,
    int ddc_its, double fraction_swap,
    IS *is_fine, IS *is_coarse)
 {
+   // Now we call petsc fortran routines in compute_cf_splitting_c from this C file
+   // so we have to have made sure this is called
+   // Otherwise things like PETSC_NULL_INTEGER_ARRAY aren't defined
+   PetscCallVoid(PetscInitializeFortran());
    compute_cf_splitting_c(&input_mat, symmetric_int, strong_threshold,
       max_luby_steps, cf_splitting_type, ddc_its, fraction_swap,
       is_fine, is_coarse);
@@ -205,6 +209,10 @@ PETSC_EXTERN void compute_cf_splitting(Mat input_mat, int symmetric_int,
 
 PETSC_EXTERN void compute_diag_dom_submatrix(Mat input_mat, double max_dd_ratio, Mat *output_mat)
 {
+   // Now we call petsc fortran routines in compute_cf_splitting_c from this C file
+   // so we have to have made sure this is called
+   // Otherwise things like PETSC_NULL_INTEGER_ARRAY aren't defined
+   PetscCallVoid(PetscInitializeFortran());
    compute_diag_dom_submatrix_c(&input_mat, max_dd_ratio, output_mat);
 }
 

--- a/src/PETSc_Helper.F90
+++ b/src/PETSc_Helper.F90
@@ -1,5 +1,6 @@
 module petsc_helper
 
+   use iso_c_binding
    use petscmat
    use c_petsc_interfaces, only: remove_small_from_sparse_kokkos, &
          remove_from_sparse_match_kokkos, &
@@ -24,7 +25,57 @@ logical, protected :: kokkos_debug_global = .FALSE.
    ! -------------------------------------------------------------------------------------------------------------------------------
    ! -------------------------------------------------------------------------------------------------------------------------------      
 
-   contains 
+   contains
+
+   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+   subroutine build_aij_nonlocal_sf_and_leaf(matrix, sf, leaf_vec)
+
+      ! Build a PetscSF + matching leaf Vec that scatter from a global vec
+      ! with the matrix's domain layout into a local "leaf" buffer indexed
+      ! the same way a Mat_MPIAIJ's lvec is. Caller owns and must destroy
+      ! both objects with PetscSFDestroy / VecDestroy.
+
+      ! Input
+      type(tMat), intent(in)        :: matrix
+
+      ! Output
+      type(tPetscSF), intent(out)   :: sf
+      type(tVec),     intent(out)   :: leaf_vec
+
+      ! Local
+      type(tMat) :: Ad, Ao
+      type(tPetscLayout) :: col_layout
+      PetscInt, dimension(:), pointer :: colmap => null()
+      PetscInt :: rows_ao, cols_ao
+      MPIU_Comm :: comm
+      PetscErrorCode :: ierr
+
+      ! ~~~~~~
+
+      ! Off-diagonal block + colmap give us the leaf-side numbering
+      call MatMPIAIJGetSeqAIJ(matrix, Ad, Ao, colmap, ierr)
+      call MatGetSize(Ao, rows_ao, cols_ao, ierr)
+
+      ! Leaf Vec sized/typed to match the off-diagonal block (this gives
+      ! VECSEQKOKKOS automatically for Kokkos matrices).
+      call MatCreateVecs(Ao, leaf_vec, PETSC_NULL_VEC, ierr)
+
+      ! Star forest mirroring the matvec halo: roots = global vec, leaves
+      ! = colmap entries. We use the column layout because for non-square
+      ! mats (e.g. row_mat in constrain_grid_transfer) the source vec has
+      ! the column/domain layout, not the row layout.
+      call PetscObjectGetComm(matrix, comm, ierr)
+      call PetscSFCreate(comm, sf, ierr)
+      call MatGetLayouts(matrix, PETSC_NULL_LAYOUT, col_layout, ierr)
+      ! PETSC_NULL_INTEGER_ARRAY for ilocal selects natural ordering.
+      ! Note: PETSc's Fortran wrapper recognises this sentinel only after
+      ! PetscInitializeFortran() has run; PFLARE C entry points that hand
+      ! off to Fortran (PCAIRInit, compute_cf_splitting, ...) all call it.
+      call PetscSFSetGraphLayout(sf, col_layout, cols_ao, &
+                                 PETSC_NULL_INTEGER_ARRAY, PETSC_COPY_VALUES, colmap, ierr)
+
+   end subroutine build_aij_nonlocal_sf_and_leaf
 
    !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1084,26 +1135,29 @@ logical, protected :: kokkos_debug_global = .FALSE.
       type(tMat), intent(inout)     :: output_mat
 
       PetscErrorCode :: ierr
-#if defined(PETSC_HAVE_KOKKOS)                     
+#if defined(PETSC_HAVE_KOKKOS)
       MPIU_Comm :: MPI_COMM_MATRIX
       integer :: comm_size, errorcode
       integer(c_long_long) :: A_array, B_array, is_row_ptr, is_col_ptr
+      integer(c_long_long) :: sf_array, leaf_vec_array
       integer :: reuse_int, our_level_int, is_row_fine_int, is_col_fine_int
       logical :: reuse_logical
       MatType :: mat_type
       Mat :: temp_mat
       PetscScalar :: normy
       type(tVec) :: max_vec
-      PetscInt :: row_loc      
-#endif      
+      type(tVec) :: leaf_vec
+      type(tPetscSF) :: sf
+      PetscInt :: row_loc
+#endif
       ! ~~~~~~~~~~
 
-#if defined(PETSC_HAVE_KOKKOS)    
+#if defined(PETSC_HAVE_KOKKOS)
 
       call MatGetType(input_mat, mat_type, ierr)
-      call PetscObjectGetComm(input_mat, MPI_COMM_MATRIX, ierr)  
-      ! Get the comm size 
-      call MPI_Comm_size(MPI_COMM_MATRIX, comm_size, errorcode)       
+      call PetscObjectGetComm(input_mat, MPI_COMM_MATRIX, ierr)
+      ! Get the comm size
+      call MPI_Comm_size(MPI_COMM_MATRIX, comm_size, errorcode)
 
       ! If doing parallel Kokkos
       if (mat_type == MATMPIAIJKOKKOS .OR. mat_type == MATSEQAIJKOKKOS .OR. &
@@ -1114,10 +1168,21 @@ logical, protected :: kokkos_debug_global = .FALSE.
          reuse_int = 0
          if (reuse_logical) reuse_int = 1
 
-         A_array = input_mat%v   
-         B_array = output_mat%v      
+         A_array = input_mat%v
+         B_array = output_mat%v
          is_row_ptr = is_row%v
          is_col_ptr = is_col%v
+
+         ! Build the SF + leaf Vec replacing Mat_MPIAIJ::Mvctx/lvec for the
+         ! single MatCreateSubMatrix_kokkos call below. In serial we still
+         ! pass these in; the kokkos routine ignores them on the serial path.
+         sf_array = 0
+         leaf_vec_array = 0
+         if (comm_size /= 1) then
+            call build_aij_nonlocal_sf_and_leaf(input_mat, sf, leaf_vec)
+            sf_array = sf%v
+            leaf_vec_array = leaf_vec%v
+         end if
 
          our_level_int = -1
          is_row_fine_int = 0
@@ -1133,9 +1198,14 @@ logical, protected :: kokkos_debug_global = .FALSE.
             if (is_col_fine) is_col_fine_int = 1
          end if
 
-         call MatCreateSubMatrix_kokkos(A_array, is_row_ptr, is_col_ptr, &
+         call MatCreateSubMatrix_kokkos(A_array, sf_array, leaf_vec_array, is_row_ptr, is_col_ptr, &
                   reuse_int, B_array, &
                   our_level_int, is_row_fine_int, is_col_fine_int)
+
+         if (comm_size /= 1) then
+            call PetscSFDestroy(sf, ierr)
+            call VecDestroy(leaf_vec, ierr)
+         end if
 
          output_mat%v = B_array
 

--- a/src/PETSc_Helperk.kokkos.cxx
+++ b/src/PETSc_Helperk.kokkos.cxx
@@ -1655,34 +1655,6 @@ PETSC_INTERN void MatAXPY_kokkos(Mat *Y, PetscScalar alpha, Mat *X)
    PetscCallVoid(MatMPIAIJGetSeqAIJ(*Y, &mat_local_y, &mat_nonlocal_y, &colmap_y));
    PetscCallVoid(MatMPIAIJGetSeqAIJ(*X, &mat_local_x, &mat_nonlocal_x, &colmap_x));
 
-   Mat_SeqAIJKokkos *mat_local_ykok = static_cast<Mat_SeqAIJKokkos *>(mat_local_y->spptr);
-   Mat_SeqAIJKokkos *mat_nonlocal_ykok = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_y->spptr);
-   Mat_SeqAIJKokkos *mat_local_xkok = static_cast<Mat_SeqAIJKokkos *>(mat_local_x->spptr);
-   Mat_SeqAIJKokkos *mat_nonlocal_xkok = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_x->spptr);
-
-   // Equivalent to calling MatSeqAIJKokkosSyncDevice which is petsc intern
-   // We have to make sure the device data is up to date before we do the axpy
-   if (mat_local_ykok->a_dual.need_sync_device()) {
-      mat_local_ykok->a_dual.sync_device();
-      mat_local_ykok->transpose_updated = PETSC_FALSE; /* values of the transpose is out-of-date */
-      mat_local_ykok->hermitian_updated = PETSC_FALSE;
-    }  
-    if (mat_nonlocal_ykok->a_dual.need_sync_device()) {
-      mat_nonlocal_ykok->a_dual.sync_device();
-      mat_nonlocal_ykok->transpose_updated = PETSC_FALSE; /* values of the transpose is out-of-date */
-      mat_nonlocal_ykok->hermitian_updated = PETSC_FALSE;
-    } 
-    if (mat_local_xkok->a_dual.need_sync_device()) {
-      mat_local_xkok->a_dual.sync_device();
-      mat_local_xkok->transpose_updated = PETSC_FALSE; /* values of the transpose is out-of-date */
-      mat_local_xkok->hermitian_updated = PETSC_FALSE;
-    }           
-    if (mat_nonlocal_xkok->a_dual.need_sync_device()) {
-      mat_nonlocal_xkok->a_dual.sync_device();
-      mat_nonlocal_xkok->transpose_updated = PETSC_FALSE; /* values of the transpose is out-of-date */
-      mat_nonlocal_xkok->hermitian_updated = PETSC_FALSE;
-    }  
-
    PetscInt rows_ao_y, cols_ao_y, rows_ao_x, cols_ao_x;
    auto exec = PetscGetKokkosExecutionSpace();
 
@@ -1712,148 +1684,130 @@ PETSC_INTERN void MatAXPY_kokkos(Mat *Y, PetscScalar alpha, Mat *X)
    PetscCallVoid(MatGetSize(*Y, &global_rows, &global_cols));
 
    // ~~~~~~~~~~~~~~~
-   // Let's go and add the local components together
+   // Local block: hand off to PETSc's MatAXPY on a duplicate of mat_local_y
+   // (the duplicate becomes the diagonal block of the new MPI matrix)
+   // ~~~~~~~~~~~~~~~
+   Mat Z_local;
+   PetscCallVoid(MatDuplicate(mat_local_y, MAT_COPY_VALUES, &Z_local));
+   PetscCallVoid(MatAXPY(Z_local, alpha, mat_local_x, DIFFERENT_NONZERO_PATTERN));
+
+   // ~~~~~~~~~~~~~~~
+   // Nonlocal block: build the merged garray = union(garray_y, garray_x) and use it as
+   // the column space of temporary SeqAIJKokkos matrices, then call PETSc's MatAXPY.
+   // Because spadd produces a nonzero in column c iff X or Y had one there, the union
+   // garray is exactly the output garray - no second remap is needed afterward.
    // ~~~~~~~~~~~~~~~
 
-   Mat_SeqAIJKokkos *xkok_local, *ykok_local;
-   ykok_local = static_cast<Mat_SeqAIJKokkos *>(mat_local_y->spptr);
-   xkok_local = static_cast<Mat_SeqAIJKokkos *>(mat_local_x->spptr);   
+   // Concatenate the two garrays on the device, then run them through rewrite_j_global_to_local.
+   // After it returns:
+   //   concat[0 .. cols_ao_y)               = merged-local indices for each garray_y entry
+   //   concat[cols_ao_y .. cols_ao_y+cols_ao_x) = merged-local indices for each garray_x entry
+   //   garray_host[0 .. col_ao_output)      = sorted-unique global indices of garray_y, garray_x
+   PetscInt cols_ao_concat = cols_ao_y + cols_ao_x;
+   PetscIntKokkosView concat = PetscIntKokkosView("concat", cols_ao_concat);
+   PetscInt zero = 0;
+   Kokkos::deep_copy(exec, Kokkos::subview(concat, Kokkos::make_pair(zero, cols_ao_y)), colmap_input_d_y);
+   Kokkos::deep_copy(exec, Kokkos::subview(concat, Kokkos::make_pair(cols_ao_y, cols_ao_concat)), colmap_input_d_x);
 
-   Kokkos::View<PetscScalar *> a_local_d_copy;
-   Kokkos::View<PetscInt *> i_local_d_copy, j_local_d_copy;
-   // Scope so the zcsr_local is destroyed once we copy 
+   PetscInt col_ao_output = 0;
+   PetscInt *garray_host = NULL;
+   rewrite_j_global_to_local(cols_ao_concat, col_ao_output, concat, &garray_host);
+
+   // Pull device CSR pointers for the original nonlocal blocks (we never mutate them).
+   const PetscInt *device_nonlocal_y_i = nullptr, *device_nonlocal_y_j = nullptr;
+   const PetscInt *device_nonlocal_x_i = nullptr, *device_nonlocal_x_j = nullptr;
+   PetscScalar *device_nonlocal_y_a = nullptr, *device_nonlocal_x_a = nullptr;
+   PetscMemType mtype;
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_y, &device_nonlocal_y_i, &device_nonlocal_y_j, &device_nonlocal_y_a, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_x, &device_nonlocal_x_i, &device_nonlocal_x_j, &device_nonlocal_x_a, &mtype));
+
+   // Read the nnz of each nonlocal block from its host i pointer
+   PetscInt nnz_y, nnz_x;
    {
-      KokkosCsrMatrix zcsr_local;
-      KernelHandle    kh_local;      
-      kh_local.create_spadd_handle(true); // X, Y are sorted
-
-      KokkosSparse::spadd_symbolic(&kh_local, xkok_local->csrmat, ykok_local->csrmat, zcsr_local);
-      KokkosSparse::spadd_numeric(&kh_local, alpha, xkok_local->csrmat, (PetscScalar)1.0, ykok_local->csrmat, zcsr_local);
-
-      kh_local.destroy_spadd_handle();
-      
-      // Get the Kokkos Views from zcsr_local - annoyingly we can't just call MatCreateSeqAIJKokkosWithCSRMatrix
-      // as it's petsc intern
-      auto a_local_d_z = zcsr_local.values;
-      auto i_local_d_z = zcsr_local.graph.row_map;
-      auto j_local_d_z = zcsr_local.graph.entries;   
-
-      a_local_d_copy = Kokkos::View<PetscScalar *>("a_local_d_copy", a_local_d_z.extent(0));
-      i_local_d_copy = Kokkos::View<PetscInt *>("i_local_d_copy", i_local_d_z.extent(0));
-      j_local_d_copy = Kokkos::View<PetscInt *>("j_local_d_copy", j_local_d_z.extent(0));   
-
-      Kokkos::deep_copy(exec, a_local_d_copy, a_local_d_z);
-      Kokkos::deep_copy(exec, i_local_d_copy, i_local_d_z);
-      Kokkos::deep_copy(exec, j_local_d_copy, j_local_d_z);
+      PetscInt n;
+      PetscBool symmetric = PETSC_FALSE, inodecompressed = PETSC_FALSE, done;
+      const PetscInt *ia;
+      PetscCallVoid(MatGetRowIJ(mat_nonlocal_y, 0, symmetric, inodecompressed, &n, &ia, NULL, &done));
+      nnz_y = ia[n];
+      PetscCallVoid(MatRestoreRowIJ(mat_nonlocal_y, 0, symmetric, inodecompressed, &n, &ia, NULL, &done));
+      PetscCallVoid(MatGetRowIJ(mat_nonlocal_x, 0, symmetric, inodecompressed, &n, &ia, NULL, &done));
+      nnz_x = ia[n];
+      PetscCallVoid(MatRestoreRowIJ(mat_nonlocal_x, 0, symmetric, inodecompressed, &n, &ia, NULL, &done));
    }
 
-   // We can create our local diagonal block matrix directly on the device
-   Mat Z_local;
-   PetscCallVoid(MatCreateSeqAIJKokkosWithKokkosViews(PETSC_COMM_SELF, local_rows, local_cols, i_local_d_copy, j_local_d_copy, a_local_d_copy, &Z_local));
-   
-   // ~~~~~~~~~~~~~~~
-   // Now let's go and add the non-local components together
-   // We first rewrite the j indices to be global as the nonlocal components of Y and X
-   // might have different non-local non-zeros (and different numbers of non-local non-zeros)
-   // ~~~~~~~~~~~~~~~
-
-   // We need to duplicate the nonlocal part of x first as we are going to overwrite the 
-   // column indices
-   // Don't need to copy y as we destroy it anyway
-   Mat mat_nonlocal_x_copy;
-   PetscCallVoid(MatDuplicate(mat_nonlocal_x, MAT_COPY_VALUES, &mat_nonlocal_x_copy));
-
-   Mat_SeqAIJKokkos *xkok_nonlocal, *ykok_nonlocal; 
-   ykok_nonlocal = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_y->spptr);
-   xkok_nonlocal = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_x_copy->spptr);          
-
-   PetscInt *device_nonlocal_x_j = xkok_nonlocal->j_device_data();
-   PetscInt *device_nonlocal_y_j = ykok_nonlocal->j_device_data();
-
-   // Get i pointers to drive the row loops
-   const PetscInt *device_nonlocal_y_i = nullptr, *device_nonlocal_x_i = nullptr;
-   PetscMemType mtype_axpy;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_y, &device_nonlocal_y_i, NULL, NULL, &mtype_axpy));
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_x_copy, &device_nonlocal_x_i, NULL, NULL, &mtype_axpy));
-
-   // Rewrite the Y nonlocal indices to be global
+   // Build owned (i, j, a) copies for each side. j is rewritten from original-local
+   // straight into merged-local via the concat lookup.
+   Kokkos::View<PetscInt *> i_y_temp("i_y_temp", local_rows + 1);
+   Kokkos::View<PetscInt *> j_y_temp("j_y_temp", nnz_y);
+   Kokkos::View<PetscScalar *> a_y_temp("a_y_temp", nnz_y);
+   Kokkos::View<const PetscInt *, DefaultMemorySpace, Kokkos::MemoryUnmanaged> i_y_orig(device_nonlocal_y_i, local_rows + 1);
+   Kokkos::View<const PetscScalar *, DefaultMemorySpace, Kokkos::MemoryUnmanaged> a_y_orig(device_nonlocal_y_a, nnz_y);
+   Kokkos::deep_copy(exec, i_y_temp, i_y_orig);
+   Kokkos::deep_copy(exec, a_y_temp, a_y_orig);
    Kokkos::parallel_for(
-      Kokkos::TeamPolicy<>(exec, local_rows, Kokkos::AUTO()),
-      KOKKOS_LAMBDA(const KokkosTeamMemberType& t) {
-         const PetscInt i = t.league_rank();
-         const PetscInt ncols = device_nonlocal_y_i[i + 1] - device_nonlocal_y_i[i];
-         Kokkos::parallel_for(Kokkos::TeamThreadRange(t, ncols), [&](const PetscInt j) {
-            const PetscInt idx = device_nonlocal_y_i[i] + j;
-            device_nonlocal_y_j[idx] = colmap_input_d_y(device_nonlocal_y_j[idx]);
-         });
-   });
+      Kokkos::RangePolicy<>(exec, 0, nnz_y), KOKKOS_LAMBDA(const PetscInt k) {
+         j_y_temp(k) = concat(device_nonlocal_y_j[k]);
+      });
 
-   // Rewrite the X nonlocal indices to be global
+   Kokkos::View<PetscInt *> i_x_temp("i_x_temp", local_rows + 1);
+   Kokkos::View<PetscInt *> j_x_temp("j_x_temp", nnz_x);
+   Kokkos::View<PetscScalar *> a_x_temp("a_x_temp", nnz_x);
+   Kokkos::View<const PetscInt *, DefaultMemorySpace, Kokkos::MemoryUnmanaged> i_x_orig(device_nonlocal_x_i, local_rows + 1);
+   Kokkos::View<const PetscScalar *, DefaultMemorySpace, Kokkos::MemoryUnmanaged> a_x_orig(device_nonlocal_x_a, nnz_x);
+   Kokkos::deep_copy(exec, i_x_temp, i_x_orig);
+   Kokkos::deep_copy(exec, a_x_temp, a_x_orig);
+   const PetscInt offset_x = cols_ao_y;
    Kokkos::parallel_for(
-      Kokkos::TeamPolicy<>(exec, local_rows, Kokkos::AUTO()),
-      KOKKOS_LAMBDA(const KokkosTeamMemberType& t) {
-         const PetscInt i = t.league_rank();
-         const PetscInt ncols = device_nonlocal_x_i[i + 1] - device_nonlocal_x_i[i];
-         Kokkos::parallel_for(Kokkos::TeamThreadRange(t, ncols), [&](const PetscInt j) {
-            const PetscInt idx = device_nonlocal_x_i[i] + j;
-            device_nonlocal_x_j[idx] = colmap_input_d_x(device_nonlocal_x_j[idx]);
-         });
-   });
-   // Ensure everything is finished before we hit the spadd below
+      Kokkos::RangePolicy<>(exec, 0, nnz_x), KOKKOS_LAMBDA(const PetscInt k) {
+         j_x_temp(k) = concat(offset_x + device_nonlocal_x_j[k]);
+      });
+
    Kokkos::fence();
 
-   // ~~~~~~~~~
+   // concat is no longer needed - both j-rewrite kernels have completed.
+   concat = PetscIntKokkosView();
 
-   Kokkos::View<PetscScalar *> a_nonlocal_d_copy;
-   Kokkos::View<PetscInt *> i_nonlocal_d_copy, j_nonlocal_d_copy;
-   PetscInt *garray_host = NULL;
-   PetscInt col_ao_output = 0;
+   // Wrap the rewritten CSR as temporary SeqAIJKokkos matrices with col_ao_output cols
+   // and let PETSc's MatAXPY run the spadd.
+   Mat temp_y, temp_x;
+   PetscCallVoid(MatCreateSeqAIJKokkosWithKokkosViews(PETSC_COMM_SELF, local_rows, col_ao_output, i_y_temp, j_y_temp, a_y_temp, &temp_y));
+   PetscCallVoid(MatCreateSeqAIJKokkosWithKokkosViews(PETSC_COMM_SELF, local_rows, col_ao_output, i_x_temp, j_x_temp, a_x_temp, &temp_x));
 
-   // Scope so the zcsr_nonlocal is destroyed once we copy 
+   PetscCallVoid(MatAXPY(temp_y, alpha, temp_x, DIFFERENT_NONZERO_PATTERN));
+
+   // temp_x is no longer needed; free it
+   PetscCallVoid(MatDestroy(&temp_x));
+
+   // Extract the result from temp_y so we can own it independently.
+   const PetscInt *device_z_i = nullptr, *device_z_j = nullptr;
+   PetscScalar *device_z_a = nullptr;
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(temp_y, &device_z_i, &device_z_j, &device_z_a, &mtype));
+
+   // Read the spadd-result nnz from its host i pointer
+   PetscInt nnz_z;
    {
-      // Now we can add the non-local components together
-      KokkosCsrMatrix zcsr_nonlocal;
-      // Global indices are sorted
-      KernelHandle    kh_nonlocal;      
-      kh_nonlocal.create_spadd_handle(true); 
-
-      KokkosSparse::spadd_symbolic(&kh_nonlocal, xkok_nonlocal->csrmat, ykok_nonlocal->csrmat, zcsr_nonlocal);
-      KokkosSparse::spadd_numeric(&kh_nonlocal, alpha, xkok_nonlocal->csrmat, (PetscScalar)1.0, ykok_nonlocal->csrmat, zcsr_nonlocal);
-
-      kh_nonlocal.destroy_spadd_handle();
-
-      // Can now destroy the copy
-      PetscCallVoid(MatDestroy(&mat_nonlocal_x_copy));
-
-      // Get the Kokkos Views from zcsr_nonlocal - annoyingly we can't just call MatCreateSeqAIJKokkosWithCSRMatrix
-      // as it's petsc intern
-      auto a_nonlocal_d_z = zcsr_nonlocal.values;
-      auto i_nonlocal_d_z = zcsr_nonlocal.graph.row_map;
-      auto j_nonlocal_d_z = zcsr_nonlocal.graph.entries;
-
-      // We know the most nonlocal indices we can have are the addition of x and y
-      // (some might be the same)
-      PetscInt cols_ao = cols_ao_x + cols_ao_y;
-
-      // ~~~~~~~~~
-
-      // Let's make sure everything on the device is finished
-      Kokkos::fence();   
-
-      // Now we need to build garray on the host and rewrite the j_nonlocal_d_z indices so they are local
-      // This fences internally
-      rewrite_j_global_to_local(cols_ao, col_ao_output, j_nonlocal_d_z, &garray_host);  
-
-      a_nonlocal_d_copy = Kokkos::View<PetscScalar *>("a_local_d_copy", a_nonlocal_d_z.extent(0));
-      i_nonlocal_d_copy = Kokkos::View<PetscInt *>("i_local_d_copy", i_nonlocal_d_z.extent(0));
-      j_nonlocal_d_copy = Kokkos::View<PetscInt *>("j_local_d_copy", j_nonlocal_d_z.extent(0));   
-
-      Kokkos::deep_copy(exec, a_nonlocal_d_copy, a_nonlocal_d_z);
-      Kokkos::deep_copy(exec, i_nonlocal_d_copy, i_nonlocal_d_z);
-      Kokkos::deep_copy(exec, j_nonlocal_d_copy, j_nonlocal_d_z);
+      PetscInt n;
+      PetscBool symmetric = PETSC_FALSE, inodecompressed = PETSC_FALSE, done;
+      const PetscInt *ia;
+      PetscCallVoid(MatGetRowIJ(temp_y, 0, symmetric, inodecompressed, &n, &ia, NULL, &done));
+      nnz_z = ia[n];
+      PetscCallVoid(MatRestoreRowIJ(temp_y, 0, symmetric, inodecompressed, &n, &ia, NULL, &done));
    }
 
-   // We can create our nonlocal diagonal block matrix directly on the device
+   Kokkos::View<PetscInt *> i_nonlocal_d_copy("i_nonlocal_d_copy", local_rows + 1);
+   Kokkos::View<PetscInt *> j_nonlocal_d_copy("j_nonlocal_d_copy", nnz_z);
+   Kokkos::View<PetscScalar *> a_nonlocal_d_copy("a_nonlocal_d_copy", nnz_z);
+   Kokkos::View<const PetscInt *, DefaultMemorySpace, Kokkos::MemoryUnmanaged> i_z_unm(device_z_i, local_rows + 1);
+   Kokkos::View<const PetscInt *, DefaultMemorySpace, Kokkos::MemoryUnmanaged> j_z_unm(device_z_j, nnz_z);
+   Kokkos::View<const PetscScalar *, DefaultMemorySpace, Kokkos::MemoryUnmanaged> a_z_unm(device_z_a, nnz_z);
+   Kokkos::deep_copy(exec, i_nonlocal_d_copy, i_z_unm);
+   Kokkos::deep_copy(exec, j_nonlocal_d_copy, j_z_unm);
+   Kokkos::deep_copy(exec, a_nonlocal_d_copy, a_z_unm);
+   Kokkos::fence();
+
+   // temp_y's data has been copied out; free it before allocating Z_nonlocal.
+   PetscCallVoid(MatDestroy(&temp_y));
+
    Mat Z_nonlocal;
    PetscCallVoid(MatCreateSeqAIJKokkosWithKokkosViews(PETSC_COMM_SELF, local_rows, col_ao_output, i_nonlocal_d_copy, j_nonlocal_d_copy, a_nonlocal_d_copy, &Z_nonlocal));
 

--- a/src/PETSc_Helperk.kokkos.cxx
+++ b/src/PETSc_Helperk.kokkos.cxx
@@ -4,7 +4,6 @@
 #include <iostream>
 #include <limits>
 #include <../src/mat/impls/aij/seq/aij.h>
-#include <../src/mat/impls/aij/mpi/mpiaij.h>
 
 //------------------------------------------------------------------------------------------------------------------------
 
@@ -2167,7 +2166,8 @@ PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosVi
 // as the matrices, ie equivalent to MatCreateSubMatrix_MPIAIJ_SameRowDist
 // is_col must be sorted
 // This one uses the views is_row_d_d and is_col_d_d directly, rewritten to be the local indices
-PETSC_INTERN void MatCreateSubMatrix_kokkos_view(Mat *input_mat, PetscIntKokkosView &is_row_d_d, PetscInt global_rows_row, \
+PETSC_INTERN void MatCreateSubMatrix_kokkos_view(Mat *input_mat, PetscSF *sf, Vec *leaf_vec, \
+         PetscIntKokkosView &is_row_d_d, PetscInt global_rows_row, \
          PetscIntKokkosView &is_col_d_d, PetscInt global_cols_col, const int reuse_int, Mat *output_mat)
 {
    PetscInt local_rows, local_cols;
@@ -2182,22 +2182,20 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos_view(Mat *input_mat, PetscIntKokkosV
    MPI_Comm MPI_COMM_MATRIX;
    PetscCallVoid(MatGetType(*input_mat, &mat_type));
 
-   const bool mpi = strcmp(mat_type, MATMPIAIJKOKKOS) == 0;   
+   const bool mpi = strcmp(mat_type, MATMPIAIJKOKKOS) == 0;
    PetscCallVoid(PetscObjectGetComm((PetscObject)*input_mat, &MPI_COMM_MATRIX));
    PetscCallVoid(MatGetSize(*input_mat, &global_rows, &global_cols));
    PetscCallVoid(MatGetLocalSize(*input_mat, &local_rows, &local_cols));
 
-   Mat_MPIAIJ *mat_mpi = nullptr;
-   Mat mat_local = NULL, mat_nonlocal = NULL;   
+   Mat mat_local = NULL, mat_nonlocal = NULL;
    Mat output_mat_local, output_mat_nonlocal;
-  
+
    PetscInt rows_ao, cols_ao;
    if (mpi)
    {
-      mat_mpi = (Mat_MPIAIJ *)(*input_mat)->data;
       PetscCallVoid(MatMPIAIJGetSeqAIJ(*input_mat, &mat_local, &mat_nonlocal, NULL));
-      PetscCallVoid(MatGetSize(mat_nonlocal, &rows_ao, &cols_ao)); 
-      
+      PetscCallVoid(MatGetSize(mat_nonlocal, &rows_ao, &cols_ao));
+
       if (reuse_int)
       {
          PetscCallVoid(MatMPIAIJGetSeqAIJ(*output_mat, &output_mat_local, &output_mat_nonlocal, NULL));
@@ -2255,12 +2253,13 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos_view(Mat *input_mat, PetscIntKokkosV
             PetscCallVoid(VecRestoreKokkosViewWrite(x_vec, &x_scalar_d));
          }
 
-         /* (2) Scatter x and cmap using Mvctx to get their off-process portions */
-         // Keep at most one active communication on Mvctx at a time.
+         /* (2) Scatter x and cmap using the caller-supplied SF/leaf to get their
+            off-process portions. Same single SF drives both scatters. */
+         // Keep at most one active communication on the SF at a time.
          // While Begin/End is in flight, do not touch the corresponding send/recv buffers.
          // Ensure send/receive buffers are stable before Begin.
-         Kokkos::fence();         
-         PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, x_vec, mat_mpi->lvec, INSERT_VALUES, SCATTER_FORWARD));
+         Kokkos::fence();
+         PetscCallVoid(VecScatterBegin(*sf, x_vec, *leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
 
          // Fill cmap_vec on device: cmap[is_col(i)] = i + isstart, rest = -1
          {
@@ -2272,10 +2271,10 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos_view(Mat *input_mat, PetscIntKokkosV
                   cmap_scalar_d(is_col_d_d(i)) = (PetscScalar)(i + isstart);
             });
             PetscCallVoid(VecRestoreKokkosViewWrite(cmap_vec, &cmap_scalar_d));
-         }         
+         }
 
          Vec lcmap_vec;
-         PetscCallVoid(VecDuplicate(mat_mpi->lvec, &lcmap_vec));
+         PetscCallVoid(VecDuplicate(*leaf_vec, &lcmap_vec));
 
          /* (3) Count how many off-local columns match */
          PetscInt col_ao_output = 0;
@@ -2284,18 +2283,18 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos_view(Mat *input_mat, PetscIntKokkosV
          auto is_col_o_match_d = PetscIntKokkosView("is_col_o_match_d", cols_ao+1);
          Kokkos::deep_copy(exec, is_col_o_match_d, 0);
 
-         // x scatter completed: mat_mpi->lvec is now safe to read.
-         PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, x_vec, mat_mpi->lvec, INSERT_VALUES, SCATTER_FORWARD));
+         // x scatter completed: *leaf_vec is now safe to read.
+         PetscCallVoid(VecScatterEnd(*sf, x_vec, *leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
 
-         // Start cmap scatter only after finishing x scatter on the same Mvctx.
+         // Start cmap scatter only after finishing x scatter on the same SF.
          // Ensure send/receive buffers are stable before Begin.
-         Kokkos::fence();         
-         PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, cmap_vec, lcmap_vec, INSERT_VALUES, SCATTER_FORWARD));
+         Kokkos::fence();
+         PetscCallVoid(VecScatterBegin(*sf, cmap_vec, lcmap_vec, INSERT_VALUES, SCATTER_FORWARD));
 
          if (cols_ao > 0)
          {
             ConstPetscScalarKokkosView lvec_scalar_d;
-            PetscCallVoid(VecGetKokkosView(mat_mpi->lvec, &lvec_scalar_d));
+            PetscCallVoid(VecGetKokkosView(*leaf_vec, &lvec_scalar_d));
 
             Kokkos::parallel_reduce("FindMatches", Kokkos::RangePolicy<>(exec, 0, cols_ao),
                KOKKOS_LAMBDA(const PetscInt i, PetscInt& thread_sum) {
@@ -2309,7 +2308,7 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos_view(Mat *input_mat, PetscIntKokkosV
                Kokkos::Sum<PetscInt>(col_ao_output)
             );
 
-            PetscCallVoid(VecRestoreKokkosView(mat_mpi->lvec, &lvec_scalar_d));
+            PetscCallVoid(VecRestoreKokkosView(*leaf_vec, &lvec_scalar_d));
          }
 
          // Need to do an exclusive scan on is_col_o_match_d to get the new local indices
@@ -2330,7 +2329,7 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos_view(Mat *input_mat, PetscIntKokkosV
          garray_output_d = PetscIntKokkosView("garray_output_d", col_ao_output);
 
          // cmap scatter completed: lcmap_vec is now safe to read.
-         PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, cmap_vec, lcmap_vec, INSERT_VALUES, SCATTER_FORWARD));
+         PetscCallVoid(VecScatterEnd(*sf, cmap_vec, lcmap_vec, INSERT_VALUES, SCATTER_FORWARD));
 
          // Loop over all the cols in the input matrix
          {
@@ -2440,7 +2439,8 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos_view(Mat *input_mat, PetscIntKokkosV
 // is_col must be sorted
 // If you pass in our_level != -1 then it uses the fine/coarse indices stored in IS_fine_views_local
 // and IS_coarse_views_local - they should match the passed in is_row and is_col though!
-PETSC_INTERN void MatCreateSubMatrix_kokkos(Mat *input_mat, IS *is_row, IS *is_col, \
+PETSC_INTERN void MatCreateSubMatrix_kokkos(Mat *input_mat, PetscSF *sf, Vec *leaf_vec, \
+                     IS *is_row, IS *is_col, \
                      const int reuse_int, Mat *output_mat, \
                      const int our_level, const int is_row_fine_int, const int is_col_fine_int)
 {
@@ -2523,7 +2523,7 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos(Mat *input_mat, IS *is_row, IS *is_c
       }        
    }  
 
-   MatCreateSubMatrix_kokkos_view(input_mat, is_row_d_d, global_rows_row, is_col_d_d, global_cols_col, reuse_int, output_mat);
+   MatCreateSubMatrix_kokkos_view(input_mat, sf, leaf_vec, is_row_d_d, global_rows_row, is_col_d_d, global_cols_col, reuse_int, output_mat);
 
    return;
 }

--- a/src/PETSc_Helperk.kokkos.cxx
+++ b/src/PETSc_Helperk.kokkos.cxx
@@ -156,13 +156,16 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
    const PetscInt global_col_end_plus_one = global_col_end_plus_one_temp;
 
    // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
+   // Get pointers to the i,j on the device and Kokkos views to the values
    // ~~~~~~~~~~~~
    const PetscInt *device_local_i = nullptr, *device_local_j = nullptr, *device_nonlocal_i = nullptr, *device_nonlocal_j = nullptr;
    PetscMemType mtype;
-   PetscScalar *device_local_vals = nullptr, *device_nonlocal_vals = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, &device_local_vals, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, &device_nonlocal_vals, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals;
+   Kokkos::View<const PetscScalar *> device_nonlocal_vals;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    // ~~~~~~~~~~~~
    // Get the number of nnzs
@@ -209,7 +212,7 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
                   [&](const PetscInt j, PetscScalar &thread_diag_abs) {
                      const bool is_diagonal = (device_local_j[device_local_i[i] + j] + global_col_start == row_index_global);
                      if (is_diagonal) {
-                        const PetscScalar val = Kokkos::abs(device_local_vals[device_local_i[i] + j]);
+                        const PetscScalar val = Kokkos::abs(device_local_vals(device_local_i[i] + j));
                         if (val > thread_diag_abs) thread_diag_abs = val;
                      }
                   },
@@ -226,7 +229,7 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
                      [&](const PetscInt j, PetscScalar &thread_diag_abs) {
                         const bool is_diagonal = (colmap_input_d(device_nonlocal_j[device_nonlocal_i[i] + j]) == row_index_global);
                         if (is_diagonal) {
-                           const PetscScalar val = Kokkos::abs(device_nonlocal_vals[device_nonlocal_i[i] + j]);
+                           const PetscScalar val = Kokkos::abs(device_nonlocal_vals(device_nonlocal_i[i] + j));
                            if (val > thread_diag_abs) thread_diag_abs = val;
                         }
                      },
@@ -252,7 +255,7 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
                      const bool is_diagonal = (device_local_j[device_local_i[i] + j] + global_col_start == row_index_global);
 
                      // If our current tolerance is bigger than the max value we've seen so far
-                     PetscScalar val = Kokkos::abs(device_local_vals[device_local_i[i] + j]);
+                     PetscScalar val = Kokkos::abs(device_local_vals(device_local_i[i] + j));
                      // If we're not comparing against the diagonal when computing relative residual
                      if (not_include_diag && is_diagonal) val = -1.0;
                      if (val > thread_max) thread_max = val;
@@ -274,7 +277,7 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
                         const bool is_diagonal = (colmap_input_d(device_nonlocal_j[device_nonlocal_i[i] + j]) == row_index_global);
 
                         // If our current tolerance is bigger than the max value we've seen so far
-                        PetscScalar val = Kokkos::abs(device_nonlocal_vals[device_nonlocal_i[i] + j]);
+                        PetscScalar val = Kokkos::abs(device_nonlocal_vals(device_nonlocal_i[i] + j));
                         // If we're not comparing against the diagonal when computing relative residual
                         if (not_include_diag && is_diagonal) val = -1.0;                  
                         if (val > thread_max) thread_max = val;
@@ -339,7 +342,7 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
             }
             
             // If the value is bigger than the tolerance, we keep it
-            if (Kokkos::abs(device_local_vals[device_local_i[i] + j]) >= rel_row_tol_d(i)) {
+            if (Kokkos::abs(device_local_vals(device_local_i[i] + j)) >= rel_row_tol_d(i)) {
                // If this is the diagonal and we're dropping all diagonals don't add it
                if (!(allow_drop_diagonal_int == -1 && is_diagonal)) thread_data.count++;
             }
@@ -414,7 +417,7 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
                   }                  
 
                   // If the value is bigger than the tolerance, we keep it
-                  if (Kokkos::abs(device_nonlocal_vals[device_nonlocal_i[i] + j]) >= rel_row_tol_d(i)) {
+                  if (Kokkos::abs(device_nonlocal_vals(device_nonlocal_i[i] + j)) >= rel_row_tol_d(i)) {
                      // If this is the diagonal and we're dropping all diagonals don't add it
                      if (!(allow_drop_diagonal_int == -1 && is_diagonal)) thread_data.count++;
                   }
@@ -570,10 +573,10 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
          const bool is_diagonal = (device_local_j[device_local_i[i] + j] + global_col_start == row_index_global);
 
          // If we hit a diagonal put it in the lump'd value
-         if (is_diagonal && lump_int) thread_sum += device_local_vals[device_local_i[i] + j];           
+         if (is_diagonal && lump_int) thread_sum += device_local_vals(device_local_i[i] + j);           
          
          // Check if we keep this column because of size
-         if (Kokkos::abs(device_local_vals[device_local_i[i] + j]) >= rel_row_tol_d(i)) {
+         if (Kokkos::abs(device_local_vals(device_local_i[i] + j)) >= rel_row_tol_d(i)) {
             // If this is the diagonal and we're dropping all diagonals don't add it
             if (!(allow_drop_diagonal_int == -1 && is_diagonal)) keep_col = true;
          }
@@ -587,7 +590,7 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
             scratch_indices(j) = 1;
          }
          // If we're not on the diagonal and we're small enough to lump
-         else if (lump_int && !is_diagonal) thread_sum += device_local_vals[device_local_i[i] + j];       
+         else if (lump_int && !is_diagonal) thread_sum += device_local_vals(device_local_i[i] + j);       
          },
          Kokkos::Sum<PetscScalar>(lump_val_local)
       ); 
@@ -602,10 +605,10 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
             const bool is_diagonal = (colmap_input_d(device_nonlocal_j[device_nonlocal_i[i] + j]) == row_index_global);
       
             // If we hit a diagonal put it in the lump'd value
-            if (is_diagonal && lump_int) thread_sum += device_nonlocal_vals[device_nonlocal_i[i] + j];
+            if (is_diagonal && lump_int) thread_sum += device_nonlocal_vals(device_nonlocal_i[i] + j);
 
             // Check if we keep this column because of size
-            if (Kokkos::abs(device_nonlocal_vals[device_nonlocal_i[i] + j]) >= rel_row_tol_d(i)) {
+            if (Kokkos::abs(device_nonlocal_vals(device_nonlocal_i[i] + j)) >= rel_row_tol_d(i)) {
                // If this is the diagonal and we're dropping all diagonals don't add it
                if (!(allow_drop_diagonal_int == -1 && is_diagonal)) keep_col = true;
             }
@@ -619,7 +622,7 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
                scratch_indices_nonlocal(j) = 1;             
             }
             // If we're not on the diagonal and we're small enough to lump
-            else if (lump_int && !is_diagonal) thread_sum += device_nonlocal_vals[device_nonlocal_i[i] + j];
+            else if (lump_int && !is_diagonal) thread_sum += device_nonlocal_vals(device_nonlocal_i[i] + j);
             },
             Kokkos::Sum<PetscScalar>(lump_val_nonlocal)
          );
@@ -665,7 +668,7 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
          if (scratch_indices(j+1) > scratch_indices(j))
          {
             j_local_d(i_local_d(i) + scratch_indices(j)) = device_local_j[device_local_i[i] + j];
-            a_local_d(i_local_d(i) + scratch_indices(j)) = device_local_vals[device_local_i[i] + j];            
+            a_local_d(i_local_d(i) + scratch_indices(j)) = device_local_vals(device_local_i[i] + j);            
          }
       });
 
@@ -676,7 +679,7 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
             {
                // Writing the global column indices, this will get compactified below
                j_nonlocal_d(i_nonlocal_d(i) + scratch_indices_nonlocal(j)) = colmap_input_d(device_nonlocal_j[device_nonlocal_i[i] + j]);
-               a_nonlocal_d(i_nonlocal_d(i) + scratch_indices_nonlocal(j)) = device_nonlocal_vals[device_nonlocal_i[i] + j];     
+               a_nonlocal_d(i_nonlocal_d(i) + scratch_indices_nonlocal(j)) = device_nonlocal_vals(device_nonlocal_i[i] + j);     
             }
          });         
       }
@@ -799,12 +802,15 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
 
       // We can now create our MPI matrix
       PetscCallVoid(MatCreateMPIAIJWithSeqAIJ(MPI_COMM_MATRIX, global_rows, global_cols, output_mat_local, output_mat_nonlocal, garray_host, output_mat));
-   }     
-   // If in serial 
+   }
+   // If in serial
    else
    {
       *output_mat = output_mat_local;
    }
+
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    return;
 }
@@ -878,23 +884,26 @@ PETSC_INTERN void remove_from_sparse_match_kokkos(Mat *input_mat, Mat *output_ma
    }
 
    // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
+   // Get pointers to the i,j on the device and Kokkos views to the values
    // ~~~~~~~~~~~~
    const PetscInt *device_local_i = nullptr, *device_local_j = nullptr, *device_nonlocal_i = nullptr, *device_nonlocal_j = nullptr;
    PetscMemType mtype;
-   PetscScalar *device_local_vals = nullptr, *device_nonlocal_vals = nullptr;  
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, &device_local_vals, &mtype));  
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, &device_nonlocal_vals, &mtype));          
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals;
+   Kokkos::View<const PetscScalar *> device_nonlocal_vals;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    // Get the output pointers
    const PetscInt *device_local_i_output = nullptr, *device_local_j_output = nullptr, *device_nonlocal_i_output = nullptr, *device_nonlocal_j_output = nullptr;
-   PetscScalar *device_local_vals_output = nullptr, *device_nonlocal_vals_output = nullptr;  
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, &device_local_j_output, &device_local_vals_output, &mtype));  
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_output, &device_nonlocal_j_output, &device_nonlocal_vals_output, &mtype)); 
-
-   Mat_SeqAIJKokkos *aijkok_local_output = static_cast<Mat_SeqAIJKokkos *>(mat_local_output->spptr);
-   Mat_SeqAIJKokkos *aijkok_nonlocal_output = NULL;
-   if (mpi) aijkok_nonlocal_output = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_output->spptr);
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, &device_local_j_output, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_output, &device_nonlocal_j_output, NULL, &mtype));
+   // Output values are read-modify-write (+= and conditional =)
+   Kokkos::View<PetscScalar *> device_local_vals_output;
+   Kokkos::View<PetscScalar *> device_nonlocal_vals_output;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local_output, &device_local_vals_output));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal_output, &device_nonlocal_vals_output));
 
    // Find maximum non-zeros per row of the input mat for sizing scratch memory
    PetscInt max_nnz_local = 0, max_nnz_nonlocal = 0;
@@ -1037,7 +1046,7 @@ PETSC_INTERN void remove_from_sparse_match_kokkos(Mat *input_mat, Mat *output_ma
             [&](const PetscInt j, PetscScalar& thread_sum) {          
 
                // If this is not being put into output then we lump it
-               if (scratch_indices(j) == -1) thread_sum += alpha * device_local_vals[device_local_i[i] + j];
+               if (scratch_indices(j) == -1) thread_sum += alpha * device_local_vals(device_local_i[i] + j);
             },
             Kokkos::Sum<PetscScalar>(lump_val_local)
          );   
@@ -1050,7 +1059,7 @@ PETSC_INTERN void remove_from_sparse_match_kokkos(Mat *input_mat, Mat *output_ma
                [&](const PetscInt j, PetscScalar& thread_sum) {           
 
                   // If this is not being put into output then we lump it
-                  if (scratch_indices_nonlocal(j) == -1) thread_sum += alpha * device_nonlocal_vals[device_nonlocal_i[i] + j];
+                  if (scratch_indices_nonlocal(j) == -1) thread_sum += alpha * device_nonlocal_vals(device_nonlocal_i[i] + j);
                },
                Kokkos::Sum<PetscScalar>(lump_val_nonlocal)
             );              
@@ -1066,11 +1075,11 @@ PETSC_INTERN void remove_from_sparse_match_kokkos(Mat *input_mat, Mat *output_ma
          {
             if (alpha_int)
             {
-               device_local_vals_output[device_local_i_output[i] + scratch_indices(j)] += alpha * device_local_vals[device_local_i[i] + j];
+               device_local_vals_output(device_local_i_output[i] + scratch_indices(j)) += alpha * device_local_vals(device_local_i[i] + j);
             }
             else
             {
-               device_local_vals_output[device_local_i_output[i] + scratch_indices(j)] = device_local_vals[device_local_i[i] + j];
+               device_local_vals_output(device_local_i_output[i] + scratch_indices(j)) = device_local_vals(device_local_i[i] + j);
             }
          }
       }); 
@@ -1085,11 +1094,11 @@ PETSC_INTERN void remove_from_sparse_match_kokkos(Mat *input_mat, Mat *output_ma
                // Writing the global column indices, this will get compactified below
                if (alpha_int)
                {
-                  device_nonlocal_vals_output[device_nonlocal_i_output[i] + scratch_indices_nonlocal(j)] += alpha * device_nonlocal_vals[device_nonlocal_i[i] + j];
+                  device_nonlocal_vals_output(device_nonlocal_i_output[i] + scratch_indices_nonlocal(j)) += alpha * device_nonlocal_vals(device_nonlocal_i[i] + j);
                }
                else
                {
-                  device_nonlocal_vals_output[device_nonlocal_i_output[i] + scratch_indices_nonlocal(j)] = device_nonlocal_vals[device_nonlocal_i[i] + j];
+                  device_nonlocal_vals_output(device_nonlocal_i_output[i] + scratch_indices_nonlocal(j)) = device_nonlocal_vals(device_nonlocal_i[i] + j);
                }
             }
          });          
@@ -1115,7 +1124,7 @@ PETSC_INTERN void remove_from_sparse_match_kokkos(Mat *input_mat, Mat *output_ma
                const bool is_diagonal = device_local_j_output[device_local_i_output[i] + j] + global_col_start == row_index_global;
 
                // Will only happen for one thread
-               if (is_diagonal) device_local_vals_output[device_local_i_output[i] + j] += lump_val;
+               if (is_diagonal) device_local_vals_output(device_local_i_output[i] + j) += lump_val;
             });   
          }
          else
@@ -1127,28 +1136,20 @@ PETSC_INTERN void remove_from_sparse_match_kokkos(Mat *input_mat, Mat *output_ma
                const bool is_diagonal = colmap_output_d(device_nonlocal_j_output[device_nonlocal_i_output[i] + j]) == row_index_global;
 
                // Will only happen for one thread
-               if (is_diagonal) device_nonlocal_vals_output[device_nonlocal_i_output[i] + j] += lump_val;
+               if (is_diagonal) device_nonlocal_vals_output(device_nonlocal_i_output[i] + j) += lump_val;
             });               
          }
       }       
    });
    Kokkos::fence();
 
-   // Have to specify we've modifed data on the device
-   // Want to call MatSeqAIJKokkosModifyDevice but its PETSC_INTERN
-   aijkok_local_output->a_dual.clear_sync_state();
-   aijkok_local_output->a_dual.modify_device();
-   aijkok_local_output->transpose_updated = PETSC_FALSE;
-   aijkok_local_output->hermitian_updated = PETSC_FALSE;
-   // Invalidate diagonals
-   if (mpi)
-   {
-      aijkok_nonlocal_output->a_dual.clear_sync_state();
-      aijkok_nonlocal_output->a_dual.modify_device();
-      aijkok_nonlocal_output->transpose_updated = PETSC_FALSE;
-      aijkok_nonlocal_output->hermitian_updated = PETSC_FALSE;
-   }        
-   PetscCallVoid(PetscObjectStateIncrease((PetscObject)(*output_mat)));
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal, &device_nonlocal_vals));
+
+   // The matching restore handles MatSeqAIJKokkosModifyDevice (clears sync state,
+   // marks device modified, invalidates transpose/hermitian, bumps object state).
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local_output, &device_local_vals_output));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal_output, &device_nonlocal_vals_output));
 
    return;
 }
@@ -1176,19 +1177,19 @@ PETSC_INTERN void MatSetAllValues_kokkos(Mat *input_mat, PetscReal val)
    PetscInt local_rows, local_cols;
    PetscCallVoid(MatGetLocalSize(*input_mat, &local_rows, &local_cols));
 
-   Mat_SeqAIJKokkos *aijkok_nonlocal = NULL;
-   Mat_SeqAIJKokkos *aijkok_local = static_cast<Mat_SeqAIJKokkos *>(mat_local->spptr);
-   if(mpi) aijkok_nonlocal = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal->spptr);
    auto exec = PetscGetKokkosExecutionSpace();
 
    // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
+   // Get pointers to the i,j on the device and write-only Kokkos views to the values
    // ~~~~~~~~~~~~
    const PetscInt *device_local_i = nullptr, *device_local_j = nullptr, *device_nonlocal_i = nullptr, *device_nonlocal_j = nullptr;
    PetscMemType mtype;
-   PetscScalar *device_local_vals = nullptr, *device_nonlocal_vals = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, &device_local_vals, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, &device_nonlocal_vals, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, NULL, &mtype));
+   Kokkos::View<PetscScalar *> device_local_vals;
+   Kokkos::View<PetscScalar *> device_nonlocal_vals;
+   PetscCallVoid(MatSeqAIJGetKokkosViewWrite(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosViewWrite(mat_nonlocal, &device_nonlocal_vals));
 
    // Set all values to val by looping over rows
    Kokkos::parallel_for(
@@ -1197,7 +1198,7 @@ PETSC_INTERN void MatSetAllValues_kokkos(Mat *input_mat, PetscReal val)
          const PetscInt i = t.league_rank();
          const PetscInt ncols = device_local_i[i + 1] - device_local_i[i];
          Kokkos::parallel_for(Kokkos::TeamThreadRange(t, ncols), [&](const PetscInt j) {
-            device_local_vals[device_local_i[i] + j] = val;
+            device_local_vals(device_local_i[i] + j) = val;
          });
    });
    // Log copy with petsc
@@ -1211,29 +1212,16 @@ PETSC_INTERN void MatSetAllValues_kokkos(Mat *input_mat, PetscReal val)
             const PetscInt i = t.league_rank();
             const PetscInt ncols = device_nonlocal_i[i + 1] - device_nonlocal_i[i];
             Kokkos::parallel_for(Kokkos::TeamThreadRange(t, ncols), [&](const PetscInt j) {
-               device_nonlocal_vals[device_nonlocal_i[i] + j] = val;
+               device_nonlocal_vals(device_nonlocal_i[i] + j) = val;
             });
       });
       PetscCallVoid(PetscLogCpuToGpu(bytes));
    }
 
-   // Have to specify we've modifed data on the device
-   // Want to call MatSeqAIJKokkosModifyDevice but its PETSC_INTERN
-
-   aijkok_local->a_dual.clear_sync_state();
-   aijkok_local->a_dual.modify_device();
-   aijkok_local->transpose_updated = PETSC_FALSE;
-   aijkok_local->hermitian_updated = PETSC_FALSE;
-   // Invalidate diagonals
-
-   if (mpi)
-   {
-      aijkok_nonlocal->a_dual.clear_sync_state();
-      aijkok_nonlocal->a_dual.modify_device();
-      aijkok_nonlocal->transpose_updated = PETSC_FALSE;
-      aijkok_nonlocal->hermitian_updated = PETSC_FALSE;
-   }
-   PetscCallVoid(PetscObjectStateIncrease((PetscObject)(*input_mat)));
+   // The matching restore handles MatSeqAIJKokkosModifyDevice (clears sync state,
+   // marks device modified, invalidates transpose/hermitian, bumps object state).
+   PetscCallVoid(MatSeqAIJRestoreKokkosViewWrite(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosViewWrite(mat_nonlocal, &device_nonlocal_vals));
 
    return;
 }
@@ -1282,13 +1270,16 @@ PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *input_mat, const int 
    auto exec = PetscGetKokkosExecutionSpace();
 
    // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
+   // Get pointers to the i,j on the device and Kokkos views to the values
    // ~~~~~~~~~~~~
    const PetscInt *device_local_i = nullptr, *device_local_j = nullptr, *device_nonlocal_i = nullptr, *device_nonlocal_j = nullptr;
    PetscMemType mtype;
-   PetscScalar *device_local_vals = nullptr, *device_nonlocal_vals = nullptr;  
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, &device_local_vals, &mtype));  
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, &device_nonlocal_vals, &mtype));          
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals;
+   Kokkos::View<const PetscScalar *> device_nonlocal_vals;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    PetscIntKokkosView nnz_match_local_row_d;
    PetscIntKokkosView nnz_match_nonlocal_row_d;
@@ -1464,7 +1455,7 @@ PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *input_mat, const int 
 
                // Want the local col indices for the local block
                j_local_d(i_local_d(i) + j) = device_local_j[device_local_i[i] + j];
-               a_local_d(i_local_d(i) + j) = device_local_vals[device_local_i[i] + j];
+               a_local_d(i_local_d(i) + j) = device_local_vals(device_local_i[i] + j);
                      
             });     
 
@@ -1478,7 +1469,7 @@ PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *input_mat, const int 
 
                   // We keep the existing local indices in the off-diagonal block here
                   j_nonlocal_d(i_nonlocal_d(i) + j) = device_nonlocal_j[device_nonlocal_i[i] + j];
-                  a_nonlocal_d(i_nonlocal_d(i) + j) = device_nonlocal_vals[device_nonlocal_i[i] + j];
+                  a_nonlocal_d(i_nonlocal_d(i) + j) = device_nonlocal_vals(device_nonlocal_i[i] + j);
                         
                });          
             }
@@ -1507,16 +1498,17 @@ PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *input_mat, const int 
       {
          mat_local_output = *output_mat;
       }     
-      Mat_SeqAIJKokkos *aijkok_local_output = static_cast<Mat_SeqAIJKokkos *>(mat_local_output->spptr);
-      Mat_SeqAIJKokkos *aijkok_nonlocal_output = NULL;
-      if (mpi) aijkok_nonlocal_output = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_output->spptr);
-
-      // Get device pointers for the existing i, j, and a arrays
+      // Get device pointers for the existing i and j arrays
       const PetscInt *device_local_i_output = nullptr, *device_local_j_output = nullptr, *device_nonlocal_i_output = nullptr;
-      PetscScalar *device_local_a_output = nullptr, *device_nonlocal_a_output = nullptr;
       PetscMemType mtype;
-      PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, &device_local_j_output, &device_local_a_output, &mtype));
-      if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_output, NULL, &device_nonlocal_a_output, &mtype));
+      PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, &device_local_j_output, NULL, &mtype));
+      if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_output, NULL, NULL, &mtype));
+
+      // Output values are fully overwritten below (zeroed first, then assigned)
+      Kokkos::View<PetscScalar *> device_local_a_output;
+      Kokkos::View<PetscScalar *> device_nonlocal_a_output;
+      PetscCallVoid(MatSeqAIJGetKokkosViewWrite(mat_local_output, &device_local_a_output));
+      if (mpi) PetscCallVoid(MatSeqAIJGetKokkosViewWrite(mat_nonlocal_output, &device_nonlocal_a_output));
 
       // Because we might be missing diagonals and we're going to skip some of them
       // in the writing loop below
@@ -1526,7 +1518,7 @@ PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *input_mat, const int 
             const PetscInt i = t.league_rank();
             const PetscInt ncols = device_local_i_output[i + 1] - device_local_i_output[i];
             Kokkos::parallel_for(Kokkos::TeamThreadRange(t, ncols), [&](const PetscInt j) {
-               device_local_a_output[device_local_i_output[i] + j] = 0.0;
+               device_local_a_output(device_local_i_output[i] + j) = 0.0;
             });
       });
 
@@ -1556,7 +1548,7 @@ PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *input_mat, const int 
                if (device_local_j_output[device_local_i_output[i] + j] >= i && \
                      !found_diag_row_d(i)) offset = 1;
 
-               device_local_a_output[device_local_i_output[i] + j + offset] = device_local_vals[device_local_i[i] + j];
+               device_local_a_output(device_local_i_output[i] + j + offset) = device_local_vals(device_local_i[i] + j);
             });
 
             // For over nonlocal columns - copy in input - identical structure in the off-diag block
@@ -1569,30 +1561,18 @@ PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *input_mat, const int 
 
                   // We keep the existing local indices in the off-diagonal block here
                   // we have all the same columns as input and hence the same garray
-                  device_nonlocal_a_output[device_nonlocal_i_output[i] + j] = device_nonlocal_vals[device_nonlocal_i[i] + j];
+                  device_nonlocal_a_output(device_nonlocal_i_output[i] + j) = device_nonlocal_vals(device_nonlocal_i[i] + j);
 
                });
             }
       });
-      
+
       Kokkos::fence();
 
-      // Have to specify we've modifed data on the device
-      // Want to call MatSeqAIJKokkosModifyDevice but its PETSC_INTERN
-      aijkok_local_output->a_dual.clear_sync_state();
-      aijkok_local_output->a_dual.modify_device();
-      aijkok_local_output->transpose_updated = PETSC_FALSE;
-      aijkok_local_output->hermitian_updated = PETSC_FALSE;
-      // Invalidate diagonals
-
-      if (mpi)
-      {
-         aijkok_nonlocal_output->a_dual.clear_sync_state();
-         aijkok_nonlocal_output->a_dual.modify_device();
-         aijkok_nonlocal_output->transpose_updated = PETSC_FALSE;
-         aijkok_nonlocal_output->hermitian_updated = PETSC_FALSE;
-      }        
-      PetscCallVoid(PetscObjectStateIncrease((PetscObject)(*output_mat)));    
+      // The matching restore handles MatSeqAIJKokkosModifyDevice (clears sync state,
+      // marks device modified, invalidates transpose/hermitian, bumps object state).
+      PetscCallVoid(MatSeqAIJRestoreKokkosViewWrite(mat_local_output, &device_local_a_output));
+      if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosViewWrite(mat_nonlocal_output, &device_nonlocal_a_output));
 
     }
 
@@ -1631,13 +1611,16 @@ PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *input_mat, const int 
 
          // We can now create our MPI matrix
          PetscCallVoid(MatCreateMPIAIJWithSeqAIJ(MPI_COMM_MATRIX, global_rows, global_cols, output_mat_local, output_mat_nonlocal, garray_host, output_mat));
-      }    
-      // If in serial 
+      }
+      // If in serial
       else
       {
          *output_mat = output_mat_local;
       }
-   }  
+   }
+
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    return;
 }
@@ -1716,10 +1699,13 @@ PETSC_INTERN void MatAXPY_kokkos(Mat *Y, PetscScalar alpha, Mat *X)
    // Pull device CSR pointers for the original nonlocal blocks (we never mutate them).
    const PetscInt *device_nonlocal_y_i = nullptr, *device_nonlocal_y_j = nullptr;
    const PetscInt *device_nonlocal_x_i = nullptr, *device_nonlocal_x_j = nullptr;
-   PetscScalar *device_nonlocal_y_a = nullptr, *device_nonlocal_x_a = nullptr;
    PetscMemType mtype;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_y, &device_nonlocal_y_i, &device_nonlocal_y_j, &device_nonlocal_y_a, &mtype));
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_x, &device_nonlocal_x_i, &device_nonlocal_x_j, &device_nonlocal_x_a, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_y, &device_nonlocal_y_i, &device_nonlocal_y_j, NULL, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_x, &device_nonlocal_x_i, &device_nonlocal_x_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> a_y_orig;
+   Kokkos::View<const PetscScalar *> a_x_orig;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal_y, &a_y_orig));
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal_x, &a_x_orig));
 
    // Read the nnz of each nonlocal block from its host i pointer
    PetscInt nnz_y, nnz_x;
@@ -1741,7 +1727,6 @@ PETSC_INTERN void MatAXPY_kokkos(Mat *Y, PetscScalar alpha, Mat *X)
    Kokkos::View<PetscInt *> j_y_temp("j_y_temp", nnz_y);
    Kokkos::View<PetscScalar *> a_y_temp("a_y_temp", nnz_y);
    Kokkos::View<const PetscInt *, DefaultMemorySpace, Kokkos::MemoryUnmanaged> i_y_orig(device_nonlocal_y_i, local_rows + 1);
-   Kokkos::View<const PetscScalar *, DefaultMemorySpace, Kokkos::MemoryUnmanaged> a_y_orig(device_nonlocal_y_a, nnz_y);
    Kokkos::deep_copy(exec, i_y_temp, i_y_orig);
    Kokkos::deep_copy(exec, a_y_temp, a_y_orig);
    Kokkos::parallel_for(
@@ -1753,7 +1738,6 @@ PETSC_INTERN void MatAXPY_kokkos(Mat *Y, PetscScalar alpha, Mat *X)
    Kokkos::View<PetscInt *> j_x_temp("j_x_temp", nnz_x);
    Kokkos::View<PetscScalar *> a_x_temp("a_x_temp", nnz_x);
    Kokkos::View<const PetscInt *, DefaultMemorySpace, Kokkos::MemoryUnmanaged> i_x_orig(device_nonlocal_x_i, local_rows + 1);
-   Kokkos::View<const PetscScalar *, DefaultMemorySpace, Kokkos::MemoryUnmanaged> a_x_orig(device_nonlocal_x_a, nnz_x);
    Kokkos::deep_copy(exec, i_x_temp, i_x_orig);
    Kokkos::deep_copy(exec, a_x_temp, a_x_orig);
    const PetscInt offset_x = cols_ao_y;
@@ -1763,6 +1747,9 @@ PETSC_INTERN void MatAXPY_kokkos(Mat *Y, PetscScalar alpha, Mat *X)
       });
 
    Kokkos::fence();
+
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal_y, &a_y_orig));
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal_x, &a_x_orig));
 
    // concat is no longer needed - both j-rewrite kernels have completed.
    concat = PetscIntKokkosView();
@@ -1780,8 +1767,9 @@ PETSC_INTERN void MatAXPY_kokkos(Mat *Y, PetscScalar alpha, Mat *X)
 
    // Extract the result from temp_y so we can own it independently.
    const PetscInt *device_z_i = nullptr, *device_z_j = nullptr;
-   PetscScalar *device_z_a = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(temp_y, &device_z_i, &device_z_j, &device_z_a, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(temp_y, &device_z_i, &device_z_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> a_z_unm;
+   PetscCallVoid(MatSeqAIJGetKokkosView(temp_y, &a_z_unm));
 
    // Read the spadd-result nnz from its host i pointer
    PetscInt nnz_z;
@@ -1799,11 +1787,12 @@ PETSC_INTERN void MatAXPY_kokkos(Mat *Y, PetscScalar alpha, Mat *X)
    Kokkos::View<PetscScalar *> a_nonlocal_d_copy("a_nonlocal_d_copy", nnz_z);
    Kokkos::View<const PetscInt *, DefaultMemorySpace, Kokkos::MemoryUnmanaged> i_z_unm(device_z_i, local_rows + 1);
    Kokkos::View<const PetscInt *, DefaultMemorySpace, Kokkos::MemoryUnmanaged> j_z_unm(device_z_j, nnz_z);
-   Kokkos::View<const PetscScalar *, DefaultMemorySpace, Kokkos::MemoryUnmanaged> a_z_unm(device_z_a, nnz_z);
    Kokkos::deep_copy(exec, i_nonlocal_d_copy, i_z_unm);
    Kokkos::deep_copy(exec, j_nonlocal_d_copy, j_z_unm);
    Kokkos::deep_copy(exec, a_nonlocal_d_copy, a_z_unm);
    Kokkos::fence();
+
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(temp_y, &a_z_unm));
 
    // temp_y's data has been copied out; free it before allocating Z_nonlocal.
    PetscCallVoid(MatDestroy(&temp_y));
@@ -1836,12 +1825,13 @@ PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosVi
    PetscInt local_rows_row = is_row_d_d.extent(0), local_cols_col = is_col_d_d.extent(0);
    
    // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
+   // Get pointers to the i,j on the device and Kokkos view to the values
    // ~~~~~~~~~~~~
    const PetscInt *device_local_i = nullptr, *device_local_j = nullptr;
    PetscMemType mtype;
-   PetscScalar *device_local_vals = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(*input_mat, &device_local_i, &device_local_j, &device_local_vals, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(*input_mat, &device_local_i, &device_local_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals;
+   PetscCallVoid(MatSeqAIJGetKokkosView(*input_mat, &device_local_vals));
 
    PetscIntKokkosView nnz_match_local_row_d;
 
@@ -2030,7 +2020,7 @@ PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosVi
             {
                // Be careful to use the correct i_idx_is_row index into i_local_d here
                j_local_d(i_local_d(i_idx_is_row) + scratch_indices(j)) = smap_d(device_local_j[device_local_i[i] + j]) - 1;
-               a_local_d(i_local_d(i_idx_is_row) + scratch_indices(j)) = device_local_vals[device_local_i[i] + j];            
+               a_local_d(i_local_d(i_idx_is_row) + scratch_indices(j)) = device_local_vals(device_local_i[i] + j);            
             }
          });
       });  
@@ -2038,13 +2028,13 @@ PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosVi
    // If we're reusing, we can just write directly to the existing views
    else
    {
-      Mat_SeqAIJKokkos *aijkok_local_output = static_cast<Mat_SeqAIJKokkos *>((*output_mat)->spptr);
-
-      // Get device pointers for the existing i and a arrays
+      // Get device pointers for the existing i array
       const PetscInt *device_local_i_output = nullptr;
-      PetscScalar *device_local_a_output = nullptr;
       PetscMemType mtype;
-      PetscCallVoid(MatSeqAIJGetCSRAndMemType(*output_mat, &device_local_i_output, NULL, &device_local_a_output, &mtype));
+      PetscCallVoid(MatSeqAIJGetCSRAndMemType(*output_mat, &device_local_i_output, NULL, NULL, &mtype));
+      // Output values are fully overwritten below (one write per output entry)
+      Kokkos::View<PetscScalar *> device_local_a_output;
+      PetscCallVoid(MatSeqAIJGetKokkosViewWrite(*output_mat, &device_local_a_output));
 
       // Execute with scratch memory
       Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const KokkosTeamMemberType& t) {
@@ -2104,20 +2094,16 @@ PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosVi
             if (scratch_indices(j+1) > scratch_indices(j))
             {
                // Be careful to use the correct i_idx_is_row index into device_local_i_output here
-               device_local_a_output[device_local_i_output[i_idx_is_row] + scratch_indices(j)] = device_local_vals[device_local_i[i] + j];
+               device_local_a_output(device_local_i_output[i_idx_is_row] + scratch_indices(j)) = device_local_vals(device_local_i[i] + j);
             }
          });
       });
-      
-      Kokkos::fence();      
 
-      // Have to specify we've modifed data on the device
-      // Want to call MatSeqAIJKokkosModifyDevice but its PETSC_INTERN
-      aijkok_local_output->a_dual.clear_sync_state();
-      aijkok_local_output->a_dual.modify_device();
-      aijkok_local_output->transpose_updated = PETSC_FALSE;
-      aijkok_local_output->hermitian_updated = PETSC_FALSE;
-      PetscObjectStateIncrease((PetscObject)(*output_mat));    
+      Kokkos::fence();
+
+      // The matching restore handles MatSeqAIJKokkosModifyDevice (clears sync state,
+      // marks device modified, invalidates transpose/hermitian, bumps object state).
+      PetscCallVoid(MatSeqAIJRestoreKokkosViewWrite(*output_mat, &device_local_a_output));
 
    }
 
@@ -2128,10 +2114,12 @@ PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosVi
    // ~~~~~~~~~~~~~~~   
 
    if (!reuse_int)
-   {   
+   {
       // Create the matrix given the sorted csr
       PetscCallVoid(MatCreateSeqAIJKokkosWithKokkosViews(PETSC_COMM_SELF, local_rows_row, local_cols_col, i_local_d, j_local_d, a_local_d, output_mat));
-   }  
+   }
+
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(*input_mat, &device_local_vals));
 
    return;
 }
@@ -2139,7 +2127,7 @@ PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosVi
 //------------------------------------------------------------------------------------------------------------------------
 
 // Does a MatGetSubMatrix for a Kokkos matrix - the petsc version currently uses the host making it very slow
-// This version only works  works if the input IS have the same parallel row/column distribution 
+// This version only works  works if the input IS have the same parallel row/column distribution
 // as the matrices, ie equivalent to MatCreateSubMatrix_MPIAIJ_SameRowDist
 // is_col must be sorted
 // This one uses the views is_row_d_d and is_col_d_d directly, rewritten to be the local indices

--- a/src/PETSc_Helperk.kokkos.cxx
+++ b/src/PETSc_Helperk.kokkos.cxx
@@ -178,9 +178,6 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
    // ~~~~~~~~~~~~~~~~~~~~~~~
    // We need the relative row tolerance, let's create some device memory to store it
    PetscScalarKokkosView rel_row_tol_d("rel_row_tol_d", local_rows);
-   // Log copy with petsc
-   size_t bytes = sizeof(PetscReal);
-   PetscCallVoid(PetscLogCpuToGpu(bytes));
 
    // We need to know how many entries are in each row after our dropping
    PetscIntKokkosView nnz_match_local_row_d("nnz_match_local_row_d", local_rows);
@@ -1174,48 +1171,19 @@ PETSC_INTERN void MatSetAllValues_kokkos(Mat *input_mat, PetscReal val)
    {
       mat_local = *input_mat;
    }
-   PetscInt local_rows, local_cols;
-   PetscCallVoid(MatGetLocalSize(*input_mat, &local_rows, &local_cols));
 
    auto exec = PetscGetKokkosExecutionSpace();
 
-   // ~~~~~~~~~~~~
-   // Get pointers to the i,j on the device and write-only Kokkos views to the values
-   // ~~~~~~~~~~~~
-   const PetscInt *device_local_i = nullptr, *device_local_j = nullptr, *device_nonlocal_i = nullptr, *device_nonlocal_j = nullptr;
-   PetscMemType mtype;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, NULL, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, NULL, &mtype));
    Kokkos::View<PetscScalar *> device_local_vals;
    Kokkos::View<PetscScalar *> device_nonlocal_vals;
    PetscCallVoid(MatSeqAIJGetKokkosViewWrite(mat_local, &device_local_vals));
    if (mpi) PetscCallVoid(MatSeqAIJGetKokkosViewWrite(mat_nonlocal, &device_nonlocal_vals));
 
-   // Set all values to val by looping over rows
-   Kokkos::parallel_for(
-      Kokkos::TeamPolicy<>(exec, local_rows, Kokkos::AUTO()),
-      KOKKOS_LAMBDA(const KokkosTeamMemberType& t) {
-         const PetscInt i = t.league_rank();
-         const PetscInt ncols = device_local_i[i + 1] - device_local_i[i];
-         Kokkos::parallel_for(Kokkos::TeamThreadRange(t, ncols), [&](const PetscInt j) {
-            device_local_vals(device_local_i[i] + j) = val;
-         });
-   });
-   // Log copy with petsc
-   size_t bytes = sizeof(PetscReal);
-   PetscCallVoid(PetscLogCpuToGpu(bytes));
+   // Set all values to val
+   Kokkos::deep_copy(exec, device_local_vals, val);
    if (mpi)
    {
-      Kokkos::parallel_for(
-         Kokkos::TeamPolicy<>(exec, local_rows, Kokkos::AUTO()),
-         KOKKOS_LAMBDA(const KokkosTeamMemberType& t) {
-            const PetscInt i = t.league_rank();
-            const PetscInt ncols = device_nonlocal_i[i + 1] - device_nonlocal_i[i];
-            Kokkos::parallel_for(Kokkos::TeamThreadRange(t, ncols), [&](const PetscInt j) {
-               device_nonlocal_vals(device_nonlocal_i[i] + j) = val;
-            });
-      });
-      PetscCallVoid(PetscLogCpuToGpu(bytes));
+      Kokkos::deep_copy(exec, device_nonlocal_vals, val);
    }
 
    // The matching restore handles MatSeqAIJKokkosModifyDevice (clears sync state,
@@ -1512,15 +1480,7 @@ PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *input_mat, const int 
 
       // Because we might be missing diagonals and we're going to skip some of them
       // in the writing loop below
-      Kokkos::parallel_for(
-         Kokkos::TeamPolicy<>(exec, local_rows, Kokkos::AUTO()),
-         KOKKOS_LAMBDA(const KokkosTeamMemberType& t) {
-            const PetscInt i = t.league_rank();
-            const PetscInt ncols = device_local_i_output[i + 1] - device_local_i_output[i];
-            Kokkos::parallel_for(Kokkos::TeamThreadRange(t, ncols), [&](const PetscInt j) {
-               device_local_a_output(device_local_i_output[i] + j) = 0.0;
-            });
-      });
+      Kokkos::deep_copy(exec, device_local_a_output, 0.0);
 
       // Only have to write a but have to be careful as we may not have diagonals in some rows
       // in the input, but they are in the output

--- a/src/PETSc_Helperk.kokkos.cxx
+++ b/src/PETSc_Helperk.kokkos.cxx
@@ -1190,18 +1190,31 @@ PETSC_INTERN void MatSetAllValues_kokkos(Mat *input_mat, PetscReal val)
    PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, &device_local_vals, &mtype));
    if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, &device_nonlocal_vals, &mtype));
 
-   PetscScalarKokkosView a_local_d, a_nonlocal_d;
-   a_local_d = PetscScalarKokkosView(device_local_vals, aijkok_local->csrmat.nnz());
-   if (mpi) a_nonlocal_d = PetscScalarKokkosView(device_nonlocal_vals, aijkok_nonlocal->csrmat.nnz());
-   // Copy in the val
-   Kokkos::deep_copy(exec, a_local_d, val);
+   // Set all values to val by looping over rows
+   Kokkos::parallel_for(
+      Kokkos::TeamPolicy<>(exec, local_rows, Kokkos::AUTO()),
+      KOKKOS_LAMBDA(const KokkosTeamMemberType& t) {
+         const PetscInt i = t.league_rank();
+         const PetscInt ncols = device_local_i[i + 1] - device_local_i[i];
+         Kokkos::parallel_for(Kokkos::TeamThreadRange(t, ncols), [&](const PetscInt j) {
+            device_local_vals[device_local_i[i] + j] = val;
+         });
+   });
    // Log copy with petsc
    size_t bytes = sizeof(PetscReal);
    PetscCallVoid(PetscLogCpuToGpu(bytes));
    if (mpi)
    {
-      Kokkos::deep_copy(exec, a_nonlocal_d, val); 
-      PetscCallVoid(PetscLogCpuToGpu(bytes));   
+      Kokkos::parallel_for(
+         Kokkos::TeamPolicy<>(exec, local_rows, Kokkos::AUTO()),
+         KOKKOS_LAMBDA(const KokkosTeamMemberType& t) {
+            const PetscInt i = t.league_rank();
+            const PetscInt ncols = device_nonlocal_i[i + 1] - device_nonlocal_i[i];
+            Kokkos::parallel_for(Kokkos::TeamThreadRange(t, ncols), [&](const PetscInt j) {
+               device_nonlocal_vals[device_nonlocal_i[i] + j] = val;
+            });
+      });
+      PetscCallVoid(PetscLogCpuToGpu(bytes));
    }
 
    // Have to specify we've modifed data on the device
@@ -1498,24 +1511,24 @@ PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *input_mat, const int 
       Mat_SeqAIJKokkos *aijkok_nonlocal_output = NULL;
       if (mpi) aijkok_nonlocal_output = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_output->spptr);
 
-      // Annoying we can't just call MatSeqAIJGetKokkosView
-      a_local_d = aijkok_local_output->a_dual.view_device();
-      if (mpi) a_nonlocal_d = aijkok_nonlocal_output->a_dual.view_device();
+      // Get device pointers for the existing i, j, and a arrays
+      const PetscInt *device_local_i_output = nullptr, *device_local_j_output = nullptr, *device_nonlocal_i_output = nullptr;
+      PetscScalar *device_local_a_output = nullptr, *device_nonlocal_a_output = nullptr;
+      PetscMemType mtype;
+      PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, &device_local_j_output, &device_local_a_output, &mtype));
+      if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_output, NULL, &device_nonlocal_a_output, &mtype));
+
       // Because we might be missing diagonals and we're going to skip some of them
       // in the writing loop below
-      Kokkos::deep_copy(exec, a_local_d, 0.0);
-
-      // Annoyingly there isn't currently the ability to get views for i (or j)
-      const PetscInt *device_local_i_output = nullptr, *device_local_j_output = nullptr, *device_nonlocal_i_ouput = nullptr;
-      PetscMemType mtype;
-      PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, &device_local_j_output, NULL, &mtype));  
-      if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_ouput, NULL, NULL, &mtype));  
-
-      // Have these point at the existing i pointers - we only need the local j
-      ConstMatRowMapKokkosView i_local_const_d = ConstMatRowMapKokkosView(device_local_i_output, local_rows+1);
-      ConstMatRowMapKokkosView j_local_const_d = ConstMatRowMapKokkosView(device_local_j_output, aijkok_local_output->csrmat.nnz());
-      ConstMatRowMapKokkosView i_nonlocal_const_d;
-      if (mpi) i_nonlocal_const_d = ConstMatRowMapKokkosView(device_nonlocal_i_ouput, local_rows+1);         
+      Kokkos::parallel_for(
+         Kokkos::TeamPolicy<>(exec, local_rows, Kokkos::AUTO()),
+         KOKKOS_LAMBDA(const KokkosTeamMemberType& t) {
+            const PetscInt i = t.league_rank();
+            const PetscInt ncols = device_local_i_output[i + 1] - device_local_i_output[i];
+            Kokkos::parallel_for(Kokkos::TeamThreadRange(t, ncols), [&](const PetscInt j) {
+               device_local_a_output[device_local_i_output[i] + j] = 0.0;
+            });
+      });
 
       // Only have to write a but have to be careful as we may not have diagonals in some rows
       // in the input, but they are in the output
@@ -1528,7 +1541,7 @@ PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *input_mat, const int 
             const PetscInt i = t.league_rank();
 
             // Still using i here (the local index into input)
-            const PetscInt ncols_local = device_local_i[i + 1] - device_local_i[i];         
+            const PetscInt ncols_local = device_local_i[i + 1] - device_local_i[i];
 
             // For over local columns - copy in input
             // We have to skip over the identity entries, which we know are always C points
@@ -1538,29 +1551,29 @@ PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *input_mat, const int 
                PetscInt offset = 0;
 
                // If we're at or after the diagonal and there isn't actually a diagonal in the input
-               // we know the output has a diagonal, so we skip ahead one in the output and 
+               // we know the output has a diagonal, so we skip ahead one in the output and
                // leave it unassigned in the output (it gets set to zero above)
-               if (j_local_const_d(i_local_const_d(i) + j) >= i && \
+               if (device_local_j_output[device_local_i_output[i] + j] >= i && \
                      !found_diag_row_d(i)) offset = 1;
 
-               a_local_d(i_local_const_d(i) + j + offset) = device_local_vals[device_local_i[i] + j];
-            });  
-           
+               device_local_a_output[device_local_i_output[i] + j + offset] = device_local_vals[device_local_i[i] + j];
+            });
+
             // For over nonlocal columns - copy in input - identical structure in the off-diag block
             if (mpi)
             {
-               PetscInt ncols_nonlocal = device_nonlocal_i[i + 1] - device_nonlocal_i[i];         
+               PetscInt ncols_nonlocal = device_nonlocal_i[i + 1] - device_nonlocal_i[i];
 
                Kokkos::parallel_for(
                   Kokkos::TeamVectorRange(t, ncols_nonlocal), [&](const PetscInt j) {
 
                   // We keep the existing local indices in the off-diagonal block here
                   // we have all the same columns as input and hence the same garray
-                  a_nonlocal_d(i_nonlocal_const_d(i) + j) = device_nonlocal_vals[device_nonlocal_i[i] + j];
-                        
-               });          
+                  device_nonlocal_a_output[device_nonlocal_i_output[i] + j] = device_nonlocal_vals[device_nonlocal_i[i] + j];
+
+               });
             }
-      });  
+      });
       
       Kokkos::fence();
 
@@ -1757,19 +1770,35 @@ PETSC_INTERN void MatAXPY_kokkos(Mat *Y, PetscScalar alpha, Mat *X)
    PetscInt *device_nonlocal_x_j = xkok_nonlocal->j_device_data();
    PetscInt *device_nonlocal_y_j = ykok_nonlocal->j_device_data();
 
+   // Get i pointers to drive the row loops
+   const PetscInt *device_nonlocal_y_i = nullptr, *device_nonlocal_x_i = nullptr;
+   PetscMemType mtype_axpy;
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_y, &device_nonlocal_y_i, NULL, NULL, &mtype_axpy));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_x_copy, &device_nonlocal_x_i, NULL, NULL, &mtype_axpy));
+
    // Rewrite the Y nonlocal indices to be global
    Kokkos::parallel_for(
-      Kokkos::RangePolicy<>(exec, 0, ykok_nonlocal->csrmat.nnz()), KOKKOS_LAMBDA(PetscInt i) { 
-
-         device_nonlocal_y_j[i] = colmap_input_d_y(device_nonlocal_y_j[i]);
-   }); 
+      Kokkos::TeamPolicy<>(exec, local_rows, Kokkos::AUTO()),
+      KOKKOS_LAMBDA(const KokkosTeamMemberType& t) {
+         const PetscInt i = t.league_rank();
+         const PetscInt ncols = device_nonlocal_y_i[i + 1] - device_nonlocal_y_i[i];
+         Kokkos::parallel_for(Kokkos::TeamThreadRange(t, ncols), [&](const PetscInt j) {
+            const PetscInt idx = device_nonlocal_y_i[i] + j;
+            device_nonlocal_y_j[idx] = colmap_input_d_y(device_nonlocal_y_j[idx]);
+         });
+   });
 
    // Rewrite the X nonlocal indices to be global
    Kokkos::parallel_for(
-      Kokkos::RangePolicy<>(exec, 0, xkok_nonlocal->csrmat.nnz()), KOKKOS_LAMBDA(PetscInt i) { 
-
-         device_nonlocal_x_j[i] = colmap_input_d_x(device_nonlocal_x_j[i]);
-   });    
+      Kokkos::TeamPolicy<>(exec, local_rows, Kokkos::AUTO()),
+      KOKKOS_LAMBDA(const KokkosTeamMemberType& t) {
+         const PetscInt i = t.league_rank();
+         const PetscInt ncols = device_nonlocal_x_i[i + 1] - device_nonlocal_x_i[i];
+         Kokkos::parallel_for(Kokkos::TeamThreadRange(t, ncols), [&](const PetscInt j) {
+            const PetscInt idx = device_nonlocal_x_i[i] + j;
+            device_nonlocal_x_j[idx] = colmap_input_d_x(device_nonlocal_x_j[idx]);
+         });
+   });
    // Ensure everything is finished before we hit the spadd below
    Kokkos::fence();
 
@@ -2057,16 +2086,11 @@ PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosVi
    {
       Mat_SeqAIJKokkos *aijkok_local_output = static_cast<Mat_SeqAIJKokkos *>((*output_mat)->spptr);
 
-      // Annoying we can't just call MatSeqAIJGetKokkosView
-      a_local_d = aijkok_local_output->a_dual.view_device();
-
-      // Annoyingly there isn't currently the ability to get views for i (or j)
+      // Get device pointers for the existing i and a arrays
       const PetscInt *device_local_i_output = nullptr;
+      PetscScalar *device_local_a_output = nullptr;
       PetscMemType mtype;
-      PetscCallVoid(MatSeqAIJGetCSRAndMemType(*output_mat, &device_local_i_output, NULL, NULL, &mtype));
-
-      // Have these point at the existing i pointers
-      ConstMatRowMapKokkosView i_local_const_d = ConstMatRowMapKokkosView(device_local_i_output, local_rows_row+1);     
+      PetscCallVoid(MatSeqAIJGetCSRAndMemType(*output_mat, &device_local_i_output, NULL, &device_local_a_output, &mtype));
 
       // Execute with scratch memory
       Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const KokkosTeamMemberType& t) {
@@ -2125,8 +2149,8 @@ PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosVi
             // of the exclusive scan for this index and the next one
             if (scratch_indices(j+1) > scratch_indices(j))
             {
-               // Be careful to use the correct i_idx_is_row index into i_local_const_d here
-               a_local_d(i_local_const_d(i_idx_is_row) + scratch_indices(j)) = device_local_vals[device_local_i[i] + j];            
+               // Be careful to use the correct i_idx_is_row index into device_local_i_output here
+               device_local_a_output[device_local_i_output[i_idx_is_row] + scratch_indices(j)] = device_local_vals[device_local_i[i] + j];
             }
          });
       });

--- a/src/PETSc_Helperk.kokkos.cxx
+++ b/src/PETSc_Helperk.kokkos.cxx
@@ -3,7 +3,6 @@
 #include <cmath>
 #include <iostream>
 #include <limits>
-#include <../src/mat/impls/aij/seq/aij.h>
 
 //------------------------------------------------------------------------------------------------------------------------
 

--- a/src/PMISR_Module.F90
+++ b/src/PMISR_Module.F90
@@ -2,7 +2,7 @@ module pmisr_module
 
    use iso_c_binding
    use petscmat
-   use petsc_helper, only: kokkos_debug
+   use petsc_helper, only: kokkos_debug, build_aij_nonlocal_sf_and_leaf
    use c_petsc_interfaces, only: pmisr_kokkos, copy_cf_markers_d2h, &
          vecscatter_mat_begin_c, vecscatter_mat_end_c, vecscatter_mat_restore_c, &
          allreducesum_petscint_mine, boolscatter_mat_begin_c, boolscatter_mat_end_c, &
@@ -32,30 +32,48 @@ module pmisr_module
       integer, dimension(:), allocatable, target, intent(inout) :: cf_markers_local
       logical, optional, intent(in)       :: zero_measure_c_point
 
-#if defined(PETSC_HAVE_KOKKOS)                     
-      integer(c_long_long) :: A_array
+      ! Build the PetscSF + leaf Vec once for strength_mat and pass them into
+      ! whichever path runs (Kokkos or CPU). Both consumers thread them down
+      ! through pmisr_kokkos / pmisr_cpu -> pmisr_existing_measure_cf_markers.
       PetscErrorCode :: ierr
+      MPIU_Comm :: MPI_COMM_MATRIX
+      integer :: comm_size, errcode
+      integer(c_long_long) :: sf_array, leaf_vec_array
+      type(tPetscSF) :: sf
+      type(tVec) :: leaf_vec
+
+#if defined(PETSC_HAVE_KOKKOS)
+      integer(c_long_long) :: A_array
       MatType :: mat_type
       integer :: pmis_int, zero_measure_c_point_int, seed_size, kfree, comm_rank, errorcode
       integer, dimension(:), allocatable :: seed
       PetscReal, dimension(:), allocatable, target :: measure_local
       PetscInt :: local_rows, local_cols
-      MPIU_Comm :: MPI_COMM_MATRIX    
       type(c_ptr)  :: measure_local_ptr, cf_markers_local_ptr
       integer, dimension(:), allocatable :: cf_markers_local_two
-#endif        
+#endif
       ! ~~~~~~~~~~
 
-#if defined(PETSC_HAVE_KOKKOS)    
+      call PetscObjectGetComm(strength_mat, MPI_COMM_MATRIX, ierr)
+      call MPI_Comm_size(MPI_COMM_MATRIX, comm_size, errcode)
+
+      sf_array = 0
+      leaf_vec_array = 0
+      if (comm_size /= 1) then
+         call build_aij_nonlocal_sf_and_leaf(strength_mat, sf, leaf_vec)
+         sf_array = sf%v
+         leaf_vec_array = leaf_vec%v
+      end if
+
+#if defined(PETSC_HAVE_KOKKOS)
 
       call MatGetType(strength_mat, mat_type, ierr)
       if (mat_type == MATMPIAIJKOKKOS .OR. mat_type == MATSEQAIJKOKKOS .OR. &
-            mat_type == MATAIJKOKKOS) then  
+            mat_type == MATAIJKOKKOS) then
 
-         call PetscObjectGetComm(strength_mat, MPI_COMM_MATRIX, ierr)    
-         call MPI_Comm_rank(MPI_COMM_MATRIX, comm_rank, errorcode)                  
+         call MPI_Comm_rank(MPI_COMM_MATRIX, comm_rank, errorcode)
 
-         A_array = strength_mat%v  
+         A_array = strength_mat%v
          pmis_int = 0
          if (pmis) pmis_int = 1
          zero_measure_c_point_int = 0
@@ -66,73 +84,81 @@ module pmisr_module
          ! Let's generate the random values on the host for now so they match
          ! for comparisons with pmisr_cpu
          call MatGetLocalSize(strength_mat, local_rows, local_cols, ierr)
-         allocate(measure_local(local_rows))   
+         allocate(measure_local(local_rows))
          call random_seed(size=seed_size)
          allocate(seed(seed_size))
          do kfree = 1, seed_size
             seed(kfree) = comm_rank + 1 + kfree
-         end do   
-         call random_seed(put=seed) 
+         end do
+         call random_seed(put=seed)
          ! Fill the measure with random numbers
          call random_number(measure_local)
-         deallocate(seed)   
-         
+         deallocate(seed)
+
          measure_local_ptr = c_loc(measure_local)
 
-         allocate(cf_markers_local(local_rows))  
+         allocate(cf_markers_local(local_rows))
          cf_markers_local_ptr = c_loc(cf_markers_local)
 
          ! Creates a cf_markers on the device
-         call pmisr_kokkos(A_array, max_luby_steps, pmis_int, measure_local_ptr, zero_measure_c_point_int)
+         call pmisr_kokkos(A_array, sf_array, leaf_vec_array, max_luby_steps, pmis_int, measure_local_ptr, zero_measure_c_point_int)
 
          ! If debugging do a comparison between CPU and Kokkos results
-         if (kokkos_debug()) then         
+         if (kokkos_debug()) then
 
-            ! Kokkos PMISR by default now doesn't copy back to the host, as any following ddc calls 
+            ! Kokkos PMISR by default now doesn't copy back to the host, as any following ddc calls
             ! use the device data
             call copy_cf_markers_d2h(cf_markers_local_ptr)
-            call pmisr_cpu(strength_mat, max_luby_steps, pmis, cf_markers_local_two, zero_measure_c_point)  
-            
-            if (any(cf_markers_local /= cf_markers_local_two)) then
+            call pmisr_cpu(strength_mat, sf_array, leaf_vec_array, max_luby_steps, pmis, &
+                           cf_markers_local_two, zero_measure_c_point)
 
-               ! do kfree = 1, local_rows
-               !    if (cf_markers_local(kfree) /= cf_markers_local_two(kfree)) then
-               !       print *, kfree, "no match", cf_markers_local(kfree), cf_markers_local_two(kfree)
-               !    end if
-               ! end do
+            if (any(cf_markers_local /= cf_markers_local_two)) then
                print *, "Kokkos and CPU versions of pmisr do not match"
-               call MPI_Abort(MPI_COMM_WORLD, MPI_ERR_OTHER, errorcode) 
+               call MPI_Abort(MPI_COMM_WORLD, MPI_ERR_OTHER, errorcode)
             end if
             deallocate(cf_markers_local_two)
          end if
 
       else
-         call pmisr_cpu(strength_mat, max_luby_steps, pmis, cf_markers_local, zero_measure_c_point)       
+         call pmisr_cpu(strength_mat, sf_array, leaf_vec_array, max_luby_steps, pmis, &
+                        cf_markers_local, zero_measure_c_point)
       end if
 #else
-      call pmisr_cpu(strength_mat, max_luby_steps, pmis, cf_markers_local, zero_measure_c_point)
-#endif        
+      call pmisr_cpu(strength_mat, sf_array, leaf_vec_array, max_luby_steps, pmis, &
+                     cf_markers_local, zero_measure_c_point)
+#endif
 
-      ! ~~~~~~ 
+      if (comm_size /= 1) then
+         call PetscSFDestroy(sf, ierr)
+         call VecDestroy(leaf_vec, ierr)
+      end if
+
+      ! ~~~~~~
 
    end subroutine pmisr
    
 ! -------------------------------------------------------------------------------------------------------------------------------
 
-   subroutine pmisr_cpu(strength_mat, max_luby_steps, pmis, cf_markers_local, zero_measure_c_point)
+   subroutine pmisr_cpu(strength_mat, sf_array, leaf_vec_array, max_luby_steps, pmis, &
+                        cf_markers_local, zero_measure_c_point)
 
       ! Let's do our own independent set with a Luby algorithm
       ! If PMIS is true, this is a traditional PMIS algorithm
       ! If PMIS is false, this is a PMISR
-      ! PMISR swaps the C-F definition compared to a PMIS and 
+      ! PMISR swaps the C-F definition compared to a PMIS and
       ! also checks the measure from smallest, rather than the largest
-      ! PMISR should give an Aff with no off-diagonal strong connections 
+      ! PMISR should give an Aff with no off-diagonal strong connections
       ! If you set positive max_luby_steps, it will avoid all parallel reductions
       ! by taking a fixed number of times in the Luby top loop
+      !
+      ! sf_array / leaf_vec_array are the PetscSF + leaf Vec built once by the
+      ! caller (Fortran pmisr wrapper) and shared with the kokkos path. Both
+      ! are zero in serial.
 
       ! ~~~~~~
 
       type(tMat), target, intent(in)      :: strength_mat
+      integer(c_long_long), intent(in)    :: sf_array, leaf_vec_array
       integer, intent(in)                 :: max_luby_steps
       logical, intent(in)                 :: pmis
       integer, dimension(:), allocatable, intent(inout) :: cf_markers_local
@@ -254,7 +280,8 @@ module pmisr_module
       ! in our Luby below
       if (pmis) measure_local = measure_local * (-1)
       
-      call pmisr_existing_measure_cf_markers(strength_mat, max_luby_steps, pmis, &
+      call pmisr_existing_measure_cf_markers(strength_mat, sf_array, leaf_vec_array, &
+               max_luby_steps, pmis, &
                measure_local, cf_markers_local, zero_measure_c_point)
 
       deallocate(measure_local)
@@ -267,15 +294,21 @@ module pmisr_module
 
    ! -------------------------------------------------------------------------------------------------------------------------------
 
-   subroutine pmisr_existing_measure_cf_markers(strength_mat, max_luby_steps, pmis, &
+   subroutine pmisr_existing_measure_cf_markers(strength_mat, sf_array, leaf_vec_array, &
+                  max_luby_steps, pmis, &
                   measure_local, cf_markers_local, zero_measure_c_point)
 
-      ! PMISR implementation that takes an existing measure_local and cf_markers_local 
+      ! PMISR implementation that takes an existing measure_local and cf_markers_local
       ! and then does the Luby algorithm to assign the rest of the CF markers
+      !
+      ! sf_array / leaf_vec_array are the PetscSF + leaf Vec built once by the
+      ! caller (Fortran pmisr/pmisr_cpu wrapper) and shared with the kokkos
+      ! path. Both are zero in serial.
 
       ! ~~~~~~
 
       type(tMat), target, intent(in)       :: strength_mat
+      integer(c_long_long), intent(in)     :: sf_array, leaf_vec_array
       integer, intent(in)                  :: max_luby_steps
       logical, intent(in)                  :: pmis
       PetscReal, dimension(:), allocatable :: measure_local
@@ -289,9 +322,9 @@ module pmisr_module
       PetscInt :: rows_ao, cols_ao, n_ad, n_ao
       PetscInt :: counter_undecided, counter_in_set_start, counter_parallel
       integer :: comm_size, loops_through
-      integer :: comm_rank, errorcode       
+      integer :: comm_rank, errorcode
       PetscErrorCode :: ierr
-      MPIU_Comm :: MPI_COMM_MATRIX      
+      MPIU_Comm :: MPI_COMM_MATRIX
       PFLARE_PETSCBOOL_C_TYPE, dimension(:), allocatable :: in_set_this_loop
       PFLARE_PETSCBOOL_C_TYPE, dimension(:), allocatable, target :: assigned_local, assigned_nonlocal
       type(c_ptr) :: measure_nonlocal_ptr=c_null_ptr, assigned_local_ptr=c_null_ptr, assigned_nonlocal_ptr=c_null_ptr
@@ -299,34 +332,35 @@ module pmisr_module
       type(tMat) :: Ad, Ao
       type(tVec) :: measure_vec
       PetscInt, dimension(:), pointer :: colmap
-      integer(c_long_long) :: A_array, vec_long
+      integer(c_long_long) :: vec_long
+      integer(c_long_long) :: A_array
       PetscInt, dimension(:), pointer :: ad_ia, ad_ja, ao_ia, ao_ja
       PetscInt :: shift = 0
       PetscBool :: symmetric = PETSC_FALSE, inodecompressed = PETSC_FALSE, done
-      logical :: zero_measure_c = .FALSE.  
+      logical :: zero_measure_c = .FALSE.
       PetscInt, parameter :: nz_ignore = -1, one=1, zero=0
 
-      ! ~~~~~~           
+      ! ~~~~~~
 
       if (present(zero_measure_c_point)) zero_measure_c = zero_measure_c_point
 
-      ! Get the comm size 
-      call PetscObjectGetComm(strength_mat, MPI_COMM_MATRIX, ierr)    
+      ! Get the comm size
+      call PetscObjectGetComm(strength_mat, MPI_COMM_MATRIX, ierr)
       call MPI_Comm_size(MPI_COMM_MATRIX, comm_size, errorcode)
-      ! Get the comm rank 
-      call MPI_Comm_rank(MPI_COMM_MATRIX, comm_rank, errorcode)      
+      ! Get the comm rank
+      call MPI_Comm_rank(MPI_COMM_MATRIX, comm_rank, errorcode)
 
       ! Get the local sizes
       call MatGetLocalSize(strength_mat, local_rows, local_cols, ierr)
-      call MatGetSize(strength_mat, global_rows, global_cols, ierr)      
-      call MatGetOwnershipRange(strength_mat, global_row_start, global_row_end_plus_one, ierr)   
+      call MatGetSize(strength_mat, global_rows, global_cols, ierr)
+      call MatGetOwnershipRange(strength_mat, global_row_start, global_row_end_plus_one, ierr)
 
       if (comm_size /= 1) then
-         call MatMPIAIJGetSeqAIJ(strength_mat, Ad, Ao, colmap, ierr) 
+         call MatMPIAIJGetSeqAIJ(strength_mat, Ad, Ao, colmap, ierr)
          ! We know the col size of Ao is the size of colmap, the number of non-zero offprocessor columns
-         call MatGetSize(Ao, rows_ao, cols_ao, ierr)    
+         call MatGetSize(Ao, rows_ao, cols_ao, ierr)
       else
-         Ad = strength_mat    
+         Ad = strength_mat
       end if
 
       ! ~~~~~~~~
@@ -351,7 +385,7 @@ module pmisr_module
       allocate(assigned_local(local_rows))
         
       ! ~~~~~~~~~~~~
-      ! Create parallel vec and scatter the measure
+      ! Create parallel vec and scatter the measure using the caller-supplied SF/leaf
       ! ~~~~~~~~~~~~
       if (comm_size/=1) then
 
@@ -359,14 +393,10 @@ module pmisr_module
          call VecCreateMPIWithArray(MPI_COMM_MATRIX, one, &
             local_rows, global_rows, measure_local, measure_vec, ierr)
 
-         A_array = strength_mat%v
          vec_long = measure_vec%v
-         ! We're just going to use the existing lvec to scatter the measure
-         ! Have to call restore after we're done with lvec (ie measure_nonlocal_ptr)
-         call vecscatter_mat_begin_c(A_array, vec_long, measure_nonlocal_ptr)
-         call vecscatter_mat_end_c(A_array, vec_long, measure_nonlocal_ptr)
-         ! This is the lvec so we have to make sure we don't do a matvec anywhere 
-         ! before calling restore
+         A_array = strength_mat%v
+         call vecscatter_mat_begin_c(sf_array, vec_long, leaf_vec_array)
+         call vecscatter_mat_end_c(sf_array, vec_long, leaf_vec_array, measure_nonlocal_ptr)
          call c_f_pointer(measure_nonlocal_ptr, measure_nonlocal, shape=[cols_ao])
 
          allocate(assigned_nonlocal(cols_ao))
@@ -471,7 +501,7 @@ module pmisr_module
          ! Start the async broadcast of assigned_local to assigned_nonlocal
          ! ~~~~~~~~~
          if (comm_size /= 1) then
-            call boolscatter_mat_begin_c(A_array, assigned_local_ptr, assigned_nonlocal_ptr)
+            call boolscatter_mat_begin_c(sf_array, assigned_local_ptr, assigned_nonlocal_ptr)
          end if
 
          ! Reset in_set_this_loop, which keeps track of which nodes are added to the set this loop
@@ -521,12 +551,12 @@ module pmisr_module
          ! Finish the async broadcast, assigned_nonlocal is now correct
          ! ~~~~~~~~
          if (comm_size /= 1) then
-            call boolscatter_mat_end_c(A_array, assigned_local_ptr, assigned_nonlocal_ptr)
-         end if     
-                 
+            call boolscatter_mat_end_c(sf_array, assigned_local_ptr, assigned_nonlocal_ptr)
+         end if
+
          ! ~~~~~~~~
          ! Now go through and do the non-local part of the matrix
-         ! ~~~~~~~~            
+         ! ~~~~~~~~
          if (comm_size /= 1) then
 
             node_loop: do ifree = 1, local_rows   
@@ -584,7 +614,7 @@ module pmisr_module
             ! After this comms finishes any local node in another processors halo 
             ! that has been assigned on another process will be correctly marked in assigned_local
             ! ~~~~~~~~~~~    
-            call boolscatter_mat_reverse_begin_c(A_array, assigned_local_ptr, assigned_nonlocal_ptr)       
+            call boolscatter_mat_reverse_begin_c(sf_array, assigned_local_ptr, assigned_nonlocal_ptr)
 
          end if
 
@@ -609,7 +639,7 @@ module pmisr_module
          ! ~~~~~~~~~
          if (comm_size /= 1) then
             ! Finishes the reduce LOR, assigned_local will now be correct
-            call boolscatter_mat_reverse_end_c(A_array, assigned_local_ptr, assigned_nonlocal_ptr)       
+            call boolscatter_mat_reverse_end_c(sf_array, assigned_local_ptr, assigned_nonlocal_ptr)
          end if
 
          ! ~~~~~~~~~~~~
@@ -650,17 +680,17 @@ module pmisr_module
       ! ~~~~~~~~~      
       deallocate(in_set_this_loop, assigned_local)
       if (comm_size/=1) then
-         call VecDestroy(measure_vec, ierr)    
-         ! Don't forget to restore on lvec from our matrix
-         call vecscatter_mat_restore_c(A_array, measure_nonlocal_ptr)             
+         call vecscatter_mat_restore_c(leaf_vec_array, measure_nonlocal_ptr)
+         call VecDestroy(measure_vec, ierr)
       end if
-      deallocate(assigned_nonlocal)    
+      deallocate(assigned_nonlocal)
 
-   end subroutine pmisr_existing_measure_cf_markers  
+   end subroutine pmisr_existing_measure_cf_markers
 
    ! -------------------------------------------------------------------------------------------------------------------------------
 
-   subroutine pmisr_existing_measure_implicit_transpose(strength_mat, max_luby_steps, pmis, &
+   subroutine pmisr_existing_measure_implicit_transpose(strength_mat, sf_array, leaf_vec_array, &
+                  max_luby_steps, pmis, &
                   measure_local, cf_markers_local, zero_measure_c_point)
 
       ! ~~~~~~~~~~~~~~~~~~~~~
@@ -694,6 +724,7 @@ module pmisr_module
       ! ~~~~~~
 
       type(tMat), target, intent(in)       :: strength_mat
+      integer(c_long_long), intent(in)     :: sf_array, leaf_vec_array
       integer, intent(in)                  :: max_luby_steps
       logical, intent(in)                  :: pmis
       PetscReal, dimension(:), allocatable :: measure_local
@@ -719,7 +750,8 @@ module pmisr_module
       type(tMat) :: Ad, Ao, Ad_spst, Ao_transpose
       type(tVec) :: measure_vec
       PetscInt, dimension(:), pointer :: colmap
-      integer(c_long_long) :: A_array, vec_long
+      integer(c_long_long) :: vec_long
+      integer(c_long_long) :: A_array
       PetscInt, dimension(:), pointer :: ad_ia, ad_ja, ao_ia, ao_ja
       PetscInt, dimension(:), pointer :: spst_ia, spst_ja, aot_ia, aot_ja
       PetscInt :: shift = 0
@@ -819,7 +851,7 @@ module pmisr_module
       allocate(veto_local(local_rows))
 
       ! ~~~~~~~~~~~~
-      ! Create parallel vec and scatter the measure
+      ! Create parallel vec and scatter the measure using the caller-supplied SF/leaf
       ! ~~~~~~~~~~~~
       if (comm_size/=1) then
 
@@ -827,14 +859,10 @@ module pmisr_module
          call VecCreateMPIWithArray(MPI_COMM_MATRIX, one, &
             local_rows, global_rows, measure_local, measure_vec, ierr)
 
-         A_array = strength_mat%v
          vec_long = measure_vec%v
-         ! We're just going to use the existing lvec to scatter the measure
-         ! Have to call restore after we're done with lvec (ie measure_nonlocal_ptr)
-         call vecscatter_mat_begin_c(A_array, vec_long, measure_nonlocal_ptr)
-         call vecscatter_mat_end_c(A_array, vec_long, measure_nonlocal_ptr)
-         ! This is the lvec so we have to make sure we don't do a matvec anywhere
-         ! before calling restore
+         A_array = strength_mat%v
+         call vecscatter_mat_begin_c(sf_array, vec_long, leaf_vec_array)
+         call vecscatter_mat_end_c(sf_array, vec_long, leaf_vec_array, measure_nonlocal_ptr)
          call c_f_pointer(measure_nonlocal_ptr, measure_nonlocal, shape=[cols_ao])
 
          allocate(assigned_nonlocal(cols_ao))
@@ -953,7 +981,7 @@ module pmisr_module
          ! and the non-local influence veto
          ! ~~~~~~~~~
          if (comm_size /= 1) then
-            call boolscatter_mat_begin_c(A_array, assigned_local_ptr, assigned_nonlocal_ptr)
+            call boolscatter_mat_begin_c(sf_array, assigned_local_ptr, assigned_nonlocal_ptr)
          end if
 
          ! ~~~~~~~~
@@ -998,7 +1026,7 @@ module pmisr_module
          ! Finish the async broadcast, assigned_nonlocal is now correct
          ! ~~~~~~~~
          if (comm_size /= 1) then
-            call boolscatter_mat_end_c(A_array, assigned_local_ptr, assigned_nonlocal_ptr)
+            call boolscatter_mat_end_c(sf_array, assigned_local_ptr, assigned_nonlocal_ptr)
          end if
 
          ! ~~~~~~~~
@@ -1041,9 +1069,9 @@ module pmisr_module
             ! After this, veto_local(i) is TRUE if any non-local transpose neighbour
             ! vetoes local node i
             ! ~~~~~~~~
-            call boolscatter_mat_reverse_begin_c(A_array, veto_local_ptr, veto_nonlocal_ptr)
+            call boolscatter_mat_reverse_begin_c(sf_array, veto_local_ptr, veto_nonlocal_ptr)
             ! Not sure we have any chance to overlap this with anything else
-            call boolscatter_mat_reverse_end_c(A_array, veto_local_ptr, veto_nonlocal_ptr)
+            call boolscatter_mat_reverse_end_c(sf_array, veto_local_ptr, veto_nonlocal_ptr)
 
             ! ~~~~~~~~
             ! Now the comms have finished, we know exactly which local nodes on this rank have no
@@ -1146,8 +1174,8 @@ module pmisr_module
             ! After this comms finishes any local node in another processors halo
             ! that has been assigned on another process will be correctly marked in assigned_local
             ! ~~~~~~~~~~~
-            call boolscatter_mat_reverse_begin_c(A_array, assigned_local_ptr, veto_nonlocal_ptr)
-            call boolscatter_mat_reverse_end_c(A_array, assigned_local_ptr, veto_nonlocal_ptr)
+            call boolscatter_mat_reverse_begin_c(sf_array, assigned_local_ptr, veto_nonlocal_ptr)
+            call boolscatter_mat_reverse_end_c(sf_array, assigned_local_ptr, veto_nonlocal_ptr)
 
             ! ~~~~~~~~~~~~~~
             ! 3. Non-local influences: we need to know which nonlocal nodes were just
@@ -1158,8 +1186,8 @@ module pmisr_module
 
             ! Reuse veto_nonlocal to receive the forward scatter result
             veto_nonlocal = .FALSE.
-            call boolscatter_mat_begin_c(A_array, in_set_ptr, veto_nonlocal_ptr)
-            call boolscatter_mat_end_c(A_array, in_set_ptr, veto_nonlocal_ptr)
+            call boolscatter_mat_begin_c(sf_array, in_set_ptr, veto_nonlocal_ptr)
+            call boolscatter_mat_end_c(sf_array, in_set_ptr, veto_nonlocal_ptr)
 
             ! Now veto_nonlocal(k) = TRUE means the remote node at nonlocal column k
             ! was just assigned this loop on its owning processor
@@ -1222,9 +1250,8 @@ module pmisr_module
 
       deallocate(in_set_this_loop, assigned_local, veto_local)
       if (comm_size/=1) then
+         call vecscatter_mat_restore_c(leaf_vec_array, measure_nonlocal_ptr)
          call VecDestroy(measure_vec, ierr)
-         ! Don't forget to restore on lvec from our matrix
-         call vecscatter_mat_restore_c(A_array, measure_nonlocal_ptr)
       end if
       deallocate(assigned_nonlocal, veto_nonlocal)
 

--- a/src/PMISR_Modulek.kokkos.cxx
+++ b/src/PMISR_Modulek.kokkos.cxx
@@ -1,7 +1,6 @@
 // Our petsc kokkos definitions - has to go first
 #include "kokkos_helper.hpp"
 #include <iostream>
-#include <../src/mat/impls/aij/seq/aij.h>
 
 // The definition of the device copy of the cf markers on a given level
 // is stored in Device_Datak.kokkos.cxx and imported as extern from

--- a/src/PMISR_Modulek.kokkos.cxx
+++ b/src/PMISR_Modulek.kokkos.cxx
@@ -2,7 +2,6 @@
 #include "kokkos_helper.hpp"
 #include <iostream>
 #include <../src/mat/impls/aij/seq/aij.h>
-#include <../src/mat/impls/aij/mpi/mpiaij.h>
 
 // The definition of the device copy of the cf markers on a given level
 // is stored in Device_Datak.kokkos.cxx and imported as extern from
@@ -13,7 +12,7 @@
 // PMISR implementation that takes an existing measure and cf_markers on the device
 // and then does the Luby algorithm to assign the rest of the CF markers
 // This mirrors the CPU version pmisr_existing_measure_cf_markers in PMISR_Module.F90
-PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, const int max_luby_steps, const int pmis_int, PetscScalarKokkosView &measure_local_d, intKokkosView &cf_markers_d, const int zero_measure_c_point_int)
+PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, PetscSF *sf, Vec *leaf_vec, const int max_luby_steps, const int pmis_int, PetscScalarKokkosView &measure_local_d, intKokkosView &cf_markers_d, const int zero_measure_c_point_int)
 {
 
    MPI_Comm MPI_COMM_MATRIX;
@@ -26,12 +25,10 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
    // Are we in parallel?
    const bool mpi = strcmp(mat_type, MATMPIAIJKOKKOS) == 0;
 
-   Mat_MPIAIJ *mat_mpi = nullptr;
    Mat mat_local = NULL, mat_nonlocal = NULL;
 
    if (mpi)
    {
-      mat_mpi = (Mat_MPIAIJ *)(*strength_mat)->data;
       PetscCallVoid(MatMPIAIJGetSeqAIJ(*strength_mat, &mat_local, &mat_nonlocal, NULL));
       PetscCallVoid(MatGetSize(mat_nonlocal, &rows_ao, &cols_ao));
    }
@@ -72,7 +69,7 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
    boolKokkosView mark_d("mark_d", local_rows);
    auto exec = PetscGetKokkosExecutionSpace();
 
-   // Scatter the measure using VecScatter (matching PETSc's own buffer management)
+   // Scatter the measure using the caller-supplied SF/leaf Vec
    if (mpi)
    {
       Vec measure_root_vec;
@@ -84,14 +81,14 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
          PetscCallVoid(VecRestoreKokkosViewWrite(measure_root_vec, &root_scalar_d));
       }
       // Ensure send/receive buffers are stable before Begin.
-      Kokkos::fence();      
-      PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, measure_root_vec, mat_mpi->lvec, INSERT_VALUES, SCATTER_FORWARD));
-      PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, measure_root_vec, mat_mpi->lvec, INSERT_VALUES, SCATTER_FORWARD));
+      Kokkos::fence();
+      PetscCallVoid(VecScatterBegin(*sf, measure_root_vec, *leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
+      PetscCallVoid(VecScatterEnd(*sf, measure_root_vec, *leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
       {
          ConstPetscScalarKokkosView lvec_scalar_d;
-         PetscCallVoid(VecGetKokkosView(mat_mpi->lvec, &lvec_scalar_d));
+         PetscCallVoid(VecGetKokkosView(*leaf_vec, &lvec_scalar_d));
          Kokkos::deep_copy(exec, measure_nonlocal_d, lvec_scalar_d);
-         PetscCallVoid(VecRestoreKokkosView(mat_mpi->lvec, &lvec_scalar_d));
+         PetscCallVoid(VecRestoreKokkosView(*leaf_vec, &lvec_scalar_d));
       }
       PetscCallVoid(VecDestroy(&measure_root_vec));
    }
@@ -154,11 +151,12 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
    // Now go through the outer Luby loop
    // ~~~~~~~~~~~~
 
-   // Create reusable Vecs for VecScatter inside the loop (cf_markers int → PetscScalar)
-   Vec scatter_root_vec = NULL, scatter_leaf_vec = NULL;
+   // Create reusable root Vec for VecScatter inside the loop (cf_markers int → PetscScalar).
+   // The caller-supplied *leaf_vec doubles as our leaf for the loop scatters.
+   Vec scatter_root_vec = NULL;
+   Vec scatter_leaf_vec = mpi ? *leaf_vec : NULL;
    if (mpi) {
       PetscCallVoid(MatCreateVecs(*strength_mat, &scatter_root_vec, NULL));
-      PetscCallVoid(VecDuplicate(mat_mpi->lvec, &scatter_leaf_vec));
    }
 
    // Let's keep track of how many times we go through the loops
@@ -194,7 +192,7 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
          }
          // Ensure the root buffer is no longer being written before Begin.
          Kokkos::fence();
-         PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
+         PetscCallVoid(VecScatterBegin(*sf, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
       }
 
 
@@ -262,7 +260,7 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
       if (mpi) {
 
          // Complete the in-flight forward scatter before reading the receive buffer.
-         PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
+         PetscCallVoid(VecScatterEnd(*sf, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
 
          // Convert PetscScalar → int after End, when the receive buffer is complete.
          {
@@ -381,7 +379,7 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
          }
          // Ensure send/receive buffers are stable before Begin.
          Kokkos::fence();
-         PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
+         PetscCallVoid(VecScatterBegin(*sf, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
 
          // While reverse scatter is in-flight, do local-only updates in cf_markers_temp_d.
          // This must not touch scatter_root_vec/scatter_leaf_vec.
@@ -411,7 +409,7 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
          });
 
          // Complete reverse scatter before reading reduced root buffer.
-         PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
+         PetscCallVoid(VecScatterEnd(*sf, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
 
          // Convert PetscScalar → int back to cf_markers_d after End.
          {
@@ -483,9 +481,8 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
    }
    while (counter_undecided != 0);
 
-   // Cleanup loop Vecs
+   // Cleanup loop Vecs (scatter_leaf_vec aliases the caller's *leaf_vec; do not destroy)
    PetscCallVoid(VecDestroy(&scatter_root_vec));
-   PetscCallVoid(VecDestroy(&scatter_leaf_vec));
 
    // ~~~~~~~~~
    // Now assign our final cf markers
@@ -520,7 +517,7 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
 // This version takes S (not S+S^T) as the strength matrix and handles the transpose
 // implicitly - it never forms the full parallel S+S^T
 // See the full comments in the CPU version pmisr_existing_measure_implicit_transpose
-PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength_mat, const int max_luby_steps, const int pmis_int, PetscScalarKokkosView &measure_local_d, intKokkosView &cf_markers_d, const int zero_measure_c_point_int)
+PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength_mat, PetscSF *sf, Vec *leaf_vec, const int max_luby_steps, const int pmis_int, PetscScalarKokkosView &measure_local_d, intKokkosView &cf_markers_d, const int zero_measure_c_point_int)
 {
 
    MPI_Comm MPI_COMM_MATRIX;
@@ -533,7 +530,6 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
    // Are we in parallel?
    const bool mpi = strcmp(mat_type, MATMPIAIJKOKKOS) == 0;
 
-   Mat_MPIAIJ *mat_mpi = nullptr;
    Mat mat_local = NULL, mat_nonlocal = NULL, mat_local_spst = NULL, mat_nonlocal_transpose = NULL;
 
    // ~~~~~~~~~~~~~~~~~~~~~
@@ -559,7 +555,6 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
 
    if (mpi)
    {
-      mat_mpi = (Mat_MPIAIJ *)(*strength_mat)->data;
       PetscCallVoid(MatMPIAIJGetSeqAIJ(*strength_mat, &mat_local, &mat_nonlocal, NULL));
       PetscCallVoid(MatGetSize(mat_nonlocal, &rows_ao, &cols_ao));
       mat_nonlocal_kok = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal->spptr);
@@ -643,14 +638,14 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
          PetscCallVoid(VecRestoreKokkosViewWrite(measure_root_vec, &root_scalar_d));
       }
       // Ensure send/receive buffers are stable before Begin.
-      Kokkos::fence();      
-      PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, measure_root_vec, mat_mpi->lvec, INSERT_VALUES, SCATTER_FORWARD));
-      PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, measure_root_vec, mat_mpi->lvec, INSERT_VALUES, SCATTER_FORWARD));
+      Kokkos::fence();
+      PetscCallVoid(VecScatterBegin(*sf, measure_root_vec, *leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
+      PetscCallVoid(VecScatterEnd(*sf, measure_root_vec, *leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
       {
          ConstPetscScalarKokkosView lvec_scalar_d;
-         PetscCallVoid(VecGetKokkosView(mat_mpi->lvec, &lvec_scalar_d));
+         PetscCallVoid(VecGetKokkosView(*leaf_vec, &lvec_scalar_d));
          Kokkos::deep_copy(exec, measure_nonlocal_d, lvec_scalar_d);
-         PetscCallVoid(VecRestoreKokkosView(mat_mpi->lvec, &lvec_scalar_d));
+         PetscCallVoid(VecRestoreKokkosView(*leaf_vec, &lvec_scalar_d));
       }
       PetscCallVoid(VecDestroy(&measure_root_vec));
    }
@@ -715,11 +710,12 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
    // Now go through the outer Luby loop
    // ~~~~~~~~~~~~
 
-   // Create reusable Vecs for VecScatter inside the loop
-   Vec scatter_root_vec = NULL, scatter_leaf_vec = NULL;
+   // Create reusable root Vec for VecScatter inside the loop. The caller-supplied
+   // *leaf_vec doubles as our leaf for every loop scatter.
+   Vec scatter_root_vec = NULL;
+   Vec scatter_leaf_vec = mpi ? *leaf_vec : NULL;
    if (mpi) {
       PetscCallVoid(MatCreateVecs(*strength_mat, &scatter_root_vec, NULL));
-      PetscCallVoid(VecDuplicate(mat_mpi->lvec, &scatter_leaf_vec));
    }
 
    // Let's keep track of how many times we go through the loops
@@ -754,8 +750,8 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
          }
          // Ensure send/receive buffers are stable before Begin.
          Kokkos::fence();         
-         PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
-         PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
+         PetscCallVoid(VecScatterBegin(*sf, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
+         PetscCallVoid(VecScatterEnd(*sf, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
          // Convert PetscScalar → int
          {
             ConstPetscScalarKokkosView leaf_scalar_d;
@@ -904,8 +900,8 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
          }
          // Ensure send/receive buffers are stable before Begin.
          Kokkos::fence();         
-         PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
-         PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
+         PetscCallVoid(VecScatterBegin(*sf, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
+         PetscCallVoid(VecScatterEnd(*sf, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
          {
             ConstPetscScalarKokkosView root_scalar_d;
             PetscCallVoid(VecGetKokkosView(scatter_root_vec, &root_scalar_d));
@@ -1022,8 +1018,8 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
          }
          // Ensure send/receive buffers are stable before Begin.
          Kokkos::fence();         
-         PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
-         PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
+         PetscCallVoid(VecScatterBegin(*sf, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
+         PetscCallVoid(VecScatterEnd(*sf, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
          {
             ConstPetscScalarKokkosView leaf_scalar_d;
             PetscCallVoid(VecGetKokkosView(scatter_leaf_vec, &leaf_scalar_d));
@@ -1084,8 +1080,8 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
          }
          // Ensure send/receive buffers are stable before Begin.
          Kokkos::fence();         
-         PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
-         PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
+         PetscCallVoid(VecScatterBegin(*sf, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
+         PetscCallVoid(VecScatterEnd(*sf, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
          {
             ConstPetscScalarKokkosView root_scalar_d;
             PetscCallVoid(VecGetKokkosView(scatter_root_vec, &root_scalar_d));
@@ -1192,9 +1188,8 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
    }
    while (counter_undecided != 0);
 
-   // Cleanup loop Vecs
+   // Cleanup loop Vecs (scatter_leaf_vec aliases the caller's *leaf_vec; do not destroy)
    PetscCallVoid(VecDestroy(&scatter_root_vec));
-   PetscCallVoid(VecDestroy(&scatter_leaf_vec));
 
    // Cleanup the local transposes
    if (destroy_spst) PetscCallVoid(MatDestroy(&mat_local_spst));
@@ -1231,12 +1226,11 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
 // PMISR cf splitting but on the device
 // This no longer copies back to the host pointer cf_markers_local at the end
 // You have to explicitly call copy_cf_markers_d2h(cf_markers_local) to do this
-PETSC_INTERN void pmisr_kokkos(Mat *strength_mat, const int max_luby_steps, const int pmis_int, PetscReal *measure_local, const int zero_measure_c_point_int)
+PETSC_INTERN void pmisr_kokkos(Mat *strength_mat, PetscSF *sf, Vec *leaf_vec, const int max_luby_steps, const int pmis_int, PetscReal *measure_local, const int zero_measure_c_point_int)
 {
 
    MPI_Comm MPI_COMM_MATRIX;
    PetscInt local_rows, local_cols, global_rows, global_cols;
-   PetscInt rows_ao, cols_ao;
    MatType mat_type;
 
    PetscCallVoid(MatGetType(*strength_mat, &mat_type));
@@ -1248,7 +1242,6 @@ PETSC_INTERN void pmisr_kokkos(Mat *strength_mat, const int max_luby_steps, cons
    if (mpi)
    {
       PetscCallVoid(MatMPIAIJGetSeqAIJ(*strength_mat, &mat_local, &mat_nonlocal, NULL));
-      PetscCallVoid(MatGetSize(mat_nonlocal, &rows_ao, &cols_ao));
    }
    else
    {
@@ -1310,8 +1303,8 @@ PETSC_INTERN void pmisr_kokkos(Mat *strength_mat, const int max_luby_steps, cons
       if (pmis_int == 1) measure_local_d(i) *= -1;
    });
 
-   // Call the existing measure cf markers function
-   pmisr_existing_measure_cf_markers_kokkos(strength_mat, max_luby_steps, pmis_int, measure_local_d, cf_markers_d, zero_measure_c_point_int);
+   // The caller (Fortran pmisr wrapper) owns the PetscSF + leaf Vec; just forward.
+   pmisr_existing_measure_cf_markers_kokkos(strength_mat, sf, leaf_vec, max_luby_steps, pmis_int, measure_local_d, cf_markers_d, zero_measure_c_point_int);
 
    // If PMIS then we swap the CF markers from PMISR
    if (pmis_int) {

--- a/src/PMISR_Modulek.kokkos.cxx
+++ b/src/PMISR_Modulek.kokkos.cxx
@@ -547,8 +547,6 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
    // for the non-local components)
    // ~~~~~~~~~~~~~~~~~~~~~
 
-   Mat_SeqAIJKokkos *mat_nonlocal_kok, *mat_local_kok;
-   PetscInt zero = 0;
    bool destroy_nonlocal_transpose = false;
    bool destroy_spst = false;
 
@@ -556,9 +554,15 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
    {
       PetscCallVoid(MatMPIAIJGetSeqAIJ(*strength_mat, &mat_local, &mat_nonlocal, NULL));
       PetscCallVoid(MatGetSize(mat_nonlocal, &rows_ao, &cols_ao));
-      mat_nonlocal_kok = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal->spptr);
+      // Read the nnz from the host i pointer
+      PetscInt n;
+      PetscBool symmetric = PETSC_FALSE, inodecompressed = PETSC_FALSE, done;
+      const PetscInt *ao_ia;
+      PetscCallVoid(MatGetRowIJ(mat_nonlocal, 0, symmetric, inodecompressed, &n, &ao_ia, NULL, &done));
+      const PetscInt nonlocal_nnz = ao_ia[n];
+      PetscCallVoid(MatRestoreRowIJ(mat_nonlocal, 0, symmetric, inodecompressed, &n, &ao_ia, NULL, &done));
       // The transpose can crash if mat_nonlocal is empty
-      if (mat_nonlocal_kok->csrmat.nnz() > zero)
+      if (nonlocal_nnz > 0)
       {
          PetscCallVoid(MatTranspose(mat_nonlocal, MAT_INITIAL_MATRIX, &mat_nonlocal_transpose));
          destroy_nonlocal_transpose = true;
@@ -568,7 +572,6 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
    {
       mat_local = *strength_mat;
    }
-   mat_local_kok = static_cast<Mat_SeqAIJKokkos *>(mat_local->spptr);
 
    // Get the comm
    PetscCallVoid(PetscObjectGetComm((PetscObject)*strength_mat, &MPI_COMM_MATRIX));
@@ -577,13 +580,24 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
    // This returns the global index of the local portion of the matrix
    PetscCallVoid(MatGetOwnershipRange(*strength_mat, &global_row_start, &global_row_end_plus_one));
 
+   // Read the nnz from the host i pointer of the local block
+   PetscInt local_nnz;
+   {
+      PetscInt n;
+      PetscBool symmetric = PETSC_FALSE, inodecompressed = PETSC_FALSE, done;
+      const PetscInt *ad_ia;
+      PetscCallVoid(MatGetRowIJ(mat_local, 0, symmetric, inodecompressed, &n, &ad_ia, NULL, &done));
+      local_nnz = ad_ia[n];
+      PetscCallVoid(MatRestoreRowIJ(mat_local, 0, symmetric, inodecompressed, &n, &ad_ia, NULL, &done));
+   }
+
    // ~~~~~~~~~~~~
    // Form the local S+S^T and get CSR pointers
    // We explicitly compute the local part of S+S^T so we don't have to
    // match the row/column indices - could do this as a symbolic as we don't need the values
    // ~~~~~~~~~~~~
    PetscScalar one = 1.0;
-   if (mat_local_kok->csrmat.nnz() > zero)
+   if (local_nnz > 0)
    {
       PetscCallVoid(MatTranspose(mat_local, MAT_INITIAL_MATRIX, &mat_local_spst));
       PetscCallVoid(MatAXPY(mat_local_spst, one, mat_local, DIFFERENT_NONZERO_PATTERN));

--- a/src/PMISR_Modulek.kokkos.cxx
+++ b/src/PMISR_Modulek.kokkos.cxx
@@ -44,13 +44,12 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, Pe
    PetscCallVoid(MatGetOwnershipRange(*strength_mat, &global_row_start, &global_row_end_plus_one));
 
    // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
+   // Get pointers to the i,j on the device
    // ~~~~~~~~~~~~
    const PetscInt *device_local_i = nullptr, *device_local_j = nullptr, *device_nonlocal_i = nullptr, *device_nonlocal_j = nullptr;
    PetscMemType mtype;
-   PetscScalar *device_local_vals = nullptr, *device_nonlocal_vals = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, &device_local_vals, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, &device_nonlocal_vals, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, NULL, &mtype));
 
    intKokkosView cf_markers_nonlocal_d;
    // Scratch buffer used for local update bookkeeping during overlap with reverse scatter.
@@ -1267,13 +1266,12 @@ PETSC_INTERN void pmisr_kokkos(Mat *strength_mat, PetscSF *sf, Vec *leaf_vec, co
    PetscCallVoid(MatGetSize(*strength_mat, &global_rows, &global_cols));
 
    // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
+   // Get pointers to the i,j on the device
    // ~~~~~~~~~~~~
    const PetscInt *device_local_i = nullptr, *device_local_j = nullptr, *device_nonlocal_i = nullptr, *device_nonlocal_j = nullptr;
    PetscMemType mtype;
-   PetscScalar *device_local_vals = nullptr, *device_nonlocal_vals = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, &device_local_vals, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, &device_nonlocal_vals, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, NULL, &mtype));
 
    // Device memory for the global variable cf_markers_local_d - be careful these aren't petsc ints
    cf_markers_local_d = intKokkosView("cf_markers_local_d", local_rows);

--- a/src/SAI_Zk.kokkos.cxx
+++ b/src/SAI_Zk.kokkos.cxx
@@ -719,13 +719,6 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
       });
    }
 
-   // ~~~~~~~~~~~~~~
-   // Mark Z's device data as modified
-   // ~~~~~~~~~~~~~~
-   Mat_SeqAIJKokkos *aijkok_local_z = static_cast<Mat_SeqAIJKokkos *>(mat_local_z->spptr);
-   Mat_SeqAIJKokkos *aijkok_nonlocal_z = NULL;
-   if (mpi) aijkok_nonlocal_z = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_z->spptr);
-
    Kokkos::fence();
 
    // Restore the read-only input views

--- a/src/SAI_Zk.kokkos.cxx
+++ b/src/SAI_Zk.kokkos.cxx
@@ -210,42 +210,51 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
    }
 
    // ~~~~~~~~~~~~~~
-   // Get device CSR pointers for all matrices
+   // Get device CSR pointers for i,j and Kokkos views to the values
    // ~~~~~~~~~~~~~~
    PetscMemType mtype;
 
    // Submatrix (non-local rows of A_ff)
    const PetscInt *device_submat_i = nullptr, *device_submat_j = nullptr;
-   PetscScalar *device_submat_vals = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(submatrices[0], &device_submat_i, &device_submat_j, &device_submat_vals, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(submatrices[0], &device_submat_i, &device_submat_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_submat_vals;
+   PetscCallVoid(MatSeqAIJGetKokkosView(submatrices[0], &device_submat_vals));
 
    // A_ff local + nonlocal
    const PetscInt *device_local_i_ff = nullptr, *device_local_j_ff = nullptr;
    const PetscInt *device_nonlocal_i_ff = nullptr, *device_nonlocal_j_ff = nullptr;
-   PetscScalar *device_local_vals_ff = nullptr, *device_nonlocal_vals_ff = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_ff, &device_local_i_ff, &device_local_j_ff, &device_local_vals_ff, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_ff, &device_nonlocal_i_ff, &device_nonlocal_j_ff, &device_nonlocal_vals_ff, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_ff, &device_local_i_ff, &device_local_j_ff, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_ff, &device_nonlocal_i_ff, &device_nonlocal_j_ff, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals_ff;
+   Kokkos::View<const PetscScalar *> device_nonlocal_vals_ff;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local_ff, &device_local_vals_ff));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal_ff, &device_nonlocal_vals_ff));
 
    // A_cf local + nonlocal
    const PetscInt *device_local_i_cf = nullptr, *device_local_j_cf = nullptr;
    const PetscInt *device_nonlocal_i_cf = nullptr, *device_nonlocal_j_cf = nullptr;
-   PetscScalar *device_local_vals_cf = nullptr, *device_nonlocal_vals_cf = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_cf, &device_local_i_cf, &device_local_j_cf, &device_local_vals_cf, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_cf, &device_nonlocal_i_cf, &device_nonlocal_j_cf, &device_nonlocal_vals_cf, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_cf, &device_local_i_cf, &device_local_j_cf, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_cf, &device_nonlocal_i_cf, &device_nonlocal_j_cf, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals_cf;
+   Kokkos::View<const PetscScalar *> device_nonlocal_vals_cf;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local_cf, &device_local_vals_cf));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal_cf, &device_nonlocal_vals_cf));
 
-   // Sparsity matrix local + nonlocal
+   // Sparsity matrix local + nonlocal (values not used in this routine)
    const PetscInt *device_local_i_sparsity = nullptr, *device_local_j_sparsity = nullptr;
    const PetscInt *device_nonlocal_i_sparsity = nullptr, *device_nonlocal_j_sparsity = nullptr;
-   PetscScalar *device_local_vals_sparsity = nullptr, *device_nonlocal_vals_sparsity = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_sparsity, &device_local_i_sparsity, &device_local_j_sparsity, &device_local_vals_sparsity, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_sparsity, &device_nonlocal_i_sparsity, &device_nonlocal_j_sparsity, &device_nonlocal_vals_sparsity, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_sparsity, &device_local_i_sparsity, &device_local_j_sparsity, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_sparsity, &device_nonlocal_i_sparsity, &device_nonlocal_j_sparsity, NULL, &mtype));
 
-   // Z output local + nonlocal
+   // Z output local + nonlocal - every entry is overwritten by the solve below
    const PetscInt *device_local_i_z = nullptr, *device_local_j_z = nullptr;
    const PetscInt *device_nonlocal_i_z = nullptr, *device_nonlocal_j_z = nullptr;
-   PetscScalar *device_local_vals_z = nullptr, *device_nonlocal_vals_z = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_z, &device_local_i_z, &device_local_j_z, &device_local_vals_z, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_z, &device_nonlocal_i_z, &device_nonlocal_j_z, &device_nonlocal_vals_z, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_z, &device_local_i_z, &device_local_j_z, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_z, &device_nonlocal_i_z, &device_nonlocal_j_z, NULL, &mtype));
+   Kokkos::View<PetscScalar *> device_local_vals_z;
+   Kokkos::View<PetscScalar *> device_nonlocal_vals_z;
+   PetscCallVoid(MatSeqAIJGetKokkosViewWrite(mat_local_z, &device_local_vals_z));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosViewWrite(mat_nonlocal_z, &device_nonlocal_vals_z));
 
    // ~~~~~~~~~~~~~~
    // Find per-row j_size = local_nnz + nonlocal_nnz and split into:
@@ -394,7 +403,7 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
       Kokkos::parallel_for(Kokkos::TeamThreadRange(member, ncols_local_cf),
          [&](const PetscInt k) {
             PetscInt col_local = device_local_j_cf[device_local_i_cf[i] + k];
-            PetscScalar val = device_local_vals_cf[device_local_i_cf[i] + k];
+            PetscScalar val = device_local_vals_cf(device_local_i_cf[i] + k);
             PetscInt global_col = col_local + global_row_start_ff;
             PetscInt pos = binary_search_sorted(j_global, j_size, global_col);
             if (pos >= 0) rhs(pos) = -val;
@@ -404,7 +413,7 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
          Kokkos::parallel_for(Kokkos::TeamThreadRange(member, ncols_nonlocal_cf),
             [&](const PetscInt k) {
                PetscInt col_nonlocal = device_nonlocal_j_cf[device_nonlocal_i_cf[i] + k];
-               PetscScalar val = device_nonlocal_vals_cf[device_nonlocal_i_cf[i] + k];
+               PetscScalar val = device_nonlocal_vals_cf(device_nonlocal_i_cf[i] + k);
                PetscInt global_col = colmap_cf_d(col_nonlocal);
                PetscInt pos = binary_search_sorted(j_global, j_size, global_col);
                if (pos >= 0) rhs(pos) = -val;
@@ -432,7 +441,7 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
                for (PetscInt k = 0; k < ncols; k++) {
                   PetscInt global_col = device_local_j_ff[device_local_i_ff[local_row] + k]
                                         + global_row_start_ff;
-                  PetscScalar val = device_local_vals_ff[device_local_i_ff[local_row] + k];
+                  PetscScalar val = device_local_vals_ff(device_local_i_ff[local_row] + k);
                   PetscInt pos = binary_search_sorted(j_global, j_size, global_col);
                   if (pos >= 0) dense_mat(pos, j) = val;
                }
@@ -443,8 +452,8 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
                   for (PetscInt k = 0; k < ncols_nl; k++) {
                      PetscInt col_nonlocal = device_nonlocal_j_ff[
                         device_nonlocal_i_ff[local_row] + k];
-                     PetscScalar val = device_nonlocal_vals_ff[
-                        device_nonlocal_i_ff[local_row] + k];
+                     PetscScalar val = device_nonlocal_vals_ff(
+                        device_nonlocal_i_ff[local_row] + k);
                      PetscInt global_col = colmap_ff_d(col_nonlocal);
                      PetscInt pos = binary_search_sorted(j_global, j_size, global_col);
                      if (pos >= 0) dense_mat(pos, j) = val;
@@ -460,8 +469,8 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
                for (PetscInt k = 0; k < ncols_sub; k++) {
                   PetscInt submat_col = device_submat_j[
                      device_submat_i[submat_row] + k];
-                  PetscScalar val = device_submat_vals[
-                     device_submat_i[submat_row] + k];
+                  PetscScalar val = device_submat_vals(
+                     device_submat_i[submat_row] + k);
                   PetscInt global_col = col_indices_off_proc_d(submat_col);
                   PetscInt pos = binary_search_sorted(j_global, j_size, global_col);
                   if (pos >= 0) dense_mat(pos, j) = val;
@@ -491,10 +500,10 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
          [&](const PetscInt k) {
             PetscInt orig_pos = j_perm(k);
             if (orig_pos < ncols_local_sparsity)
-               device_local_vals_z[device_local_i_z[i] + orig_pos] = sol(k);
+               device_local_vals_z(device_local_i_z[i] + orig_pos) = sol(k);
             else if (mpi)
-               device_nonlocal_vals_z[device_nonlocal_i_z[i]
-                  + (orig_pos - ncols_local_sparsity)] = sol(k);
+               device_nonlocal_vals_z(device_nonlocal_i_z[i]
+                  + (orig_pos - ncols_local_sparsity)) = sol(k);
          });
    });
 
@@ -609,7 +618,7 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
                   for (PetscInt k = 0; k < ncols; k++) {
                      PetscInt global_col = device_local_j_ff[device_local_i_ff[local_row] + k]
                                            + global_row_start_ff;
-                     PetscScalar val = device_local_vals_ff[device_local_i_ff[local_row] + k];
+                     PetscScalar val = device_local_vals_ff(device_local_i_ff[local_row] + k);
                      PetscInt pos = binary_search_sorted(j_global, j_size, global_col);
                      if (pos >= 0) dense_mat(pos, j) = val;
                   }
@@ -619,8 +628,8 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
                      for (PetscInt k = 0; k < ncols_nl; k++) {
                         PetscInt col_nonlocal = device_nonlocal_j_ff[
                            device_nonlocal_i_ff[local_row] + k];
-                        PetscScalar val = device_nonlocal_vals_ff[
-                           device_nonlocal_i_ff[local_row] + k];
+                        PetscScalar val = device_nonlocal_vals_ff(
+                           device_nonlocal_i_ff[local_row] + k);
                         PetscInt global_col = colmap_ff_d(col_nonlocal);
                         PetscInt pos = binary_search_sorted(j_global, j_size, global_col);
                         if (pos >= 0) dense_mat(pos, j) = val;
@@ -702,10 +711,10 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
             [&](const PetscInt k) {
                PetscInt orig_pos = j_perm(k);
                if (orig_pos < ncols_local_sparsity)
-                  device_local_vals_z[device_local_i_z[i] + orig_pos] = sol(k);
+                  device_local_vals_z(device_local_i_z[i] + orig_pos) = sol(k);
                else if (mpi)
-                  device_nonlocal_vals_z[device_nonlocal_i_z[i]
-                     + (orig_pos - ncols_local_sparsity)] = sol(k);
+                  device_nonlocal_vals_z(device_nonlocal_i_z[i]
+                     + (orig_pos - ncols_local_sparsity)) = sol(k);
             });
       });
    }
@@ -719,18 +728,17 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
 
    Kokkos::fence();
 
-   // Have to specify we've modified data on the device
-   aijkok_local_z->a_dual.clear_sync_state();
-   aijkok_local_z->a_dual.modify_device();
-   aijkok_local_z->transpose_updated = PETSC_FALSE;
-   aijkok_local_z->hermitian_updated = PETSC_FALSE;
-   if (mpi)
-   {
-      aijkok_nonlocal_z->a_dual.clear_sync_state();
-      aijkok_nonlocal_z->a_dual.modify_device();
-      aijkok_nonlocal_z->transpose_updated = PETSC_FALSE;
-      aijkok_nonlocal_z->hermitian_updated = PETSC_FALSE;
-   }
+   // Restore the read-only input views
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(submatrices[0], &device_submat_vals));
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local_ff, &device_local_vals_ff));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal_ff, &device_nonlocal_vals_ff));
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local_cf, &device_local_vals_cf));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal_cf, &device_nonlocal_vals_cf));
+
+   // The matching restore handles MatSeqAIJKokkosModifyDevice (clears sync state,
+   // marks device modified, invalidates transpose/hermitian, bumps object state).
+   PetscCallVoid(MatSeqAIJRestoreKokkosViewWrite(mat_local_z, &device_local_vals_z));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosViewWrite(mat_nonlocal_z, &device_nonlocal_vals_z));
 
    // ~~~~~~~~~~~~~~
    // Cleanup


### PR DESCRIPTION
This PR modifies PFLARE so that the build does not depend on the PETSc source outside of the PETSc include/ and lib/, i.e., PFLARE no longer needs to vendor the PETSc source to build. 