### PR TITLE
Add PCPFLAREINVGetInverseMat to expose the underlying inverse matrix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,8 @@ Explore
 
 Build
 1. In top repo directory: `make -j3 build_tests`
-2. Rule: fix all compile warnings.
+2. If Python code changed, in the top repo directory: `make python`
+3. Rule: fix all compile warnings.
 
 Tests
 1. Run the test targets below once. Trust `make`'s exit code: 0 means all tests passed; any failure breaks the run with a non-zero code and prints the error to the terminal. Don't re-run to grep the output.

--- a/include/pflare.h
+++ b/include/pflare.h
@@ -57,6 +57,9 @@ PETSC_EXTERN PetscErrorCode PCPFLAREINVGetPolyOrder(PC, PetscInt *);
 PETSC_EXTERN PetscErrorCode PCPFLAREINVGetSparsityOrder(PC, PetscInt *);
 PETSC_EXTERN PetscErrorCode PCPFLAREINVGetType(PC, PCPFLAREINVType *);
 PETSC_EXTERN PetscErrorCode PCPFLAREINVGetMatrixFree(PC, PetscBool *);
+/* Returns the underlying approximate-inverse matrix (borrowed reference - do not
+   destroy; only valid after PCSetUp and until the next setup/reset) */
+PETSC_EXTERN PetscErrorCode PCPFLAREINVGetInverseMat(PC, Mat *);
 /* Define PCPFLAREINV set routines */
 PETSC_EXTERN PetscErrorCode PCPFLAREINVSetPolyOrder(PC, PetscInt);
 PETSC_EXTERN PetscErrorCode PCPFLAREINVSetSparsityOrder(PC, PetscInt);

--- a/python/ex_pcpflareinv_options.py
+++ b/python/ex_pcpflareinv_options.py
@@ -2,10 +2,15 @@
 Tests the direct Python API for PCPFLAREINV get/set option functions introduced in
 pflare.py (backed by PCPFLAREINV_Interfaces.F90).
 
-Two checks are performed:
+Checks performed:
   1. Round-trip: set a value via the direct API, get it back, verify it matches.
   2. Functional: configure a Newton matrix-free PCPFLAREINV via the direct API,
      run a solve, verify convergence.
