### PR TITLE
Support building on a PETSc configured without MPI (MPIUNI)

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -260,6 +260,23 @@ jobs:
             OMP_NUM_THREADS=2
             ARCH=arch-linux-c-opt-omp
             
+  gnu_debug_no_mpi_kokkos:
+    runs-on: ubuntu-22.04
+    needs: [setup]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Docker image with PETSc configured without MPI and with Kokkos
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64
+          push: false
+          context: .
+          file: ./dockerfiles/Dockerfile_no_mpi
+          build-args: |
+            ARCH=arch-linux-c-debug
+
   intel_opt:
     runs-on: ubuntu-22.04
     needs: [setup]

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,8 @@ endef
 export PETSC_USE_64BIT_INDICES := $(if $(call _have_conf,PETSC_USE_64BIT_INDICES),1,0)
 export PETSC_USE_SHARED_LIBRARIES := $(if $(call _have_conf,PETSC_USE_SHARED_LIBRARIES),1,0)
 export PETSC_HAVE_KOKKOS := $(if $(call _have_conf,PETSC_HAVE_KOKKOS),1,0)
+# Detect if PETSc was configured without MPI
+export PETSC_HAVE_MPIUNI := $(if $(call _have_conf,PETSC_HAVE_MPIUNI),1,0)
 
 # To prevent overlinking with conda builds, only explicitly link 
 # to the libraries we use in pflare

--- a/dockerfiles/Dockerfile_no_mpi
+++ b/dockerfiles/Dockerfile_no_mpi
@@ -1,0 +1,38 @@
+ARG BASE_IMAGE=stevendargaville/petsc_no_mpi
+
+FROM ${BASE_IMAGE}
+# Use the debug petsc build by default
+ARG ARCH=arch-linux-c-debug
+
+LABEL maintainer="Steven Dargaville"
+LABEL description="PFLARE built on a PETSc configured without MPI (MPIUNI)"
+
+ENV PETSC_ARCH=$ARCH
+# -on_error_abort ensures any test failures are caught and the build fails
+# fp trap turns on floating point exception trapping in petsc
+ENV PETSC_OPTIONS="-on_error_abort -fp_trap on"
+
+WORKDIR /build
+
+COPY . /build/PFLARE
+
+# Ensure pipelines fail if any stage fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Build and test PFLARE against a PETSc configured without MPI (MPIUNI).
+# The parallel test targets are skipped automatically by the Makefiles when
+# PETSc has been built without MPI (PETSC_HAVE_MPIUNI), so only the serial
+# tests (Fortran, C and Python) run here.
+# Set the line length to 132 to check for truncation problems - the cray fortran
+# compiler was defaulting to 132 and we don't have a CI for that, so this will trigger it.
+# The base image is built with Kokkos, so enforce C++20 for Kokkos 5.0 compatibility.
+RUN set -euo pipefail; \
+    echo "Using PETSC_OPTIONS=${PETSC_OPTIONS}"; \
+    cd PFLARE && \
+    make -j2 FFLAGS="-Werror -Wall -ffree-line-length-132 -ffixed-line-length-132" CFLAGS="-Werror -Wall" CXXFLAGS="-Werror -Wall -std=c++20" CPPFLAGS="-Werror -Wall" && \
+    make python && \
+    make -j2 check FFLAGS="-Werror -Wall -ffree-line-length-132 -ffixed-line-length-132" CFLAGS="-Werror -Wall" CXXFLAGS="-Werror -Wall -std=c++20" CPPFLAGS="-Werror -Wall" && \
+    make -j2 tests FFLAGS="-Werror -Wall -ffree-line-length-132 -ffixed-line-length-132" CFLAGS="-Werror -Wall" CXXFLAGS="-Werror -Wall -std=c++20" CPPFLAGS="-Werror -Wall" && \
+    make tests_python
+
+WORKDIR /build/PFLARE

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,8 +1,10 @@
 ## Installing PFLARE
 
-PFLARE depends on MPI, BLAS, LAPACK and PETSc configured with a graph partitioner (e.g., ParMETIS). PFLARE uses the same compilers and flags defined in the PETSc configure.
+PFLARE depends on BLAS, LAPACK and PETSc. PFLARE uses the same compilers and flags defined in the PETSc configure. PFLARE has been tested on Linux and MacOS, across a range of compilers, including GNU, Intel, LLVM and Cray. 
 
-If you wish to run PFLARE on GPUs you should configure PETSc with Kokkos and the relevant GPU backend. PFLARE has been tested with GNU, Intel, LLVM, NVIDIA and Cray compilers. 
+If you wish to run in parallel, configure PETSc with MPI. For good performance also configure PETSc with a graph partitioner (e.g., ParMETIS).
+
+If you wish to run PFLARE on GPUs, configure PETSc with Kokkos and the relevant GPU backend. 
 
 Please choose one of the build methods below. If you wish to contribute to PFLARE we would recommend building from the source.
 
@@ -22,7 +24,7 @@ PFLARE is available in the Spack package repository and can be installed with:
 
       spack install pflare
 
-This package is currently available in the development branch of the Spack package repository and will be included in a future Spack release. If the package is not yet available in your Spack installation, you can use the PFLARE Spack repository at: https://github.com/PFLAREProject/PFLARE_spack
+This package is available from the v2026.06.0 release of the ``spack-packages`` repository, corresponding to v1.2 of the ``spack`` repository. If the package is not yet available in your Spack installation, you can use the PFLARE Spack repository at: https://github.com/PFLAREProject/PFLARE_spack
 
 ### Source build
 

--- a/python/Makefile
+++ b/python/Makefile
@@ -37,72 +37,90 @@ export PYTHONPATH := $(PETSCPYTHONPATH):$(CURDIR):$(if $(PYTHONPATH),$(PYTHONPAT
 python:
 	$(PYTHON) setup.py build_ext --inplace
 
-run_tests:
+# Run all the python tests (serial + parallel)
+run_tests: run_tests_serial run_tests_parallel
+
+run_tests_serial:
 	 @if $(PYTHON) -c "import pflare" >/dev/null 2>&1; then \
 		echo ""; \
 		echo "Test AIRG with GMRES polynomials for 2D finite difference stencil with Python"; \
 		$(PYTHON) ex2.py; \
-		echo "Test AIRG with GMRES polynomials for 2D finite difference stencil with Python in parallel"; \
-		$(MPIEXEC) -n 2 $(PYTHON) ex2.py; \
-		echo ""; \
 		echo "Test lAIR with GMRES polynomials for 2D finite difference stencil with Python"; \
 		$(PYTHON) ex2.py -pc_air_z_type lair; \
-		echo "Test lAIR with GMRES polynomials for 2D finite difference stencil with Python in parallel"; \
-		$(MPIEXEC) -n 2 $(PYTHON) ex2.py -pc_air_z_type lair; \
-		echo ""; \
 		echo "Test single level GMRES polynomial preconditioning with Python"; \
 		$(PYTHON) ex2.py -pc_type pflareinv -pc_pflareinv_type power; \
-		echo "Test single level GMRES polynomial preconditioning with Python in parallel"; \
-		$(MPIEXEC) -n 2 $(PYTHON) ex2.py -pc_type pflareinv -pc_pflareinv_type power; \
-		echo ""; \
 		echo "Test PMISR DDC CF splitting and diagonal dominance extract with Python"; \
 		$(PYTHON) ex2_cf_splitting.py; \
-		echo "Test PMISR DDC CF splitting and diagonal dominance extract with Python in parallel"; \
-		$(MPIEXEC) -n 2 $(PYTHON) ex2_cf_splitting.py; \
-		echo ""; \
 		echo "Test PCAIR direct option set/get API with Python"; \
 		$(PYTHON) ex_pcair_options.py && echo "OK"; \
-		echo "Test PCAIR direct option set/get API with Python in parallel"; \
-		$(MPIEXEC) -n 2 $(PYTHON) ex_pcair_options.py && echo "OK"; \
-		echo ""; \
 		echo "Test PCAIR complexity getter API with Python"; \
 		$(PYTHON) ex_pcair_complexities.py && echo "OK"; \
-		echo "Test PCAIR complexity getter API with Python in parallel"; \
-		$(MPIEXEC) -n 2 $(PYTHON) ex_pcair_complexities.py && echo "OK"; \
-		echo ""; \
 		echo "Test PCPFLAREINV direct option set/get API with Python"; \
 		$(PYTHON) ex_pcpflareinv_options.py && echo "OK"; \
-		echo "Test PCPFLAREINV direct option set/get API with Python in parallel"; \
-		$(MPIEXEC) -n 2 $(PYTHON) ex_pcpflareinv_options.py && echo "OK"; \
-		echo ""; \
 		echo "Test save/restore poly coefficients with PCAIR with Python"; \
 		$(PYTHON) ex6f_getcoeffs.py -pc_type air; \
-		echo "Test save/restore poly coefficients with PCAIR in parallel with Python"; \
-		$(MPIEXEC) -n 2 $(PYTHON) ex6f_getcoeffs.py -pc_type air; \
-		echo ""; \
 		echo "Test save/restore poly coefficients with PCPFLAREINV with Python"; \
 		$(PYTHON) ex6f_getcoeffs.py -pc_type pflareinv; \
-		echo "Test save/restore poly coefficients with PCPFLAREINV in parallel with Python"; \
-		$(MPIEXEC) -n 2 $(PYTHON) ex6f_getcoeffs.py -pc_type pflareinv; \
 		echo "Test save/restore poly coefficients with PCPFLAREINV with Python with Newton"; \
 		$(PYTHON) ex6f_getcoeffs.py -pc_type pflareinv -pc_pflareinv_type newton; \
+	 else \
+		echo 'Python tests skipped (PFLARE Python module not built or not found)'; \
+	 fi
+
+run_tests_parallel:
+ifeq ($(PETSC_HAVE_MPIUNI),1)
+	@echo "Parallel python tests skipped (PETSc configured without MPI)"
+else
+	 @if $(PYTHON) -c "import pflare" >/dev/null 2>&1; then \
+		echo ""; \
+		echo "Test AIRG with GMRES polynomials for 2D finite difference stencil with Python in parallel"; \
+		$(MPIEXEC) -n 2 $(PYTHON) ex2.py; \
+		echo "Test lAIR with GMRES polynomials for 2D finite difference stencil with Python in parallel"; \
+		$(MPIEXEC) -n 2 $(PYTHON) ex2.py -pc_air_z_type lair; \
+		echo "Test single level GMRES polynomial preconditioning with Python in parallel"; \
+		$(MPIEXEC) -n 2 $(PYTHON) ex2.py -pc_type pflareinv -pc_pflareinv_type power; \
+		echo "Test PMISR DDC CF splitting and diagonal dominance extract with Python in parallel"; \
+		$(MPIEXEC) -n 2 $(PYTHON) ex2_cf_splitting.py; \
+		echo "Test PCAIR direct option set/get API with Python in parallel"; \
+		$(MPIEXEC) -n 2 $(PYTHON) ex_pcair_options.py && echo "OK"; \
+		echo "Test PCAIR complexity getter API with Python in parallel"; \
+		$(MPIEXEC) -n 2 $(PYTHON) ex_pcair_complexities.py && echo "OK"; \
+		echo "Test PCPFLAREINV direct option set/get API with Python in parallel"; \
+		$(MPIEXEC) -n 2 $(PYTHON) ex_pcpflareinv_options.py && echo "OK"; \
+		echo "Test save/restore poly coefficients with PCAIR in parallel with Python"; \
+		$(MPIEXEC) -n 2 $(PYTHON) ex6f_getcoeffs.py -pc_type air; \
+		echo "Test save/restore poly coefficients with PCPFLAREINV in parallel with Python"; \
+		$(MPIEXEC) -n 2 $(PYTHON) ex6f_getcoeffs.py -pc_type pflareinv; \
 		echo "Test save/restore poly coefficients with PCPFLAREINV in parallel with Python with Newton"; \
 		$(MPIEXEC) -n 2 $(PYTHON) ex6f_getcoeffs.py -pc_type pflareinv -pc_pflareinv_type newton; \
 	 else \
 		echo 'Python tests skipped (PFLARE Python module not built or not found)'; \
 	 fi
+endif
 
 # ~~~~~~~~~~~
 # ~~~~~~~~~~~
-run_check:
+run_check: run_check_serial run_check_parallel
+
+run_check_serial:
 	 @if $(PYTHON) -c "import pflare" >/dev/null 2>&1; then \
 		echo "Python check"; \
 		$(PYTHON) ex2.py -ksp_max_it 5 -on_error_abort && echo "OK" || (echo "FAIL" && exit 1); \
+	 else \
+		echo 'Python check skipped (PFLARE Python module not built or not found)'; \
+	 fi
+
+run_check_parallel:
+ifeq ($(PETSC_HAVE_MPIUNI),1)
+	@echo "Parallel Python check skipped (PETSc configured without MPI)"
+else
+	 @if $(PYTHON) -c "import pflare" >/dev/null 2>&1; then \
 		echo "Parallel Python check"; \
 		$(MPIEXEC) -n 2 $(PYTHON) ex2.py -ksp_max_it 5 -on_error_abort && echo "OK" || (echo "FAIL" && exit 1); \
 	 else \
 		echo 'Python check skipped (PFLARE Python module not built or not found)'; \
 	 fi
+endif
 
 # Cleanup
 clean::

--- a/src/Approx_Inverse_Setup.F90
+++ b/src/Approx_Inverse_Setup.F90
@@ -367,16 +367,20 @@ module approx_inverse_setup
             ! Some of the ranks on MPI_COMM_MATRIX will already have the coefficients, but I'm not going 
             ! to bother creating an intercommunicator to send the coefficients from any rank on the comm of buffers%matrix
             ! to the comm of ranks which aren't in MPI_COMM_MATRIX but are in buffers%matrix
-            call MPI_IBcast(coefficients, size(coefficients, 1), MPI_DOUBLE, 0, &
+#if !defined(PETSC_HAVE_MPIUNI)
+            call MPI_IBcast(coefficients, size(coefficients, 1), MPI_DOUBLE_PRECISION, 0, &
                      MPI_COMM_MATRIX, buffers%request, errorcode)
+#endif
 
          ! Gmres polynomial with Newton basis - Can only use matrix-free
          else if (inverse_type == PFLAREINV_NEWTON .OR. inverse_type == PFLAREINV_NEWTON_NO_EXTRA) then
 
             ! Have to broadcast the 2D real and imaginary roots
-            call MPI_IBcast(coefficients, size(coefficients, 1) * size(coefficients, 2), MPI_DOUBLE, 0, &
+#if !defined(PETSC_HAVE_MPIUNI)
+            call MPI_IBcast(coefficients, size(coefficients, 1) * size(coefficients, 2), MPI_DOUBLE_PRECISION, 0, &
                      MPI_COMM_MATRIX, buffers%request, errorcode)
-         end if    
+#endif
+         end if
       end if  
 
    end subroutine start_approximate_inverse

--- a/src/C_PETSc_Routines.c
+++ b/src/C_PETSc_Routines.c
@@ -216,7 +216,14 @@ PETSC_INTERN void MatPartitioning_c(Mat *adj, PetscInt new_size, PetscInt *proc_
    PetscCallVoid(MatPartitioningCreate(comm, &mpart));
    PetscCallVoid(MatPartitioningSetAdjacency(mpart, *adj));
    // Uses parmetis by default but you can change via the command line options
+#if defined(PETSC_HAVE_PARMETIS)
    PetscCallVoid(MatPartitioningSetType(mpart, MATPARTITIONINGPARMETIS));
+#else
+   // ParMETIS is not available (e.g. PETSc built without MPI); fall back to a
+   // built-in partitioner that needs no external package. This path is only
+   // reached in parallel, so it never runs in a serial (MPIUNI) build anyway
+   PetscCallVoid(MatPartitioningSetType(mpart, MATPARTITIONINGAVERAGE));
+#endif
    PetscCallVoid(MatPartitioningSetFromOptions(mpart));
    PetscCallVoid(MatPartitioningSetNParts(mpart, new_size));
 

--- a/src/MatDiagDom.F90
+++ b/src/MatDiagDom.F90
@@ -251,7 +251,8 @@ module matdiagdom
       else
          max_dd_ratio_local = maxval(diag_dom_ratio)
       end if
-      call MPI_Allreduce(max_dd_ratio_local, max_dd_ratio_achieved, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_MATRIX, errorcode)
+      call MPI_Allreduce(max_dd_ratio_local, max_dd_ratio_achieved, 1, MPI_DOUBLE_PRECISION, &
+                         MPI_MAX, MPI_COMM_MATRIX, errorcode)
 
    end subroutine MatDiagDomRatio_cpu
 

--- a/src/Repartition.F90
+++ b/src/Repartition.F90
@@ -55,7 +55,7 @@ module repartition
          ratio = dble(local_nnzs)/dble(off_proc_nnzs)
       end if
 
-      call MPI_Allreduce(ratio, ratio_parallel, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_MATRIX, errorcode)
+      call MPI_Allreduce(ratio, ratio_parallel, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_MATRIX, errorcode)
 
       ratio = ratio_parallel  
       ! Only divide by the number of processors that are active

--- a/src/TSQR.F90
+++ b/src/TSQR.F90
@@ -41,17 +41,23 @@ module tsqr
       ! Creates our custom reduction
 
       ! ~~~~~~
+#if !defined(PETSC_HAVE_MPIUNI)
       integer :: errorcode
-      ! ~~~~~~    
+#endif
+      ! ~~~~~~
 
       ! Point at the custom reduction function
       if (.NOT. built_custom_op_tsqr) then
          ! We should be able to set commute as true, as the order doesn't matter for QRs
          ! But I have bumped into cases where due to rounding (typically in low-rank systems)
          ! the small entries in the resulting R can differ on different cores
-         ! When we use this as part of our gmres polynomials, this can give 10% difference in some of 
+         ! When we use this as part of our gmres polynomials, this can give 10% difference in some of
          ! the coefficients on different cores which is not acceptable
+         ! MPIUNI does not provide a Fortran MPI_Op_create; the custom reduction is only
+         ! ever used in the parallel (comm_size/=1) path in start_tsqr, so skip it in serial
+#if !defined(PETSC_HAVE_MPIUNI)
          call MPI_Op_create(custom_reduction_tsqr, .FALSE., reduction_op_tsqr, errorcode)
+#endif
          built_custom_op_tsqr = .true.
       end if
       
@@ -228,10 +234,13 @@ module tsqr
 
       ! ~~~~~~~~~~~
       ! This is where the parallel comms need to go on R, can ignore Q
-      ! ~~~~~~~~~~~  
-      if (comm_size/=1) then      
+      ! ~~~~~~~~~~~
+      ! MPIUNI provides no Fortran MPI_IAllreduce and comm_size is always 1 in serial,
+      ! so this non-blocking reduction only exists for the parallel (real MPI) build
+#if !defined(PETSC_HAVE_MPIUNI)
+      if (comm_size/=1) then
 
-         ! Only need a single all reduce, this is the only comms outside of the 
+         ! Only need a single all reduce, this is the only comms outside of the
          ! matvecs above
          buffers%request = MPI_REQUEST_NULL
          ! This is now a non-blocking allreduce, you have to finish this where needed
@@ -241,16 +250,17 @@ module tsqr
          if (errorcode /= MPI_SUCCESS) then
             print *, "MPI_IAllreduce failed"
             call MPI_Abort(MPI_COMM_WORLD, MPI_ERR_OTHER, errorcode)
-         end if 
+         end if
 
          ! ~~~~~
          ! ~~~~~
-         ! This non-blocking is resolved in finish_tsqr_parallel, which you must call 
+         ! This non-blocking is resolved in finish_tsqr_parallel, which you must call
          ! outside this routine
          ! ~~~~~
          ! ~~~~~
 
       end if
+#endif
       
    end subroutine start_tsqr   
 

--- a/src/Timers.F90
+++ b/src/Timers.F90
@@ -54,8 +54,13 @@ function wall_time()
    real(kind = c_double):: wall_time
    logical, save :: started=.false.
    real(kind = c_double), save :: wall_time0
+   PetscLogDouble :: current_time
+   PetscErrorCode :: ierr
 
-   wall_time = MPI_Wtime()
+   ! Use PetscTime rather than MPI_Wtime - MPIUNI (PETSc built without MPI) does not
+   ! provide a typed Fortran MPI_Wtime, whereas PetscTime works in serial and parallel
+   call PetscTime(current_time, ierr)
+   wall_time = current_time
    if(.not.started) then
       wall_time0 = wall_time
       wall_time = 0d0

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -188,6 +188,9 @@ run_tests_load_serial:
 # ~~~~~~~~~~~
 # ~~~~~~~~~~~
 run_tests_load_parallel:
+ifeq ($(PETSC_HAVE_MPIUNI),1)
+	@echo "Load parallel tests skipped (PETSc configured without MPI)"
+else
 #
 	@echo "Test AIRG with GMRES polynomials for hyperbolic streaming problem, matrix-free smoothing in C in parallel"
 	$(MPIEXEC) -n 2 ./ex6 -f data/mat_stream_2364 -pc_air_a_drop 1e-3 -pc_air_inverse_type power -pc_air_matrix_free_polys -ksp_max_it 5
@@ -250,7 +253,8 @@ run_tests_load_parallel:
 	done
 #
 	@echo "Test Newton AIRG with GMRES polynomials for hyperbolic streaming problem, matrix-free smoothing in parallel"
-	$(MPIEXEC) -n 2 ./ex12f -f data/mat_stream_2364 -pc_air_a_drop 1e-3 -pc_air_inverse_type newton -pc_air_matrix_free_polys -ksp_max_it 5	
+	$(MPIEXEC) -n 2 ./ex12f -f data/mat_stream_2364 -pc_air_a_drop 1e-3 -pc_air_inverse_type newton -pc_air_matrix_free_polys -ksp_max_it 5
+endif
 
 # ~~~~~~~~~~~
 # ~~~~~~~~~~~
@@ -674,6 +678,9 @@ run_tests_no_load_serial:
 # ~~~~~~~~~~~
 # ~~~~~~~~~~~
 run_tests_no_load_short_parallel:
+ifeq ($(PETSC_HAVE_MPIUNI),1)
+	@echo "No-load short parallel tests skipped (PETSc configured without MPI)"
+else
 #
 	@echo ""
 	@echo "Test PCAIR reuse_amount (1=CF splitting only, 2=+SpGEMMs, 3=everything) in Fortran in parallel"
@@ -945,13 +952,17 @@ ifeq ($(PETSC_HAVE_KOKKOS),1)
 	@echo "Test AIRG on steady 1D advection in parallel KOKKOS"
 	$(MPIEXEC) -n 2 ./adv_1dk -n 1000 -ksp_rtol 1e-10 -ksp_atol 1e-50 -ksp_pc_side right \
 	 -pc_air_coarsest_inverse_type newton -pc_air_coarsest_poly_order 10 -pc_air_coarsest_matrix_free_polys -ksp_max_it 10 \
-	 -vec_type kokkos -mat_type aijkokkos -pc_air_a_drop 1e-3 -pc_air_inverse_type power	
+	 -vec_type kokkos -mat_type aijkokkos -pc_air_a_drop 1e-3 -pc_air_inverse_type power
 
+endif
 endif
 
 # ~~~~~~~~~~~
 # ~~~~~~~~~~~
 run_tests_no_load_parallel:
+ifeq ($(PETSC_HAVE_MPIUNI),1)
+	@echo "No-load parallel tests skipped (PETSc configured without MPI)"
+else
 #
 	@echo ""
 	@echo "Test AIRG with SUPG CG FEM in 3D unstructured tets in parallel"
@@ -1022,6 +1033,7 @@ run_tests_no_load_parallel:
 				-pc_air_inverse_sparsity_order $$sparsity -ksp_norm_type unpreconditioned -ksp_max_it 5; \
 		done; \
 	done
+endif
 
 # ~~~~~~~~~~~
 # ~~~~~~~~~~~
@@ -1163,6 +1175,9 @@ run_tests_medium_serial:
 # ~~~~~~~~~~~
 # ~~~~~~~~~~~
 run_tests_medium_parallel:
+ifeq ($(PETSC_HAVE_MPIUNI),1)
+	@echo "Medium parallel tests skipped (PETSc configured without MPI)"
+else
 
 #
 	@echo ""
@@ -1216,7 +1231,8 @@ run_tests_medium_parallel:
 		$(MPIEXEC) -n 2 ./adv_dg_upwind -adv_dg_petscspace_degree 2 -pc_type air -ksp_type richardson -ksp_norm_type unpreconditioned \
 		-ksp_rtol 1e-10 -ksp_atol 1e-50 \
 		-dm_plex_filename data/square_unstruc.msh -dm_refine $$refine -ksp_max_it 7; \
-	done		
+	done
+endif
 
 # ~~~~~~~~~~~
 # ~~~~~~~~~~~
@@ -1228,15 +1244,23 @@ run_check:
 	@./matrandom -ksp_max_it 5 -on_error_abort  && echo "OK" || (echo "FAIL" && exit 1)	
 	@echo "Serial check"
 	@./adv_diff_fd -da_grid_x 25 -da_grid_y 25 -pc_type air -ksp_max_it 5 -on_error_abort  && echo "OK" || (echo "FAIL" && exit 1)
+ifeq ($(PETSC_HAVE_MPIUNI),1)
+	@echo "Parallel check skipped (PETSc configured without MPI)"
+else
 	@echo "Parallel check"
 	@$(MPIEXEC) -n 2 ./adv_diff_fd -da_grid_x 25 -da_grid_y 25 -pc_type air -ksp_max_it 5 -on_error_abort  && echo "OK" || (echo "FAIL" && exit 1)
+endif
 ifeq ($(PETSC_HAVE_KOKKOS),1)
 # 
 	@echo "Serial KOKKOS check"
 	@./adv_diff_fd -da_grid_x 25 -da_grid_y 25 -pc_type air -ksp_max_it 5 -dm_vec_type kokkos -dm_mat_type aijkokkos -on_error_abort  && echo "OK" || (echo "FAIL" && exit 1)
+ifeq ($(PETSC_HAVE_MPIUNI),1)
+	@echo "Parallel KOKKOS check skipped (PETSc configured without MPI)"
+else
 	@echo "Parallel KOKKOS check"
 	@$(MPIEXEC) -n 2 ./adv_diff_fd -da_grid_x 25 -da_grid_y 25 -pc_type air -ksp_max_it 5 -dm_vec_type kokkos -dm_mat_type aijkokkos -on_error_abort  && echo "OK" || (echo "FAIL" && exit 1)
-else	
+endif
+else
 	@echo "KOKKOS check skipped (PETSc has not been configured with KOKKOS)"	
 
 endif	


### PR DESCRIPTION
## Summary

PFLARE previously required PETSc to be configured with MPI (and therefore a graph partitioner like ParMETIS). Every method in PFLARE works in serial, so this lets PFLARE build and pass its tests on top of a PETSc configured **without** MPI, where PETSc uses its bundled **MPIUNI** serial-MPI shim (and drops Metis/ParMETIS).

## Changes

**Source (portable — no behaviour change on real-MPI builds):**
- `src/Timers.F90` — use `PetscTime()` instead of `MPI_Wtime()` (MPIUNI has no typed Fortran `MPI_Wtime`).
- `src/TSQR.F90`, `src/Approx_Inverse_Setup.F90` — guard `MPI_Op_create`, `MPI_IAllreduce`, `MPI_IBcast` with `#if !defined(PETSC_HAVE_MPIUNI)` (MPIUNI provides no Fortran wrappers for these; they were already parallel-only dead code in serial).
- `MPI_DOUBLE` → `MPI_DOUBLE_PRECISION` in `MatDiagDom.F90`, `Repartition.F90`, `Approx_Inverse_Setup.F90` (MPIUNI's `mpif.h` doesn't define `MPI_DOUBLE`).
- `src/C_PETSc_Routines.c` — `#if defined(PETSC_HAVE_PARMETIS)` around the partitioner type with a `MATPARTITIONINGAVERAGE` fallback.

**Build/test system:**
- `Makefile` — detect and export `PETSC_HAVE_MPIUNI` (mirrors the existing `PETSC_HAVE_KOKKOS` pattern).
- `tests/Makefile` — skip the parallel test targets when `PETSC_HAVE_MPIUNI=1` (`petsc-mpiexec.uni -n 2` errors out).
- `python/Makefile` — split `run_tests`/`run_check` into serial/parallel sub-targets; the parallel ones skip under MPIUNI.

**CI:**
- `dockerfiles/Dockerfile_no_mpi` + `gnu_opt_no_mpi` job using the new `stevendargaville/petsc_no_mpi` image.

**Docs:**
- `docs/installation.md` — MPI/ParMETIS documented as optional (needed only for parallel).

## Testing

Against a Kokkos-enabled, no-MPI PETSc: `make build_tests` (clean `-Werror -Wall` + 132-col), `make check`, `make tests_short`, `make python`, `make tests_python` all pass — serial Fortran/C/Kokkos/Python tests run, parallel ones report "skipped". The CI job exercises the full `check`/`tests` on the no-MPI image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)