+  3. PCPFLAREINVGetInverseMat: the accessor returns None before PCSetUp; after
+     setup it returns the underlying approximate-inverse matrix (assembled aij
+     or a matrix-free shell) which the user can operate on directly, and which
+     is a refcounted borrowed reference (deleting it must not free the PC's
+     matrix).
 '''
 
 import sys
@@ -120,6 +125,52 @@ check('reuse_poly_coeffs', pflare.pcpflareinv_get_reuse_poly_coeffs(pc), True)
 
 pflare.pcpflareinv_set_reuse_poly_coeffs(pc, False)
 check('reuse_poly_coeffs_false', pflare.pcpflareinv_get_reuse_poly_coeffs(pc), False)
+
+# -----------------------------------------------------------------------
+# PCPFLAREINVGetInverseMat: access the underlying approximate-inverse matrix
+# -----------------------------------------------------------------------
+
+# Assembled inverse on a fresh PC
+pc_inv = PETSc.PC().create(comm=comm)
+pc_inv.setType('pflareinv')
+pc_inv.setOperators(A, A)
+pflare.pcpflareinv_set_type(pc_inv, pflare.PFLAREINV_POWER)
+pflare.pcpflareinv_set_matrix_free(pc_inv, False)
+
+# Before PCSetUp the inverse matrix does not exist yet
+check('inverse_mat_pre_setup_none', pflare.pcpflareinv_get_inverse_mat(pc_inv), None)
+
+pc_inv.setUp()
+M = pflare.pcpflareinv_get_inverse_mat(pc_inv)
+check('inverse_mat_not_none', M is not None, True)
+if M is not None:
+    check('inverse_mat_is_aij', 'aij' in M.getType().lower(), True)
+    check('inverse_mat_size', M.getSize(), A.getSize())
+
+    # Use the returned matrix directly (Schur-complement-style matrix product)
+    M2 = M.matMult(M)
+    check('inverse_mat_matmult_size', M2.getSize(), A.getSize())
+    M2.destroy()
+pc_inv.destroy()
+
+# Matrix-free inverse returns a usable shell
+pc_inv_mf = PETSc.PC().create(comm=comm)
+pc_inv_mf.setType('pflareinv')
+pc_inv_mf.setOperators(A, A)
+pflare.pcpflareinv_set_type(pc_inv_mf, pflare.PFLAREINV_POWER)
+pflare.pcpflareinv_set_matrix_free(pc_inv_mf, True)
+pc_inv_mf.setUp()
+Mmf = pflare.pcpflareinv_get_inverse_mat(pc_inv_mf)
+check('inverse_mat_mf_not_none', Mmf is not None, True)
+if Mmf is not None:
+    check('inverse_mat_mf_is_shell', Mmf.getType(), 'shell')
+    xf, yf = A.createVecs()
+    xf.set(1.0)
+    Mmf.mult(xf, yf)           # shell MatMult must work
+    check('inverse_mat_mf_matmult', yf.norm() > 0.0, True)
+    xf.destroy()
+    yf.destroy()
+pc_inv_mf.destroy()
 
 if errors:
     if rank == 0:

--- a/python/pflare.py
+++ b/python/pflare.py
@@ -158,6 +158,7 @@ pcpflareinv_get_type               = pflare_defs.pcpflareinv_get_type
 pcpflareinv_get_matrix_free        = pflare_defs.pcpflareinv_get_matrix_free
 pcpflareinv_get_reuse_poly_coeffs  = pflare_defs.pcpflareinv_get_reuse_poly_coeffs
 pcpflareinv_get_poly_coeffs        = pflare_defs.pcpflareinv_get_poly_coeffs
+pcpflareinv_get_inverse_mat        = pflare_defs.pcpflareinv_get_inverse_mat
 
 # -----------------------------------------------------------------------
 # PCPFLAREINV Set functions

--- a/python/pflare_defs.pyx
+++ b/python/pflare_defs.pyx
@@ -12,6 +12,10 @@ from petsc4py.PETSc cimport IS, PetscIS
 cdef extern from "petsc.h":
 	ctypedef int    PetscInt  "PetscInt"
 	ctypedef double PetscReal "PetscReal"
+	# Increment a PETSc object's reference count (used to balance petsc4py's
+	# automatic destroy when wrapping a borrowed reference). Declared here (from
+	# petsc.h) so Cython does not emit a prototype that conflicts with PETSc's.
+	int PetscObjectReference(void *obj)
 
 cdef extern:
 	void PCRegister_PFLARE()
@@ -146,6 +150,9 @@ cdef extern:
 	int PCPFLAREINVGetType(PetscPC pc, int *pflare_type)
 	int PCPFLAREINVGetMatrixFree(PetscPC pc, int *flag)
 	int PCPFLAREINVGetReusePolyCoeffs(PetscPC pc, int *flag)
+
+	# PCPFLAREINV - underlying approximate-inverse matrix (borrowed reference)
+	int PCPFLAREINVGetInverseMat(PetscPC pc, PetscMat *mat)
 
 	# PCPFLAREINV - polynomial coefficients (PC passed by value, not pointer)
 	# Returns a pointer into internal PCPFLAREINV memory (valid until the next PCSetUp or PCReset).
@@ -734,6 +741,21 @@ cpdef bint pcpflareinv_get_reuse_poly_coeffs(PC pc):
 	cdef int result = 0
 	PCPFLAREINVGetReusePolyCoeffs(pc.pc, &result)
 	return bool(result)
+
+cpdef pcpflareinv_get_inverse_mat(PC pc):
+	"""Return the underlying approximate-inverse matrix of a PCPFLAREINV.
+
+	Borrowed reference into the PC; valid only after PCSetUp and until the next
+	setup/reset. Returns None if PCSetUp has not been called yet.
+	"""
+	cdef Mat mat = Mat()
+	PCPFLAREINVGetInverseMat(pc.pc, &(mat.mat))
+	if mat.mat == NULL:
+		return None
+	# Borrowed reference: petsc4py will MatDestroy on garbage collection, so
+	# increment the count to keep the PC's matrix valid
+	PetscObjectReference(<void*>mat.mat)
+	return mat
 
 cpdef pcpflareinv_set_poly_order(PC pc, int order):
 	PCPFLAREINVSetPolyOrder(pc.pc, <PetscInt>order)

--- a/src/PCPFLAREINV.c
+++ b/src/PCPFLAREINV.c
@@ -164,6 +164,32 @@ static PetscErrorCode PCPFLAREINVGetMatrixFree_PFLAREINV(PC pc, PetscBool *flg)
    PetscFunctionReturn(PETSC_SUCCESS);
 }
 
+// ~~~~~~~~~~
+
+// Get the underlying matrix that represents our approximate inverse
+// This is a borrowed reference into the PCPFLAREINV object - DO NOT destroy it
+// It is either an assembled matrix (e.g. MATAIJ/MATDIAGONAL) or a matrix-free
+// MATSHELL, depending on the inverse type and the matrix_free option
+// The returned matrix is only valid until the next PCSetUp/PCReset/PCDestroy
+// (a re-setup with a different non-zero pattern rebuilds it)
+// Before PCSetUp has been called it is NULL - call PCSetUp (or KSPSetUp) first
+PetscErrorCode PCPFLAREINVGetInverseMat(PC pc, Mat *mat)
+{
+   PetscFunctionBegin;
+   PetscUseMethod(pc, "PCPFLAREINVGetInverseMat_C", (PC, Mat *), (pc, mat));
+   PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+static PetscErrorCode PCPFLAREINVGetInverseMat_PFLAREINV(PC pc, Mat *mat)
+{
+   PC_PFLAREINV *inv_data;
+
+   PetscFunctionBegin;
+   inv_data = (PC_PFLAREINV *)pc->data;
+   *mat = inv_data->mat_inverse;
+   PetscFunctionReturn(PETSC_SUCCESS);
+}
+
 // Set routines
 
 // This is the order of polynomial we use
@@ -408,6 +434,7 @@ static PetscErrorCode PCDestroy_PFLAREINV_c(PC pc)
    PetscCall(PetscObjectComposeFunction((PetscObject)pc, "PCPFLAREINVSetPolyCoeffs_C", NULL));
    PetscCall(PetscObjectComposeFunction((PetscObject)pc, "PCPFLAREINVGetReusePolyCoeffs_C", NULL));
    PetscCall(PetscObjectComposeFunction((PetscObject)pc, "PCPFLAREINVSetReusePolyCoeffs_C", NULL));
+   PetscCall(PetscObjectComposeFunction((PetscObject)pc, "PCPFLAREINVGetInverseMat_C", NULL));
    PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -674,6 +701,7 @@ PETSC_EXTERN PetscErrorCode PCCreate_PFLAREINV(PC pc)
    PetscCall(PetscObjectComposeFunction((PetscObject)pc, "PCPFLAREINVSetPolyCoeffs_C", PCPFLAREINVSetPolyCoeffs_PFLAREINV));
    PetscCall(PetscObjectComposeFunction((PetscObject)pc, "PCPFLAREINVGetReusePolyCoeffs_C", PCPFLAREINVGetReusePolyCoeffs_PFLAREINV));
    PetscCall(PetscObjectComposeFunction((PetscObject)pc, "PCPFLAREINVSetReusePolyCoeffs_C", PCPFLAREINVSetReusePolyCoeffs_PFLAREINV));
+   PetscCall(PetscObjectComposeFunction((PetscObject)pc, "PCPFLAREINVGetInverseMat_C", PCPFLAREINVGetInverseMat_PFLAREINV));
 
    PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/PCPFLAREINV_Interfaces.F90
+++ b/src/PCPFLAREINV_Interfaces.F90
@@ -79,7 +79,7 @@ module pcpflareinv_interfaces
       end function PCPFLAREINVGetPolyCoeffs_mine
    end interface
 
-   interface 
+   interface
       function PCPFLAREINVGetReusePolyCoeffs_mine(A_array, b) &
          bind(c, name="PCPFLAREINVGetReusePolyCoeffs")
          use iso_c_binding
@@ -89,7 +89,18 @@ module pcpflareinv_interfaces
          integer(PFLARE_PETSCERRORCODE_C_KIND)  :: PCPFLAREINVGetReusePolyCoeffs_mine
       end function PCPFLAREINVGetReusePolyCoeffs_mine
    end interface
-   
+
+   interface
+      function PCPFLAREINVGetInverseMat_mine(A_array, mat_array) &
+         bind(c, name="PCPFLAREINVGetInverseMat")
+         use iso_c_binding
+#include "finclude/pflare_types.h"
+         integer(c_long_long), value            :: A_array
+         integer(c_long_long), intent(out)      :: mat_array
+         integer(PFLARE_PETSCERRORCODE_C_KIND)  :: PCPFLAREINVGetInverseMat_mine
+      end function PCPFLAREINVGetInverseMat_mine
+   end interface
+
    ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ! Set routines - interfaces to the C routines in PCPFLAREINV
    ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -313,9 +324,34 @@ module pcpflareinv_interfaces
 
    end subroutine PCPFLAREINVGetReusePolyCoeffs
 
+! -------------------------------------------------------------------------------------------------------------------------------
+
+   subroutine PCPFLAREINVGetInverseMat(pc, mat, ierr)
+
+      ! Returns the underlying approximate-inverse matrix as a borrowed reference.
+      ! Do NOT destroy mat - it is owned by the PC. It is either an assembled
+      ! matrix or a matrix-free MATSHELL, and is only valid after PCSetUp and
+      ! until the next setup/reset. Before PCSetUp the returned handle is null.
+
+      ! ~~~~~~~~~~
+      type(tPC), intent(in)         :: pc
+      type(tMat), intent(inout)     :: mat
+      PetscErrorCode, intent(inout) :: ierr
+
+      integer(c_long_long) :: pc_ptr
+      integer(c_long_long) :: mat_ptr
+      ! ~~~~~~~~~~
+
+      pc_ptr  = pc%v
+      mat_ptr = 0
+      ierr    = PCPFLAREINVGetInverseMat_mine(pc_ptr, mat_ptr)
+      mat%v   = mat_ptr
+
+   end subroutine PCPFLAREINVGetInverseMat
+
    ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ! Set routines - Fortran versions of the C routines in PCPFLAREINV
-   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~    
+   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ! -------------------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`PCPFLAREINV` builds an approximate inverse and stores it internally as a single `Mat` (assembled `MATAIJ`/`MATDIAGONAL`, or a matrix-free `MATSHELL`), but there was no way for a user to reach it. This adds an accessor so users can operate on that matrix directly — e.g. form their own matrix-matrix products for Schur-complement work.

New API (C / Fortran / Python):
- `PCPFLAREINVGetInverseMat(PC, Mat *)` — C
- `PCPFLAREINVGetInverseMat(pc, mat, ierr)` — Fortran
- `pcpflareinv_get_inverse_mat(pc)` — Python

## Semantics

- **Borrowed reference** — caller must not destroy it; valid only after `PCSetUp` and until the next setup/reset.
- **No auto-setup** — returns `NULL`/`None` before `PCSetUp` (mirrors `PCPFLAREINVGetPolyCoeffs`).
- Works for both assembled and matrix-free inverses.
- The Python wrapper increments the reference count so petsc4py's automatic `MatDestroy` on garbage collection doesn't free the PC's matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)