### PR TITLE
Remove vendoring of the PETSc source

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -224,6 +224,24 @@ jobs:
           build-args: |
             ARCH=arch-linux-c-debug
 
+  gnu_debug_kokkos_prefix:
+    runs-on: ubuntu-22.04
+    needs: setup
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Docker image with KOKKOS and debug PETSc with prefix DIR
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64
+          push: false
+          context: .
+          file: ./dockerfiles/Dockerfile_kokkos
+          build-args: |
+            ARCH=
+            PETSC_DIR=/build/petsc_prefix            
+
   gnu_opt_64_bit_kokkos:
     runs-on: ubuntu-22.04
     needs: [setup]

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,6 +1,7 @@
 ARG BASE_IMAGE=stevendargaville/petsc
 
 FROM ${BASE_IMAGE}
+ARG PETSC_DIR=/build/petsc
 # Use the optimised petsc build by default
 ARG ARCH=arch-linux-c-opt
 # Don't use malloc dump by default
@@ -10,6 +11,7 @@ LABEL maintainer="Steven Dargaville"
 LABEL description="PFLARE"
 
 ENV PETSC_ARCH=$ARCH
+ENV PETSC_DIR=$PETSC_DIR
 # -on_error_abort ensures any test failures are caught and the build fails
 # fp trap turns on floating point exception trapping in petsc
 ENV PETSC_OPTIONS="-on_error_abort -fp_trap on"

--- a/dockerfiles/Dockerfile_kokkos
+++ b/dockerfiles/Dockerfile_kokkos
@@ -1,6 +1,7 @@
 ARG BASE_IMAGE=stevendargaville/petsc_kokkos
 
 FROM ${BASE_IMAGE}
+ARG PETSC_DIR=/build/petsc
 # Use the optimised petsc build by default
 ARG ARCH=arch-linux-c-opt
 # Set the number of OpenMP threads to 1 by default
@@ -11,6 +12,7 @@ ARG MALLOC_DUMP=false
 LABEL maintainer="Steven Dargaville"
 LABEL description="PFLARE_kokkos"
 
+ENV PETSC_DIR=$PETSC_DIR
 ENV PETSC_ARCH=$ARCH
 ENV OMP_NUM_THREADS=$OMP_NUM_THREADS
 # This turns on checks between kokkos and cpu versions

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ Please choose one of the build methods below. If you wish to contribute to PFLAR
 
 ### PETSc configure build
 
-PFLARE has now been added to the PETSc configure as an external package, as of the PETSc 3.25 release. PFLARE can be built by adding ``--download-pflare`` to the PETSc configure. 
+PFLARE is available through the PETSc configure as an external package, since the PETSc 3.25 release. PFLARE can be built by adding ``--download-pflare`` to the PETSc configure. 
 
 The PC types added by PFLARE can then be used as native PETSc PC types through command line arguments without any changes to existing code. The [Linking to PFLARE](#linking-to-pflare) and [Modifying existing code](#modifying-existing-code) sections below can therefore be skipped. 
 
@@ -44,9 +44,7 @@ The full set of tests can be run with:
 
 6) ``make tests`` in the top level directory.
 
-Please use the `main` branch of PETSc and compile PETSc directly from the source code, as PFLARE requires access to some of the PETSc types only available in the source. If PETSc was installed out of place, you should add the `/include` directory from the PETSc source location to `CFLAGS, CXXFLAGS, CPPFLAGS` before calling `make` for PFLARE. 
-
-If you wish to use an older version of PETSc, please see the [PFLARE Spack](https://github.com/PFLAREProject/PFLARE_spack) `package.py` where a list of compatible PFLARE release versions is maintained.
+Please use the `main` branch of PETSc. If you wish to use an older version of PETSc, please see the [PFLARE Spack](https://github.com/PFLAREProject/PFLARE_spack) `package.py` where a list of compatible PFLARE release versions is maintained.
 
 ### Docker
 

--- a/include/kokkos_helper.hpp
+++ b/include/kokkos_helper.hpp
@@ -4,17 +4,18 @@
 // petscvec_kokkos.hpp has to go first
 #include <petscvec_kokkos.hpp>
 #include <petscmat_kokkos.hpp>
+#include <petsc_kokkos.hpp>
 #include "petsc.h"
-#include <../src/mat/impls/aij/seq/kokkos/aijkok.hpp>
 #include <Kokkos_StdAlgorithms.hpp>
-#include <../src/vec/vec/impls/seq/kokkos/veckokkosimpl.hpp>
 #include <Kokkos_Random.hpp>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_DualView.hpp>
 #include <KokkosSparse_spadd.hpp>
+#include <KokkosSparse_CrsMatrix.hpp>
 #include <Kokkos_NestedSort.hpp>
 #include <KokkosBatched_Gesv.hpp>
 #include <KokkosBlas2_team_gemv.hpp>
+#include <petsc/private/kokkosimpl.hpp>
 
 using DefaultExecutionSpace = Kokkos::DefaultExecutionSpace;
 using DefaultMemorySpace    = Kokkos::DefaultExecutionSpace::memory_space;
@@ -23,7 +24,6 @@ using PetscIntConstKokkosViewHost = Kokkos::View<const PetscInt *, HostMirrorMem
 using intKokkosViewHost = Kokkos::View<int *, HostMirrorMemorySpace>;
 using intKokkosView = Kokkos::View<int *, Kokkos::DefaultExecutionSpace>;
 using boolKokkosView = Kokkos::View<bool *, Kokkos::DefaultExecutionSpace>;
-using ConstMatRowMapKokkosView = KokkosCsrGraph::row_map_type::const_type;
 
 // Create views using scratch memory space
 typedef Kokkos::DefaultExecutionSpace::scratch_memory_space
@@ -33,6 +33,8 @@ using ScratchScalarView = Kokkos::View<PetscScalar*, ScratchSpace, Kokkos::Memor
 using Scratch2DIntView = Kokkos::View<PetscInt**, ScratchSpace, Kokkos::MemoryUnmanaged>;
 using Scratch2DScalarView = Kokkos::View<PetscScalar**, ScratchSpace, Kokkos::MemoryUnmanaged>;
 using ViewPetscIntPtr = std::shared_ptr<PetscIntKokkosView>;
+using KokkosTeamMemberType = Kokkos::TeamPolicy<DefaultExecutionSpace>::member_type;
+using KokkosCsrMatrix = KokkosSparse::CrsMatrix<PetscScalar, PetscInt, DefaultMemorySpace, void, PetscInt>;
 
 PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *, int, Mat *);
 PETSC_INTERN void rewrite_j_global_to_local(PetscInt, PetscInt&, PetscIntKokkosView, PetscInt**);

--- a/src/C_PETSc_Interfaces.F90
+++ b/src/C_PETSc_Interfaces.F90
@@ -28,109 +28,86 @@ module c_petsc_interfaces
 
    end interface
 
-   interface   
-      
-      subroutine vecscatter_mat_begin_c(A_array, vec_long, cf_markers_nonlocal) &
+   interface
+
+      subroutine vecscatter_mat_begin_c(A_array, vec_long, leaf_vec_array) &
          bind(c, name="vecscatter_mat_begin_c")
          use iso_c_binding
-         integer(c_long_long) :: A_array, vec_long
-         type(c_ptr) :: cf_markers_nonlocal
+         integer(c_long_long) :: A_array, vec_long, leaf_vec_array
 
-      end subroutine vecscatter_mat_begin_c         
- 
-   end interface   
-   
-   interface   
-      
-      subroutine vecscatter_mat_end_c(A_array, vec_long, cf_markers_nonlocal) &
+      end subroutine vecscatter_mat_begin_c
+
+   end interface
+
+   interface
+
+      subroutine vecscatter_mat_end_c(A_array, vec_long, leaf_vec_array, cf_markers_nonlocal) &
          bind(c, name="vecscatter_mat_end_c")
          use iso_c_binding
-         integer(c_long_long) :: A_array, vec_long
+         integer(c_long_long) :: A_array, vec_long, leaf_vec_array
          type(c_ptr) :: cf_markers_nonlocal
 
-      end subroutine vecscatter_mat_end_c         
- 
-   end interface     
+      end subroutine vecscatter_mat_end_c
 
-   interface   
-      
+   end interface
+
+   interface
+
       subroutine boolscatter_mat_begin_c(A_array, assigned_local, assigned_nonlocal) &
          bind(c, name="boolscatter_mat_begin_c")
          use iso_c_binding
          integer(c_long_long) :: A_array
          type(c_ptr), value :: assigned_local, assigned_nonlocal
 
-      end subroutine boolscatter_mat_begin_c         
- 
-   end interface   
-   
-   interface   
-      
+      end subroutine boolscatter_mat_begin_c
+
+   end interface
+
+   interface
+
       subroutine boolscatter_mat_end_c(A_array, assigned_local, assigned_nonlocal) &
          bind(c, name="boolscatter_mat_end_c")
          use iso_c_binding
          integer(c_long_long) :: A_array
          type(c_ptr), value :: assigned_local, assigned_nonlocal
-      end subroutine boolscatter_mat_end_c         
- 
-   end interface     
+      end subroutine boolscatter_mat_end_c
 
-   interface   
-      
+   end interface
+
+   interface
+
       subroutine boolscatter_mat_reverse_begin_c(A_array, assigned_local, assigned_nonlocal) &
          bind(c, name="boolscatter_mat_reverse_begin_c")
          use iso_c_binding
          integer(c_long_long) :: A_array
          type(c_ptr), value :: assigned_local, assigned_nonlocal
 
-      end subroutine boolscatter_mat_reverse_begin_c         
- 
-   end interface   
-   
-   interface   
-      
+      end subroutine boolscatter_mat_reverse_begin_c
+
+   end interface
+
+   interface
+
       subroutine boolscatter_mat_reverse_end_c(A_array, assigned_local, assigned_nonlocal) &
          bind(c, name="boolscatter_mat_reverse_end_c")
          use iso_c_binding
          integer(c_long_long) :: A_array
          type(c_ptr), value :: assigned_local, assigned_nonlocal
-      end subroutine boolscatter_mat_reverse_end_c         
- 
-   end interface      
+      end subroutine boolscatter_mat_reverse_end_c
 
-   interface      
-      
-      subroutine vecscatter_mat_restore_c(A_array, cf_markers_nonlocal) &
+   end interface
+
+   interface
+
+      subroutine vecscatter_mat_restore_c(leaf_vec_array, cf_markers_nonlocal) &
          bind(c, name="vecscatter_mat_restore_c")
          use iso_c_binding
-         integer(c_long_long) :: A_array
+         integer(c_long_long) :: leaf_vec_array
          type(c_ptr) :: cf_markers_nonlocal
 
-      end subroutine vecscatter_mat_restore_c         
- 
-   end interface  
-   
-   interface   
-      
-      subroutine vecscatter_mat_reverse_begin_c(A_array, vec_long) &
-         bind(c, name="vecscatter_mat_reverse_begin_c")
-         use iso_c_binding
-         integer(c_long_long) :: A_array, vec_long
+      end subroutine vecscatter_mat_restore_c
 
-      end subroutine vecscatter_mat_reverse_begin_c         
- 
-   end interface   
-   
-   interface   
-      
-      subroutine vecscatter_mat_reverse_end_c(A_array, vec_long) &
-         bind(c, name="vecscatter_mat_reverse_end_c")
-         use iso_c_binding
-         integer(c_long_long) :: A_array, vec_long
-
-      end subroutine vecscatter_mat_reverse_end_c         
- 
-   end interface    
+   end interface
    
    interface
 
@@ -380,7 +357,7 @@ module c_petsc_interfaces
          integer(c_long_long) :: A_array
          type(c_ptr), value :: measure_local
          integer(c_int), value :: max_luby_steps, pmis_int, zero_meaure_c_point_int
-      end subroutine pmisr_kokkos         
+      end subroutine pmisr_kokkos
  
    end interface     
 
@@ -408,7 +385,7 @@ module c_petsc_interfaces
          PetscReal, value :: max_dd_ratio_achieved
          integer(c_long_long) :: Aff_array
          type(c_ptr), value :: random_numbers_ptr
-      end subroutine ddc_kokkos         
+      end subroutine ddc_kokkos
  
    end interface 
    

--- a/src/C_PETSc_Routines.c
+++ b/src/C_PETSc_Routines.c
@@ -4,94 +4,59 @@
 
 // Include the petsc header files
 #include <petsc.h>
-#include <../src/mat/impls/aij/mpi/mpiaij.h>
 #include <petsc/private/pcimpl.h>
 
-// Does a vecscatter according to the pattern in the given Mat
-// Have to do this in C as there is no fortran interface to MatGetCommunicationStructs
-PETSC_INTERN void vecscatter_mat_begin_c(Mat *matrix, Vec *vec_long, double **nonlocal_vals)
+// Forward scatter using the matrix's own mult PetscSF (the borrowed mvctx) into
+// a caller-owned leaf Vec.
+PETSC_INTERN void vecscatter_mat_begin_c(Mat *matrix, Vec *vec_long, Vec *leaf_vec)
 {
-
-   Mat_MPIAIJ *a = (Mat_MPIAIJ *)((*matrix)->data);
-
-   // Do the scatter
-   PetscCallVoid(VecScatterBegin(a->Mvctx, *vec_long, a->lvec, INSERT_VALUES, SCATTER_FORWARD));
+   PetscSF sf;
+   PetscCallVoid(MatGetMultPetscSF(*matrix, &sf));
+   PetscCallVoid(VecScatterBegin(sf, *vec_long, *leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
 }
 
-// End the scatter started in vecscatter_mat_begin_c and return a pointer
-// Have to call vecscatter_mat_restore_c on the pointer when done
-PETSC_INTERN void vecscatter_mat_end_c(Mat *matrix, Vec *vec_long, double **nonlocal_vals)
+// End the scatter started in vecscatter_mat_begin_c and hand back a raw pointer
+// into leaf_vec for the Fortran caller. Pair with vecscatter_mat_restore_c.
+PETSC_INTERN void vecscatter_mat_end_c(Mat *matrix, Vec *vec_long, Vec *leaf_vec, double **nonlocal_vals)
 {
-
-   Mat_MPIAIJ *a = (Mat_MPIAIJ *)((*matrix)->data);
-   PetscCallVoid(VecScatterEnd(a->Mvctx, *vec_long, a->lvec, INSERT_VALUES, SCATTER_FORWARD));
-
-   // lvec will now have the updated nonlocal values in it
-   // and so we will just return a pointer to the values in that vec
-   // these correspond to the numbering in Ao, with the local to global map for the columns
-   // in colmap
-   PetscCallVoid(VecGetArray(a->lvec, nonlocal_vals));
-   // Have to call a restore once you're done
+   PetscSF sf;
+   PetscCallVoid(MatGetMultPetscSF(*matrix, &sf));
+   PetscCallVoid(VecScatterEnd(sf, *vec_long, *leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
+   PetscCallVoid(VecGetArray(*leaf_vec, nonlocal_vals));
 }
 
-// Does a vecscatter according to the pattern in the given Mat
-// Have to do this in C as there is no fortran interface to MatGetCommunicationStructs
+PETSC_INTERN void vecscatter_mat_restore_c(Vec *leaf_vec, double **nonlocal_vals)
+{
+   PetscCallVoid(VecRestoreArray(*leaf_vec, nonlocal_vals));
+}
+
+// Bool scatter / reduce on the matrix's own mult PetscSF (the borrowed mvctx).
 PETSC_INTERN void boolscatter_mat_begin_c(Mat *matrix, bool *local_vals, bool *nonlocal_vals)
 {
-
-   Mat_MPIAIJ *a = (Mat_MPIAIJ *)((*matrix)->data);
-
-   // Do the scatter
-   PetscCallVoid(PetscSFBcastBegin(a->Mvctx, MPI_C_BOOL, local_vals, nonlocal_vals, MPI_REPLACE));
+   PetscSF sf;
+   PetscCallVoid(MatGetMultPetscSF(*matrix, &sf));
+   PetscCallVoid(PetscSFBcastBegin(sf, MPI_C_BOOL, local_vals, nonlocal_vals, MPI_REPLACE));
 }
 
-// End the scatter started in boolscatter_mat_begin_c and return a pointer
 PETSC_INTERN void boolscatter_mat_end_c(Mat *matrix, bool *local_vals, bool *nonlocal_vals)
 {
-   Mat_MPIAIJ *a = (Mat_MPIAIJ *)((*matrix)->data);
-   PetscCallVoid(PetscSFBcastEnd(a->Mvctx, MPI_C_BOOL, local_vals, nonlocal_vals, MPI_REPLACE));
-}
-
-PETSC_INTERN void vecscatter_mat_restore_c(Mat *matrix, double **nonlocal_vals)
-{
-
-   Mat_MPIAIJ *a = (Mat_MPIAIJ *)((*matrix)->data);
-   PetscCallVoid(VecRestoreArray(a->lvec, nonlocal_vals));
-}
-
-// Does a reverse scatter
-// Must have updated the values in lvec before calling this
-PETSC_INTERN void vecscatter_mat_reverse_begin_c(Mat *matrix, Vec *vec_long)
-{
-
-   Mat_MPIAIJ *a = (Mat_MPIAIJ *)((*matrix)->data);
-   // Could call this but can just access them directly
-   //MatGetCommunicationStructs(*matrix, &lvec, PetscInt *colmap[], &multScatter)
-
-   // Do the reverse scatter - has to be an add
-   PetscCallVoid(VecScatterBegin(a->Mvctx, a->lvec, *vec_long, ADD_VALUES, SCATTER_REVERSE));
-}
-
-PETSC_INTERN void vecscatter_mat_reverse_end_c(Mat *matrix, Vec *vec_long)
-{
-
-   Mat_MPIAIJ *a = (Mat_MPIAIJ *)((*matrix)->data);
-   PetscCallVoid(VecScatterEnd(a->Mvctx, a->lvec, *vec_long, ADD_VALUES, SCATTER_REVERSE));
+   PetscSF sf;
+   PetscCallVoid(MatGetMultPetscSF(*matrix, &sf));
+   PetscCallVoid(PetscSFBcastEnd(sf, MPI_C_BOOL, local_vals, nonlocal_vals, MPI_REPLACE));
 }
 
 PETSC_INTERN void boolscatter_mat_reverse_begin_c(Mat *matrix, bool *local_vals, bool *nonlocal_vals)
 {
-
-   Mat_MPIAIJ *a = (Mat_MPIAIJ *)((*matrix)->data);
-
-   // Do the scatter
-   PetscCallVoid(PetscSFReduceBegin(a->Mvctx, MPI_C_BOOL, nonlocal_vals, local_vals, MPI_LOR));
+   PetscSF sf;
+   PetscCallVoid(MatGetMultPetscSF(*matrix, &sf));
+   PetscCallVoid(PetscSFReduceBegin(sf, MPI_C_BOOL, nonlocal_vals, local_vals, MPI_LOR));
 }
 
 PETSC_INTERN void boolscatter_mat_reverse_end_c(Mat *matrix, bool *local_vals, bool *nonlocal_vals)
 {
-   Mat_MPIAIJ *a = (Mat_MPIAIJ *)((*matrix)->data);
-   PetscCallVoid(PetscSFReduceEnd(a->Mvctx, MPI_C_BOOL, nonlocal_vals, local_vals, MPI_LOR));
+   PetscSF sf;
+   PetscCallVoid(MatGetMultPetscSF(*matrix, &sf));
+   PetscCallVoid(PetscSFReduceEnd(sf, MPI_C_BOOL, nonlocal_vals, local_vals, MPI_LOR));
 }
 
 // Annoying as MPIU_INTEGER is defined in fortran, but not if we call that fortran
@@ -568,7 +533,7 @@ PETSC_INTERN PetscErrorCode MatGetNNZs_both_c(Mat *A, PetscInt *nnzs_local, Pets
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-extern PetscErrorCode MatGetDiagonalMarkers_SeqAIJ(Mat, const PetscInt **, PetscBool *);
+PETSC_EXTERN PetscErrorCode MatGetDiagonalMarkers_SeqAIJ(Mat, const PetscInt **, PetscBool *);
 // Returns true if a matrix is only the diagonal
 PETSC_INTERN PetscErrorCode MatGetDiagonalOnly_c(Mat *A, int *diag_only)
 {
@@ -594,18 +559,36 @@ PETSC_INTERN PetscErrorCode MatGetDiagonalOnly_c(Mat *A, int *diag_only)
      mat_local = *A;
   } 
 
-  Mat_SeqAIJ *a = (Mat_SeqAIJ *)mat_local->data;
   PetscCall(MatGetLocalSize(*A, &local_rows, &local_cols));
   *diag_only = 0;
 
+  // Use MatGetRowIJ to read the SeqAIJ nnz count without touching the private struct.
+  PetscInt local_nnz = 0, nonlocal_nnz = 0;
+  {
+     PetscInt n;
+     PetscBool symmetric = PETSC_FALSE, inodecompressed = PETSC_FALSE, done;
+     const PetscInt *ad_ia;
+     PetscCall(MatGetRowIJ(mat_local, 0, symmetric, inodecompressed, &n, &ad_ia, NULL, &done));
+     local_nnz = ad_ia[n];
+     PetscCall(MatRestoreRowIJ(mat_local, 0, symmetric, inodecompressed, &n, &ad_ia, NULL, &done));
+  }
+
   if (size != 1)
   {
-      Mat_SeqAIJ *b = (Mat_SeqAIJ *)mat_nonlocal->data;
       PetscBool diagDense;
+
+      {
+         PetscInt n;
+         PetscBool symmetric = PETSC_FALSE, inodecompressed = PETSC_FALSE, done;
+         const PetscInt *ao_ia;
+         PetscCall(MatGetRowIJ(mat_nonlocal, 0, symmetric, inodecompressed, &n, &ao_ia, NULL, &done));
+         nonlocal_nnz = ao_ia[n];
+         PetscCall(MatRestoreRowIJ(mat_nonlocal, 0, symmetric, inodecompressed, &n, &ao_ia, NULL, &done));
+      }
 
       // In parallel also have to check the nonlocal has nothing in it
       PetscCall(MatGetDiagonalMarkers_SeqAIJ(mat_local, NULL, &diagDense));
-      if (diagDense && local_rows == a->nz && b->nz == 0)
+      if (diagDense && local_rows == local_nnz && nonlocal_nnz == 0)
       {
          rank_diag_serial++;
       }
@@ -617,12 +600,12 @@ PETSC_INTERN PetscErrorCode MatGetDiagonalOnly_c(Mat *A, int *diag_only)
   {
       PetscBool diagDense;
       PetscCall(MatGetDiagonalMarkers_SeqAIJ(*A, NULL, &diagDense));
-      // In serial easy 
-      if (diagDense && local_rows == a->nz)
+      // In serial easy
+      if (diagDense && local_rows == local_nnz)
       {
          rank_diag++;
       }
-  }   
+  }
 
   // If every rank is diagonal only, the entire matrix is diagonal
   if (rank_diag == size)

--- a/src/Constrain_Z_or_W.F90
+++ b/src/Constrain_Z_or_W.F90
@@ -240,7 +240,9 @@ module constrain_z_or_w
       type(tMat) :: new_z_or_w
       type(c_ptr) :: b_c_nonlocal_c_ptr
       integer(c_long_long) :: A_array, vec_long
+      integer(c_long_long) :: leaf_vec_array
       type(tMat) :: Ad, Ao
+      type(tVec) :: leaf_vec
       PetscInt, dimension(:), pointer :: colmap
       real(c_double), pointer :: b_c_nonlocal(:)
       PetscScalar, dimension(:), pointer :: b_c_local, b_f_vals
@@ -333,16 +335,21 @@ module constrain_z_or_w
          deallocate(b_c_nonlocal_alloc)
          allocate(b_c_nonlocal_alloc(cols_ao, size(null_vecs_c)))
 
+         ! Build a leaf Vec once (sized/typed to match Ao) and reuse it across
+         ! every null-vec iteration. The halo scatter itself uses the matrix's
+         ! own mult PetscSF (via MatGetMultPetscSF inside the C scatter routines),
+         ! and every null_vecs_c(i) shares the column layout of the matrix.
+         call MatCreateVecs(Ao, leaf_vec, PETSC_NULL_VEC, ierr)
+         leaf_vec_array = leaf_vec%v
+
          ! Loop over all the near nullspace vectors and get the nonlocal components
          do null_vec = 1, size(null_vecs_c)
-         
+
             ! We want the nonlocal values in B_c
             vec_long = null_vecs_c(null_vec)%v
 
-            ! Do the comms
-            ! Have to call restore after we're done with lvec (ie null_vecs_c(null_vec))
-            call vecscatter_mat_begin_c(A_array, vec_long, b_c_nonlocal_c_ptr)
-            call vecscatter_mat_end_c(A_array, vec_long, b_c_nonlocal_c_ptr)
+            call vecscatter_mat_begin_c(A_array, vec_long, leaf_vec_array)
+            call vecscatter_mat_end_c(A_array, vec_long, leaf_vec_array, b_c_nonlocal_c_ptr)
             ! Nonlocal vals only pointer
             ! b_c_nonlocal now contains all the nonlocal values of B_c we need for all the nonlocal columns
             ! in every local row
@@ -351,10 +358,12 @@ module constrain_z_or_w
             ! Copy the values
             b_c_nonlocal_alloc(:, null_vec) = b_c_nonlocal
             ! Make sure to restore as soon as we're done with it
-            call vecscatter_mat_restore_c(A_array, b_c_nonlocal_c_ptr)
+            call vecscatter_mat_restore_c(leaf_vec_array, b_c_nonlocal_c_ptr)
 
          end do
-         
+
+         call VecDestroy(leaf_vec, ierr)
+
       ! In serial this is simple
       else
 

--- a/src/DDC_Module.F90
+++ b/src/DDC_Module.F90
@@ -67,6 +67,9 @@ module ddc_module
          return
       end if
 
+      call PetscObjectGetComm(input_mat, MPI_COMM_MATRIX, ierr)
+      call MPI_Comm_rank(MPI_COMM_MATRIX, comm_rank_ddc, errorcode_ddc)
+
       ! Compute the diagonal dominance ratio - either returned in diag_dom_ratio
       ! or stored in a device copy for kokkos
       ! max_dd_ratio_achieved is always returned and is the max diag dom ratio across
@@ -85,8 +88,6 @@ module ddc_module
       random_numbers_ptr = c_null_ptr
       if (trigger_dd_ratio_compute_local) then
          
-         call PetscObjectGetComm(input_mat, MPI_COMM_MATRIX, ierr)
-         call MPI_Comm_rank(MPI_COMM_MATRIX, comm_rank_ddc, errorcode_ddc)
          call MatGetLocalSize(input_mat, local_rows, local_cols, ierr)
          ! We allocate randoms here to be the size of input, rather than 
          ! just F points as if we are on the device the is_fine won't be allocated
@@ -152,7 +153,8 @@ module ddc_module
             call copy_cf_markers_d2h(cf_markers_local_ptr)
             if (trigger_dd_ratio_compute_local) then
                call ddc_cpu(input_mat, is_fine, fraction_swap, max_dd_ratio, max_dd_ratio_achieved, &
-                  diag_dom_ratio, cf_markers_local_two, Aff=Aff_ddc, &
+                  diag_dom_ratio, cf_markers_local_two, &
+                  Aff=Aff_ddc, &
                   diag_dom_ratio_random=diag_dom_ratio_random)
             else
                call ddc_cpu(input_mat, is_fine, fraction_swap, max_dd_ratio, max_dd_ratio_achieved, &
@@ -227,6 +229,10 @@ module ddc_module
       !  for swapping C to F based on row-wise diagonal dominance (ie alpha_diag)
       ! If fraction_swap > 0 it uses fraction_swap as the local fraction of worst C points to swap to F
       !  though it won't hit that fraction exactly as we bin the diag dom ratios for speed, it will be close to the fraction
+      !
+      ! When Aff is present and the trigger path runs, the halo scatters inside
+      ! pmisr_existing_measure_implicit_transpose use Aff's own mult PetscSF
+      ! (obtained via MatGetMultPetscSF), so nothing needs to be forwarded here.
 
       ! ~~~~~~
       type(tMat), target, intent(in)      :: input_mat
@@ -381,7 +387,8 @@ module ddc_module
          ! Uses the implicit transpose version which takes Aff directly
          ! and handles Aff+Aff^T internally without forming the explicit sum
          max_luby_steps = -1
-         call pmisr_existing_measure_implicit_transpose(Aff, max_luby_steps, .FALSE., &
+         call pmisr_existing_measure_implicit_transpose(Aff, &
+                  max_luby_steps, .FALSE., &
                   diag_dom_ratio_measure, cf_markers_local_aff)
 
          ! Let's go and swap the badly diagonally dominant rows to F points

--- a/src/DDC_Modulek.kokkos.cxx
+++ b/src/DDC_Modulek.kokkos.cxx
@@ -1,8 +1,6 @@
 // Our petsc kokkos definitions - has to go first
 #include "kokkos_helper.hpp"
 #include <iostream>
-#include <../src/mat/impls/aij/seq/aij.h>
-#include <../src/mat/impls/aij/mpi/mpiaij.h>
 
 // The definition of the device copy of the cf markers on a given level 
 // is stored in Device_Datak.kokkos.cxx and imported as extern from 
@@ -101,7 +99,7 @@ PETSC_INTERN void ddc_kokkos(Mat *input_mat, const PetscReal fraction_swap, cons
 
          // Call PMISR with implicit transpose - takes Aff directly, handles Aff+Aff^T internally
          // pmis_int=0 means PMISR, zero_measure_c_point_int=0
-         pmisr_existing_measure_implicit_transpose_kokkos(aff, -1, 0, measure_d, cf_markers_aff_d, 0);
+         pmisr_existing_measure_implicit_transpose_kokkos(aff, -1, 0, measure_d, cf_markers_aff_d, 0);  // halo SF obtained from aff via MatGetMultPetscSF inside the callee
 
          // Swap F-tagged points back into cf_markers_d
          Kokkos::parallel_for(

--- a/src/Device_Datak.kokkos.cxx
+++ b/src/Device_Datak.kokkos.cxx
@@ -1,8 +1,6 @@
 // Our petsc kokkos definitions - has to go first
 #include "kokkos_helper.hpp"
 #include <iostream>
-#include <../src/mat/impls/aij/seq/aij.h>
-#include <../src/mat/impls/aij/mpi/mpiaij.h>
 
 // This is a device copy of the cf markers on a given level
 // to save having to copy it to/from the host between pmisr and ddc calls

--- a/src/Gmres_Polyk.kokkos.cxx
+++ b/src/Gmres_Polyk.kokkos.cxx
@@ -159,28 +159,39 @@ PETSC_INTERN void mat_mult_powers_share_sparsity_kokkos(Mat *input_mat, const in
    PetscCallVoid(MatShift(*output_mat, coefficients[0]));
 
    // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
+   // Get pointers to the i,j on the device and Kokkos views to the values
    // This should happen after all the (potentially) host matscale, mataxpy and matshift above
    // ~~~~~~~~~~~~
    const PetscInt *device_submat_i = nullptr, *device_submat_j = nullptr;
    PetscMemType mtype;
-   PetscScalar *device_submat_vals = nullptr;  
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(submatrices[0], &device_submat_i, &device_submat_j, &device_submat_vals, &mtype));  
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(submatrices[0], &device_submat_i, &device_submat_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_submat_vals;
+   PetscCallVoid(MatSeqAIJGetKokkosView(submatrices[0], &device_submat_vals));
 
    const PetscInt *device_local_i_input = nullptr, *device_local_j_input = nullptr, *device_nonlocal_i_input = nullptr, *device_nonlocal_j_input = nullptr;
-   PetscScalar *device_local_vals_input = nullptr, *device_nonlocal_vals_input = nullptr;  
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_input, &device_local_i_input, &device_local_j_input, &device_local_vals_input, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_input, &device_nonlocal_i_input, &device_nonlocal_j_input, &device_nonlocal_vals_input, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_input, &device_local_i_input, &device_local_j_input, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_input, &device_nonlocal_i_input, &device_nonlocal_j_input, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals_input;
+   Kokkos::View<const PetscScalar *> device_nonlocal_vals_input;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local_input, &device_local_vals_input));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal_input, &device_nonlocal_vals_input));
 
    const PetscInt *device_local_i_sparsity = nullptr, *device_local_j_sparsity = nullptr, *device_nonlocal_i_sparsity = nullptr, *device_nonlocal_j_sparsity = nullptr;
-   PetscScalar *device_local_vals_sparsity = nullptr, *device_nonlocal_vals_sparsity = nullptr;  
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_sparsity, &device_local_i_sparsity, &device_local_j_sparsity, &device_local_vals_sparsity, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_sparsity, &device_nonlocal_i_sparsity, &device_nonlocal_j_sparsity, &device_nonlocal_vals_sparsity, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_sparsity, &device_local_i_sparsity, &device_local_j_sparsity, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_sparsity, &device_nonlocal_i_sparsity, &device_nonlocal_j_sparsity, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals_sparsity;
+   Kokkos::View<const PetscScalar *> device_nonlocal_vals_sparsity;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local_sparsity, &device_local_vals_sparsity));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal_sparsity, &device_nonlocal_vals_sparsity));
 
    const PetscInt *device_local_i_output = nullptr, *device_local_j_output = nullptr, *device_nonlocal_i_output = nullptr, *device_nonlocal_j_output = nullptr;
-   PetscScalar *device_local_vals_output = nullptr, *device_nonlocal_vals_output = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, &device_local_j_output, &device_local_vals_output, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_output, &device_nonlocal_j_output, &device_nonlocal_vals_output, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, &device_local_j_output, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_output, &device_nonlocal_j_output, NULL, &mtype));
+   // Output values are accumulated into via += so we need read-write access
+   Kokkos::View<PetscScalar *> device_local_vals_output;
+   Kokkos::View<PetscScalar *> device_nonlocal_vals_output;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local_output, &device_local_vals_output));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal_output, &device_nonlocal_vals_output));
 
    // ~~~~~~~~~~~~~~
    // Build a mapping from the input matrix's nonlocal column indices to the 
@@ -347,12 +358,12 @@ PETSC_INTERN void mat_mult_powers_share_sparsity_kokkos(Mat *input_mat, const in
          // Fill vals_prev
          if (j < local_cols_row_i)
          {
-            vals_prev[j] = device_local_vals_sparsity[device_local_i_sparsity[i] + j];
+            vals_prev[j] = device_local_vals_sparsity(device_local_i_sparsity[i] + j);
          }
          // Nonlocal part
          else
          {
-            vals_prev[j] = device_nonlocal_vals_sparsity[device_nonlocal_i_sparsity[i] + (j - local_cols_row_i)];
+            vals_prev[j] = device_nonlocal_vals_sparsity(device_nonlocal_i_sparsity[i] + (j - local_cols_row_i));
          }
       });
       
@@ -485,16 +496,16 @@ PETSC_INTERN void mat_mult_powers_share_sparsity_kokkos(Mat *input_mat, const in
                      {
                         if (idx_col_of_row_j < local_cols_row_of_col_j)
                         {
-                           val_target = device_local_vals_input[device_local_i_input[row_of_col_j] + idx_col_of_row_j];
+                           val_target = device_local_vals_input(device_local_i_input[row_of_col_j] + idx_col_of_row_j);
                         }
                         else
                         {
-                           val_target = device_nonlocal_vals_input[device_nonlocal_i_input[row_of_col_j] + idx_col_of_row_j - local_cols_row_of_col_j];
+                           val_target = device_nonlocal_vals_input(device_nonlocal_i_input[row_of_col_j] + idx_col_of_row_j - local_cols_row_of_col_j);
                         }
                      }
                      else
                      {
-                        val_target = device_submat_vals[device_submat_i[row_of_col_j] + idx_col_of_row_j];
+                        val_target = device_submat_vals(device_submat_i[row_of_col_j] + idx_col_of_row_j);
                      }
 
                      // Has to be atomic! Potentially lots of contention so maybe not 
@@ -534,12 +545,12 @@ PETSC_INTERN void mat_mult_powers_share_sparsity_kokkos(Mat *input_mat, const in
                   {
                      diag_increm = 1;
                   }
-                  device_local_vals_output[device_local_i_output[i] + j + diag_increm] += coeff_term * vals_temp[j];
+                  device_local_vals_output(device_local_i_output[i] + j + diag_increm) += coeff_term * vals_temp[j];
                }
                // Nonlocal part
                else
                {
-                  device_nonlocal_vals_output[device_nonlocal_i_output[i] + (j - local_cols_row_i)] += coeff_term * vals_temp[j];
+                  device_nonlocal_vals_output(device_nonlocal_i_output[i] + (j - local_cols_row_i)) += coeff_term * vals_temp[j];
                }
             }
 
@@ -552,27 +563,19 @@ PETSC_INTERN void mat_mult_powers_share_sparsity_kokkos(Mat *input_mat, const in
       }
    });
     
-   Mat_SeqAIJKokkos *aijkok_local_output = static_cast<Mat_SeqAIJKokkos *>(mat_local_output->spptr);
-   Mat_SeqAIJKokkos *aijkok_nonlocal_output = NULL;
-   if (mpi) aijkok_nonlocal_output = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_output->spptr);   
-
    Kokkos::fence();
 
-   // Have to specify we've modifed data on the device
-   // Want to call MatSeqAIJKokkosModifyDevice but its PETSC_INTERN
-   aijkok_local_output->a_dual.clear_sync_state();
-   aijkok_local_output->a_dual.modify_device();
-   aijkok_local_output->transpose_updated = PETSC_FALSE;
-   aijkok_local_output->hermitian_updated = PETSC_FALSE;
-   // Invalidate diagonals
-   if (mpi)
-   {
-      aijkok_nonlocal_output->a_dual.clear_sync_state();
-      aijkok_nonlocal_output->a_dual.modify_device();
-      aijkok_nonlocal_output->transpose_updated = PETSC_FALSE;
-      aijkok_nonlocal_output->hermitian_updated = PETSC_FALSE;
-   }      
-   PetscCallVoid(PetscObjectStateIncrease((PetscObject)(*output_mat)));   
+   // Restore the read-only input/sparsity/submat views
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(submatrices[0], &device_submat_vals));
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local_input, &device_local_vals_input));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal_input, &device_nonlocal_vals_input));
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local_sparsity, &device_local_vals_sparsity));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal_sparsity, &device_nonlocal_vals_sparsity));
+
+   // The matching restore handles MatSeqAIJKokkosModifyDevice (clears sync state,
+   // marks device modified, invalidates transpose/hermitian, bumps object state).
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local_output, &device_local_vals_output));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal_output, &device_nonlocal_vals_output));
 
    for (int i = 1; i < poly_sparsity_order; i++)
    {

--- a/src/Grid_Transferk.kokkos.cxx
+++ b/src/Grid_Transferk.kokkos.cxx
@@ -54,13 +54,16 @@ PETSC_INTERN void generate_one_point_with_one_entry_from_sparse_kokkos(Mat *inpu
    PetscCallVoid(MatGetOwnershipRangeColumn(*input_mat, &global_col_start, &global_col_end_plus_one));
 
    // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
+   // Get pointers to the i,j on the device and Kokkos views to the values
    // ~~~~~~~~~~~~
    const PetscInt *device_local_i = nullptr, *device_local_j = nullptr, *device_nonlocal_i = nullptr, *device_nonlocal_j = nullptr;
    PetscMemType mtype;
-   PetscScalar *device_local_vals = nullptr, *device_nonlocal_vals = nullptr;  
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, &device_local_vals, &mtype));  
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, &device_nonlocal_vals, &mtype));          
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals;
+   Kokkos::View<const PetscScalar *> device_nonlocal_vals;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    // ~~~~~~~~~~~~
    // Get the number of nnzs
@@ -100,8 +103,8 @@ PETSC_INTERN void generate_one_point_with_one_entry_from_sparse_kokkos(Mat *inpu
          [&](const PetscInt j, ReduceDataMaxRow& thread_data) {
 
             // If it's the biggest value keep it
-            if (Kokkos::abs(device_local_vals[device_local_i[i] + j]) > thread_data.val) {
-               thread_data.val = Kokkos::abs(device_local_vals[device_local_i[i] + j]);
+            if (Kokkos::abs(device_local_vals(device_local_i[i] + j)) > thread_data.val) {
+               thread_data.val = Kokkos::abs(device_local_vals(device_local_i[i] + j));
                thread_data.col = device_local_j[device_local_i[i] + j];
             }
          }, local_row_result
@@ -115,8 +118,8 @@ PETSC_INTERN void generate_one_point_with_one_entry_from_sparse_kokkos(Mat *inpu
             [&](const PetscInt j, ReduceDataMaxRow& thread_data) {
 
                // If it's the biggest value keep it
-               if (Kokkos::abs(device_nonlocal_vals[device_nonlocal_i[i] + j]) > thread_data.val) {
-                  thread_data.val = Kokkos::abs(device_nonlocal_vals[device_nonlocal_i[i] + j]);
+               if (Kokkos::abs(device_nonlocal_vals(device_nonlocal_i[i] + j)) > thread_data.val) {
+                  thread_data.val = Kokkos::abs(device_nonlocal_vals(device_nonlocal_i[i] + j));
                   // Set the global index
                   thread_data.col = colmap_input_d(device_nonlocal_j[device_nonlocal_i[i] + j]);
                }
@@ -290,11 +293,14 @@ PETSC_INTERN void generate_one_point_with_one_entry_from_sparse_kokkos(Mat *inpu
       // We can now create our MPI matrix
       PetscCallVoid(MatCreateMPIAIJWithSeqAIJ(MPI_COMM_MATRIX, global_rows, global_cols, output_mat_local, output_mat_nonlocal, garray_host, output_mat));
    }     
-   // If in serial 
+   // If in serial
    else
    {
       *output_mat = output_mat_local;
    }
+
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    return;
 }
@@ -373,13 +379,16 @@ PETSC_INTERN void compute_P_from_W_kokkos(Mat *input_mat, PetscInt global_row_st
    PetscCallVoid(PetscObjectGetComm((PetscObject)*input_mat, &MPI_COMM_MATRIX));
 
    // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
+   // Get pointers to the i,j on the device and Kokkos views to the values
    // ~~~~~~~~~~~~
    const PetscInt *device_local_i = nullptr, *device_local_j = nullptr, *device_nonlocal_i = nullptr, *device_nonlocal_j = nullptr;
    PetscMemType mtype;
-   PetscScalar *device_local_vals = nullptr, *device_nonlocal_vals = nullptr;  
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, &device_local_vals, &mtype));  
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, &device_nonlocal_vals, &mtype));          
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals;
+   Kokkos::View<const PetscScalar *> device_nonlocal_vals;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    PetscIntKokkosView nnz_match_local_row_d;
    PetscIntKokkosView nnz_match_nonlocal_row_d;
@@ -552,14 +561,14 @@ PETSC_INTERN void compute_P_from_W_kokkos(Mat *input_mat, PetscInt global_row_st
                Kokkos::TeamThreadRange(t, ncols_local), [&](const PetscInt j) {
 
                j_local_d(i_local_d(row_index) + j) = device_local_j[device_local_i[i] + j];
-               a_local_d(i_local_d(row_index) + j) = device_local_vals[device_local_i[i] + j];
-                     
-            });     
+               a_local_d(i_local_d(row_index) + j) = device_local_vals(device_local_i[i] + j);
+
+            });
 
             // For over nonlocal columns - copy in W
             if (mpi)
             {
-               PetscInt ncols_nonlocal = device_nonlocal_i[i + 1] - device_nonlocal_i[i];         
+               PetscInt ncols_nonlocal = device_nonlocal_i[i + 1] - device_nonlocal_i[i];
 
                Kokkos::parallel_for(
                   Kokkos::TeamThreadRange(t, ncols_nonlocal), [&](const PetscInt j) {
@@ -567,7 +576,7 @@ PETSC_INTERN void compute_P_from_W_kokkos(Mat *input_mat, PetscInt global_row_st
                   // We keep the existing local indices in the off-diagonal block here
                   // we have all the same columns as W and hence the same garray
                   j_nonlocal_d(i_nonlocal_d(row_index) + j) = device_nonlocal_j[device_nonlocal_i[i] + j];
-                  a_nonlocal_d(i_nonlocal_d(row_index) + j) = device_nonlocal_vals[device_nonlocal_i[i] + j];
+                  a_nonlocal_d(i_nonlocal_d(row_index) + j) = device_nonlocal_vals(device_nonlocal_i[i] + j);
                         
                });          
             }
@@ -585,24 +594,17 @@ PETSC_INTERN void compute_P_from_W_kokkos(Mat *input_mat, PetscInt global_row_st
       {
          mat_local_output = *output_mat;
       }     
-      Mat_SeqAIJKokkos *aijkok_local_output = static_cast<Mat_SeqAIJKokkos *>(mat_local_output->spptr);
-      Mat_SeqAIJKokkos *aijkok_nonlocal_output = NULL;
-      if (mpi) aijkok_nonlocal_output = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_output->spptr);
-
-      // Annoying we can't just call MatSeqAIJGetKokkosView
-      a_local_d = aijkok_local_output->a_dual.view_device();
-      if (mpi) a_nonlocal_d = aijkok_nonlocal_output->a_dual.view_device();
-
-      // Annoyingly there isn't currently the ability to get views for i (or j)
-      const PetscInt *device_local_i_output = nullptr, *device_nonlocal_i_ouput = nullptr;
+      // Get device pointers for the existing i array
+      const PetscInt *device_local_i_output = nullptr, *device_nonlocal_i_output = nullptr;
       PetscMemType mtype;
-      PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, NULL, NULL, &mtype));  
-      if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_ouput, NULL, NULL, &mtype));  
+      PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, NULL, NULL, &mtype));
+      if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_output, NULL, NULL, &mtype));
 
-      // Have these point at the existing i pointers - we don't need j if we're reusing
-      ConstMatRowMapKokkosView i_local_const_d = ConstMatRowMapKokkosView(device_local_i_output, local_rows+1);
-      ConstMatRowMapKokkosView i_nonlocal_const_d;
-      if (mpi) i_nonlocal_const_d = ConstMatRowMapKokkosView(device_nonlocal_i_ouput, local_rows+1);        
+      // Read-write Kokkos views to the values - we only update the W block, the identity block is preserved
+      Kokkos::View<PetscScalar *> device_local_a_output;
+      Kokkos::View<PetscScalar *> device_nonlocal_a_output;
+      PetscCallVoid(MatSeqAIJGetKokkosView(mat_local_output, &device_local_a_output));
+      if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal_output, &device_nonlocal_a_output));
 
       // Only have to write W as the identity block cannot change
       // Loop over the rows of W - annoying we have const views as this is just the same loop as above
@@ -616,49 +618,38 @@ PETSC_INTERN void compute_P_from_W_kokkos(Mat *input_mat, PetscInt global_row_st
             // Convert to global fine index into a local index in the full matrix
             PetscInt row_index = fine_view_d(i) - global_row_start;
             // Still using i here (the local index into W)
-            const PetscInt ncols_local = device_local_i[i + 1] - device_local_i[i];         
+            const PetscInt ncols_local = device_local_i[i + 1] - device_local_i[i];
 
             // For over local columns - copy in W
             Kokkos::parallel_for(
                Kokkos::TeamThreadRange(t, ncols_local), [&](const PetscInt j) {
 
-               a_local_d(i_local_const_d(row_index) + j) = device_local_vals[device_local_i[i] + j];
-                     
-            });     
+               device_local_a_output(device_local_i_output[row_index] + j) = device_local_vals(device_local_i[i] + j);
+
+            });
 
             // For over nonlocal columns - copy in W
             if (mpi)
             {
-               PetscInt ncols_nonlocal = device_nonlocal_i[i + 1] - device_nonlocal_i[i];         
+               PetscInt ncols_nonlocal = device_nonlocal_i[i + 1] - device_nonlocal_i[i];
 
                Kokkos::parallel_for(
                   Kokkos::TeamThreadRange(t, ncols_nonlocal), [&](const PetscInt j) {
 
                   // We keep the existing local indices in the off-diagonal blocl here
                   // we have all the same columns as W and hence the same garray
-                  a_nonlocal_d(i_nonlocal_const_d(row_index) + j) = device_nonlocal_vals[device_nonlocal_i[i] + j];
-                        
-               });          
+                  device_nonlocal_a_output(device_nonlocal_i_output[row_index] + j) = device_nonlocal_vals(device_nonlocal_i[i] + j);
+
+               });
             }
-      });   
+      });
 
       Kokkos::fence();
 
-      // Have to specify we've modifed data on the device
-      // Want to call MatSeqAIJKokkosModifyDevice but its PETSC_INTERN
-      aijkok_local_output->a_dual.clear_sync_state();
-      aijkok_local_output->a_dual.modify_device();
-      aijkok_local_output->transpose_updated = PETSC_FALSE;
-      aijkok_local_output->hermitian_updated = PETSC_FALSE;
-      // Invalidate diagonals
-      if (mpi)
-      {
-         aijkok_nonlocal_output->a_dual.clear_sync_state();
-         aijkok_nonlocal_output->a_dual.modify_device();
-         aijkok_nonlocal_output->transpose_updated = PETSC_FALSE;
-         aijkok_nonlocal_output->hermitian_updated = PETSC_FALSE;
-      }      
-      PetscCallVoid(PetscObjectStateIncrease((PetscObject)(*output_mat)));
+      // The matching restore handles MatSeqAIJKokkosModifyDevice (clears sync state,
+      // marks device modified, invalidates transpose/hermitian, bumps object state).
+      PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local_output, &device_local_a_output));
+      if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal_output, &device_nonlocal_a_output));
 
    }
 
@@ -716,6 +707,9 @@ PETSC_INTERN void compute_P_from_W_kokkos(Mat *input_mat, PetscInt global_row_st
 
    PetscCallVoid(ISRestoreIndices(*is_fine, &fine_indices_ptr));
    PetscCallVoid(ISRestoreIndices(*is_coarse, &coarse_indices_ptr));
+
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    return;
 }
@@ -858,16 +852,19 @@ PETSC_INTERN void compute_R_from_Z_kokkos(Mat *input_mat, PetscInt global_row_st
    PetscCallVoid(PetscLogCpuToGpu(bytes));        
    Kokkos::deep_copy(exec, orig_view_d, orig_view_h); 
    bytes = orig_view_h.extent(0) * sizeof(PetscInt);
-   PetscCallVoid(PetscLogCpuToGpu(bytes));       
+   PetscCallVoid(PetscLogCpuToGpu(bytes));
 
    // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
+   // Get pointers to the i,j on the device and Kokkos views to the values
    // ~~~~~~~~~~~~
    const PetscInt *device_local_i = nullptr, *device_local_j = nullptr, *device_nonlocal_i = nullptr, *device_nonlocal_j = nullptr;
    PetscMemType mtype;
-   PetscScalar *device_local_vals = nullptr, *device_nonlocal_vals = nullptr;  
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, &device_local_vals, &mtype));  
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, &device_nonlocal_vals, &mtype));          
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals;
+   Kokkos::View<const PetscScalar *> device_nonlocal_vals;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    PetscIntKokkosView nnz_match_local_row_d;
    PetscIntKokkosView nnz_match_nonlocal_row_d;
@@ -1014,7 +1011,7 @@ PETSC_INTERN void compute_R_from_Z_kokkos(Mat *input_mat, PetscInt global_row_st
                // Want the local col indices for the local block
                // The orig_view_d contains the global indices for the original full matrix
                j_local_d(i_local_d(row_index) + j) = orig_view_d(device_local_j[device_local_i[i] + j]) - global_row_start;
-               a_local_d(i_local_d(row_index) + j) = device_local_vals[device_local_i[i] + j];
+               a_local_d(i_local_d(row_index) + j) = device_local_vals(device_local_i[i] + j);
                      
             });     
 
@@ -1030,7 +1027,7 @@ PETSC_INTERN void compute_R_from_Z_kokkos(Mat *input_mat, PetscInt global_row_st
                   // we have all the same non-local local column indices as Z (as the identity added is always local)
                   // The garray is the same size, its just the global indices that have changed
                   j_nonlocal_d(i_nonlocal_d(row_index) + j) = device_nonlocal_j[device_nonlocal_i[i] + j];
-                  a_nonlocal_d(i_nonlocal_d(row_index) + j) = device_nonlocal_vals[device_nonlocal_i[i] + j];
+                  a_nonlocal_d(i_nonlocal_d(row_index) + j) = device_nonlocal_vals(device_nonlocal_i[i] + j);
                         
                });          
             }
@@ -1059,27 +1056,19 @@ PETSC_INTERN void compute_R_from_Z_kokkos(Mat *input_mat, PetscInt global_row_st
       {
          mat_local_output = *output_mat;
       }     
-      Mat_SeqAIJKokkos *aijkok_local_output = static_cast<Mat_SeqAIJKokkos *>(mat_local_output->spptr);
-      Mat_SeqAIJKokkos *aijkok_nonlocal_output = NULL;
-      if (mpi) aijkok_nonlocal_output = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_output->spptr);
-
-      // Annoying we can't just call MatSeqAIJGetKokkosView
-      a_local_d = aijkok_local_output->a_dual.view_device();
-      if (mpi) a_nonlocal_d = aijkok_nonlocal_output->a_dual.view_device();
-
-      // Annoyingly there isn't currently the ability to get views for i (or j)
-      const PetscInt *device_local_i_output = nullptr, *device_local_j_output = nullptr, *device_nonlocal_i_ouput = nullptr;
+      // Get device pointers for the existing i and j arrays
+      const PetscInt *device_local_i_output = nullptr, *device_local_j_output = nullptr, *device_nonlocal_i_output = nullptr;
       PetscMemType mtype;
-      PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, &device_local_j_output, NULL, &mtype));  
-      if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_ouput, NULL, NULL, &mtype));  
+      PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, &device_local_j_output, NULL, &mtype));
+      if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_output, NULL, NULL, &mtype));
 
-      // Have these point at the existing i pointers - we only need the local j
-      ConstMatRowMapKokkosView i_local_const_d = ConstMatRowMapKokkosView(device_local_i_output, local_rows_z+1);
-      ConstMatRowMapKokkosView j_local_const_d = ConstMatRowMapKokkosView(device_local_j_output, aijkok_local_output->csrmat.nnz());
-      ConstMatRowMapKokkosView i_nonlocal_const_d;
-      if (mpi) i_nonlocal_const_d = ConstMatRowMapKokkosView(device_nonlocal_i_ouput, local_rows_z+1);        
+      // Read-write Kokkos views to the values - we update the Z block, the identity entries are preserved
+      Kokkos::View<PetscScalar *> device_local_a_output;
+      Kokkos::View<PetscScalar *> device_nonlocal_a_output;
+      PetscCallVoid(MatSeqAIJGetKokkosView(mat_local_output, &device_local_a_output));
+      if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal_output, &device_nonlocal_a_output));
 
-      // Only have to write Z but have to be careful as we have the identity mixed 
+      // Only have to write Z but have to be careful as we have the identity mixed
       // in there
       // Loop over the rows of Z - annoying we have const views as this is just the same loop as above
       Kokkos::parallel_for(
@@ -1092,7 +1081,7 @@ PETSC_INTERN void compute_R_from_Z_kokkos(Mat *input_mat, PetscInt global_row_st
             // Simple row index
             PetscInt row_index = i;
             // Still using i here (the local index into Z)
-            const PetscInt ncols_local = device_local_i[i + 1] - device_local_i[i];         
+            const PetscInt ncols_local = device_local_i[i + 1] - device_local_i[i];
 
             // For over local columns - copy in Z
             // We have to skip over the identity entries, which we know are always C points
@@ -1103,43 +1092,32 @@ PETSC_INTERN void compute_R_from_Z_kokkos(Mat *input_mat, PetscInt global_row_st
 
                // If we're at or after the C point identity, our index into R gets a +1
                // so we skip over writing to that index in R
-               if (j_local_const_d(i_local_const_d(row_index) + j) >= coarse_view_d(i) - global_row_start) offset = 1;
-               a_local_d(i_local_const_d(row_index) + j + offset) = device_local_vals[device_local_i[i] + j];
-            });     
+               if (device_local_j_output[device_local_i_output[row_index] + j] >= coarse_view_d(i) - global_row_start) offset = 1;
+               device_local_a_output(device_local_i_output[row_index] + j + offset) = device_local_vals(device_local_i[i] + j);
+            });
 
             // For over nonlocal columns - copy in Z - identical structure in the off-diag block
             if (mpi)
             {
-               PetscInt ncols_nonlocal = device_nonlocal_i[i + 1] - device_nonlocal_i[i];         
+               PetscInt ncols_nonlocal = device_nonlocal_i[i + 1] - device_nonlocal_i[i];
 
                Kokkos::parallel_for(
                   Kokkos::TeamThreadRange(t, ncols_nonlocal), [&](const PetscInt j) {
 
                   // We keep the existing local indices in the off-diagonal block here
                   // we have all the same columns as Z and hence the same garray
-                  a_nonlocal_d(i_nonlocal_const_d(row_index) + j) = device_nonlocal_vals[device_nonlocal_i[i] + j];
-                        
-               });          
+                  device_nonlocal_a_output(device_nonlocal_i_output[row_index] + j) = device_nonlocal_vals(device_nonlocal_i[i] + j);
+
+               });
             }
-      });   
+      });
 
       Kokkos::fence();
 
-      // Have to specify we've modifed data on the device
-      // Want to call MatSeqAIJKokkosModifyDevice but its PETSC_INTERN
-      aijkok_local_output->a_dual.clear_sync_state();
-      aijkok_local_output->a_dual.modify_device();
-      aijkok_local_output->transpose_updated = PETSC_FALSE;
-      aijkok_local_output->hermitian_updated = PETSC_FALSE;
-      // Invalidate diagonals
-      if (mpi)
-      {
-         aijkok_nonlocal_output->a_dual.clear_sync_state();
-         aijkok_nonlocal_output->a_dual.modify_device();
-         aijkok_nonlocal_output->transpose_updated = PETSC_FALSE;
-         aijkok_nonlocal_output->hermitian_updated = PETSC_FALSE;
-      }        
-      PetscCallVoid(PetscObjectStateIncrease((PetscObject)(*output_mat)));
+      // The matching restore handles MatSeqAIJKokkosModifyDevice (clears sync state,
+      // marks device modified, invalidates transpose/hermitian, bumps object state).
+      PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local_output, &device_local_a_output));
+      if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal_output, &device_nonlocal_a_output));
 
     }
 
@@ -1190,6 +1168,9 @@ PETSC_INTERN void compute_R_from_Z_kokkos(Mat *input_mat, PetscInt global_row_st
    PetscCallVoid(ISRestoreIndices(*is_fine, &fine_indices_ptr));
    PetscCallVoid(ISRestoreIndices(*is_coarse, &coarse_indices_ptr));
    PetscCallVoid(ISRestoreIndices(*orig_fine_col_indices, &is_pointer_orig_fine_col));
+
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    return;
 }

--- a/src/MatDiagDom.F90
+++ b/src/MatDiagDom.F90
@@ -32,10 +32,8 @@ module matdiagdom
       PetscReal, dimension(:), allocatable, target, intent(out) :: diag_dom_ratio
       PetscReal, intent(out)              :: max_dd_ratio_achieved
 
-      PetscErrorCode :: ierr
-      MPIU_Comm :: MPI_COMM_MATRIX
-
 #if defined(PETSC_HAVE_KOKKOS)
+      PetscErrorCode :: ierr
       integer :: errorcode, ifree
       MatType :: mat_type
       PetscReal :: tol, diff
@@ -46,8 +44,6 @@ module matdiagdom
       PetscReal :: max_dd_ratio_cpu
 #endif
 
-      call PetscObjectGetComm(input_mat, MPI_COMM_MATRIX, ierr)
-
 #if defined(PETSC_HAVE_KOKKOS)
       call MatGetType(input_mat, mat_type, ierr)
       if (mat_type == MATMPIAIJKOKKOS .OR. mat_type == MATSEQAIJKOKKOS .OR. &
@@ -56,6 +52,7 @@ module matdiagdom
          A_array = input_mat%v
          local_rows_aff_kokkos = 0
          max_dd_ratio_achieved = 0d0
+
          call MatDiagDomRatio_kokkos(A_array, max_dd_ratio_achieved, local_rows_aff_kokkos)
 
          if (kokkos_debug()) then
@@ -65,7 +62,8 @@ module matdiagdom
                call copy_diag_dom_ratio_d2h(diag_dom_ratio_ptr)
             end if
 
-            call MatDiagDomRatio_cpu(input_mat, is_fine, cf_markers_local, diag_dom_ratio_cpu, max_dd_ratio_cpu)
+            call MatDiagDomRatio_cpu(input_mat, is_fine, cf_markers_local, &
+                                     diag_dom_ratio_cpu, max_dd_ratio_cpu)
 
             tol = dd_ratio_abs_tol + dd_ratio_rel_tol * max(abs(max_dd_ratio_cpu), abs(max_dd_ratio_achieved))
             if (abs(max_dd_ratio_cpu - max_dd_ratio_achieved) > tol) then
@@ -85,22 +83,29 @@ module matdiagdom
             deallocate(diag_dom_ratio_cpu)
          end if
       else
-         call MatDiagDomRatio_cpu(input_mat, is_fine, cf_markers_local, diag_dom_ratio, max_dd_ratio_achieved)
+         call MatDiagDomRatio_cpu(input_mat, is_fine, cf_markers_local, &
+                                  diag_dom_ratio, max_dd_ratio_achieved)
       end if
 #else
-      call MatDiagDomRatio_cpu(input_mat, is_fine, cf_markers_local, diag_dom_ratio, max_dd_ratio_achieved)
+      call MatDiagDomRatio_cpu(input_mat, is_fine, cf_markers_local, &
+                               diag_dom_ratio, max_dd_ratio_achieved)
 #endif
 
    end subroutine MatDiagDomRatio
 
 ! -------------------------------------------------------------------------------------------------------------------------------
 
-   subroutine MatDiagDomRatio_cpu(input_mat, is_fine, cf_markers_local, diag_dom_ratio, max_dd_ratio_achieved)
+   subroutine MatDiagDomRatio_cpu(input_mat, is_fine, cf_markers_local, &
+                                  diag_dom_ratio, max_dd_ratio_achieved)
 
       ! Compute diagonal dominance ratio over local fine rows of input_mat
       ! without extracting Aff. This mirrors the Kokkos MatDiagDomRatio path:
       ! sum abs(F-neighbour off-diagonals) / abs(F-diagonal), with nonlocal
       ! F markers obtained from the matrix halo scatter.
+      !
+      ! The halo scatter uses input_mat's own mult PetscSF (via MatGetMultPetscSF
+      ! inside the C scatter routines); we build a matching leaf Vec locally and
+      ! destroy it at the end.
 
       ! ~~~~~~
 
@@ -119,9 +124,9 @@ module matdiagdom
       PetscErrorCode :: ierr
       integer :: errorcode, comm_size
       MPIU_Comm :: MPI_COMM_MATRIX
-      integer(c_long_long) :: A_array, vec_long
+      integer(c_long_long) :: vec_long, A_array, leaf_vec_array
       type(tMat) :: Ad, Ao
-      type(tVec) :: cf_markers_vec
+      type(tVec) :: cf_markers_vec, leaf_vec
       PetscInt, dimension(:), pointer :: is_pointer => null(), colmap => null()
       PetscInt, dimension(:), pointer :: ad_ia => null(), ad_ja => null(), ao_ia => null(), ao_ja => null()
       PetscScalar, dimension(:), pointer :: ad_vals => null(), ao_vals => null()
@@ -185,10 +190,16 @@ module matdiagdom
 
          call VecCreateMPIWithArray(MPI_COMM_MATRIX, one, local_rows, global_rows, &
                cf_markers_local_real, cf_markers_vec, ierr)
-         A_array = input_mat%v
          vec_long = cf_markers_vec%v
-         call vecscatter_mat_begin_c(A_array, vec_long, cf_markers_nonlocal_ptr)
-         call vecscatter_mat_end_c(A_array, vec_long, cf_markers_nonlocal_ptr)
+
+         ! Leaf Vec sized/typed to match the off-diagonal block
+         call MatCreateVecs(Ao, leaf_vec, PETSC_NULL_VEC, ierr)
+         leaf_vec_array = leaf_vec%v
+
+         ! Use input_mat's mult SF + the local leaf Vec for the single halo scatter.
+         A_array = input_mat%v
+         call vecscatter_mat_begin_c(A_array, vec_long, leaf_vec_array)
+         call vecscatter_mat_end_c(A_array, vec_long, leaf_vec_array, cf_markers_nonlocal_ptr)
          call c_f_pointer(cf_markers_nonlocal_ptr, cf_markers_nonlocal, shape=[cols_ao])
       end if
 
@@ -231,8 +242,9 @@ module matdiagdom
 
       ! Cleanup for halo scatter resources.
       if (mpi) then
-         call vecscatter_mat_restore_c(A_array, cf_markers_nonlocal_ptr)
+         call vecscatter_mat_restore_c(leaf_vec_array, cf_markers_nonlocal_ptr)
          call VecDestroy(cf_markers_vec, ierr)
+         call VecDestroy(leaf_vec, ierr)
          deallocate(cf_markers_local_real)
       end if
 

--- a/src/MatDiagDomk.kokkos.cxx
+++ b/src/MatDiagDomk.kokkos.cxx
@@ -1,8 +1,6 @@
 // Our petsc kokkos definitions - has to go first
 #include "kokkos_helper.hpp"
 #include <iostream>
-#include <../src/mat/impls/aij/seq/aij.h>
-#include <../src/mat/impls/aij/mpi/mpiaij.h>
 
 // The definition of the device copy of the cf markers on a given level 
 // is stored in Device_Datak.kokkos.cxx and imported as extern from 
@@ -21,24 +19,26 @@ PETSC_INTERN void MatDiagDomRatio_kokkos(Mat *input_mat, PetscReal *max_dd_ratio
    MPI_Comm MPI_COMM_MATRIX;
    PetscCallVoid(MatGetType(*input_mat, &mat_type));
 
-   const bool mpi = strcmp(mat_type, MATMPIAIJKOKKOS) == 0;   
+   const bool mpi = strcmp(mat_type, MATMPIAIJKOKKOS) == 0;
    PetscCallVoid(PetscObjectGetComm((PetscObject)*input_mat, &MPI_COMM_MATRIX));
-   PetscCallVoid(MatGetLocalSize(*input_mat, &local_rows, &local_cols)); 
+   PetscCallVoid(MatGetLocalSize(*input_mat, &local_rows, &local_cols));
 
-   Mat_MPIAIJ *mat_mpi = nullptr;
-   Mat mat_local = NULL, mat_nonlocal = NULL;   
+   Mat mat_local = NULL, mat_nonlocal = NULL;
+   // The matrix's own mult SF (the borrowed mvctx) drives the halo scatter;
+   // we build a matching leaf Vec locally and destroy it once done.
+   PetscSF sf = NULL;
+   Vec leaf_vec = NULL;
 
    PetscInt rows_ao, cols_ao;
    if (mpi)
    {
-      mat_mpi = (Mat_MPIAIJ *)(*input_mat)->data;
-      PetscCallVoid(MatMPIAIJGetSeqAIJ(*input_mat, &mat_local, &mat_nonlocal, NULL));      
+      PetscCallVoid(MatMPIAIJGetSeqAIJ(*input_mat, &mat_local, &mat_nonlocal, NULL));
       PetscCallVoid(MatGetSize(mat_nonlocal, &rows_ao, &cols_ao));
    }
    else
    {
       mat_local = *input_mat;
-   }   
+   }
 
    // Can't use the global directly within the parallel 
    // regions on the device
@@ -70,6 +70,10 @@ PETSC_INTERN void MatDiagDomRatio_kokkos(Mat *input_mat, PetscReal *max_dd_ratio
    {
       cf_markers_nonlocal_d = intKokkosView("cf_markers_nonlocal_d", cols_ao);
 
+      // Borrowed mult SF + locally-built leaf Vec (sized/typed to match Ao)
+      PetscCallVoid(MatGetMultPetscSF(*input_mat, &sf));
+      PetscCallVoid(MatCreateVecs(mat_nonlocal, &leaf_vec, NULL));
+
       // Scatter cf_markers via VecScatter (int -> PetscScalar conversion required)
       PetscCallVoid(MatCreateVecs(*input_mat, &scatter_root_vec, NULL));
       {
@@ -83,10 +87,10 @@ PETSC_INTERN void MatDiagDomRatio_kokkos(Mat *input_mat, PetscReal *max_dd_ratio
       }
 
       // Start comms, then overlap with local-only work below.
-      // Mvctx must have only one active comm at a time.
+      // The SF must have only one active comm at a time.
       // Ensure send/receive buffers are stable before Begin.
-      Kokkos::fence();      
-      PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, scatter_root_vec, mat_mpi->lvec, INSERT_VALUES, SCATTER_FORWARD));
+      Kokkos::fence();
+      PetscCallVoid(VecScatterBegin(sf, scatter_root_vec, leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
    }
 
    // ~~~~~~~~~~~~~~~
@@ -158,17 +162,18 @@ PETSC_INTERN void MatDiagDomRatio_kokkos(Mat *input_mat, PetscReal *max_dd_ratio
    // Finish the in-flight scatter and only then read from the receive buffer.
    if (mpi)
    {
-      PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, scatter_root_vec, mat_mpi->lvec, INSERT_VALUES, SCATTER_FORWARD));
+      PetscCallVoid(VecScatterEnd(sf, scatter_root_vec, leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
       {
          ConstPetscScalarKokkosView lvec_scalar_d;
-         PetscCallVoid(VecGetKokkosView(mat_mpi->lvec, &lvec_scalar_d));
+         PetscCallVoid(VecGetKokkosView(leaf_vec, &lvec_scalar_d));
          Kokkos::parallel_for(
             Kokkos::RangePolicy<>(exec, 0, cols_ao), KOKKOS_LAMBDA(PetscInt i) {
                cf_markers_nonlocal_d(i) = (int)lvec_scalar_d(i);
          });
-         PetscCallVoid(VecRestoreKokkosView(mat_mpi->lvec, &lvec_scalar_d));
+         PetscCallVoid(VecRestoreKokkosView(leaf_vec, &lvec_scalar_d));
       }
       PetscCallVoid(VecDestroy(&scatter_root_vec));
+      PetscCallVoid(VecDestroy(&leaf_vec));
       Kokkos::fence();
    }
 

--- a/src/PCAIR.c
+++ b/src/PCAIR.c
@@ -205,6 +205,10 @@ PETSC_EXTERN void compute_cf_splitting(Mat input_mat, int symmetric_int,
    int ddc_its, double fraction_swap,
    IS *is_fine, IS *is_coarse)
 {
+   // Now we call petsc fortran routines in compute_cf_splitting_c from this C file
+   // so we have to have made sure this is called
+   // Otherwise things like PETSC_NULL_INTEGER_ARRAY aren't defined
+   PetscCallVoid(PetscInitializeFortran());
    compute_cf_splitting_c(&input_mat, symmetric_int, strong_threshold,
       max_luby_steps, cf_splitting_type, ddc_its, fraction_swap,
       is_fine, is_coarse);
@@ -212,6 +216,10 @@ PETSC_EXTERN void compute_cf_splitting(Mat input_mat, int symmetric_int,
 
 PETSC_EXTERN void compute_diag_dom_submatrix(Mat input_mat, double max_dd_ratio, Mat *output_mat)
 {
+   // Now we call petsc fortran routines in compute_cf_splitting_c from this C file
+   // so we have to have made sure this is called
+   // Otherwise things like PETSC_NULL_INTEGER_ARRAY aren't defined
+   PetscCallVoid(PetscInitializeFortran());
    compute_diag_dom_submatrix_c(&input_mat, max_dd_ratio, output_mat);
 }
 

--- a/src/PETSc_Helperk.kokkos.cxx
+++ b/src/PETSc_Helperk.kokkos.cxx
@@ -3,8 +3,6 @@
 #include <cmath>
 #include <iostream>
 #include <limits>
-#include <../src/mat/impls/aij/seq/aij.h>
-#include <../src/mat/impls/aij/mpi/mpiaij.h>
 
 //------------------------------------------------------------------------------------------------------------------------
 
@@ -158,13 +156,16 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
    const PetscInt global_col_end_plus_one = global_col_end_plus_one_temp;
 
    // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
+   // Get pointers to the i,j on the device and Kokkos views to the values
    // ~~~~~~~~~~~~
    const PetscInt *device_local_i = nullptr, *device_local_j = nullptr, *device_nonlocal_i = nullptr, *device_nonlocal_j = nullptr;
    PetscMemType mtype;
-   PetscScalar *device_local_vals = nullptr, *device_nonlocal_vals = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, &device_local_vals, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, &device_nonlocal_vals, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals;
+   Kokkos::View<const PetscScalar *> device_nonlocal_vals;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    // ~~~~~~~~~~~~
    // Get the number of nnzs
@@ -177,9 +178,6 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
    // ~~~~~~~~~~~~~~~~~~~~~~~
    // We need the relative row tolerance, let's create some device memory to store it
    PetscScalarKokkosView rel_row_tol_d("rel_row_tol_d", local_rows);
-   // Log copy with petsc
-   size_t bytes = sizeof(PetscReal);
-   PetscCallVoid(PetscLogCpuToGpu(bytes));
 
    // We need to know how many entries are in each row after our dropping
    PetscIntKokkosView nnz_match_local_row_d("nnz_match_local_row_d", local_rows);
@@ -211,7 +209,7 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
                   [&](const PetscInt j, PetscScalar &thread_diag_abs) {
                      const bool is_diagonal = (device_local_j[device_local_i[i] + j] + global_col_start == row_index_global);
                      if (is_diagonal) {
-                        const PetscScalar val = Kokkos::abs(device_local_vals[device_local_i[i] + j]);
+                        const PetscScalar val = Kokkos::abs(device_local_vals(device_local_i[i] + j));
                         if (val > thread_diag_abs) thread_diag_abs = val;
                      }
                   },
@@ -228,7 +226,7 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
                      [&](const PetscInt j, PetscScalar &thread_diag_abs) {
                         const bool is_diagonal = (colmap_input_d(device_nonlocal_j[device_nonlocal_i[i] + j]) == row_index_global);
                         if (is_diagonal) {
-                           const PetscScalar val = Kokkos::abs(device_nonlocal_vals[device_nonlocal_i[i] + j]);
+                           const PetscScalar val = Kokkos::abs(device_nonlocal_vals(device_nonlocal_i[i] + j));
                            if (val > thread_diag_abs) thread_diag_abs = val;
                         }
                      },
@@ -254,7 +252,7 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
                      const bool is_diagonal = (device_local_j[device_local_i[i] + j] + global_col_start == row_index_global);
 
                      // If our current tolerance is bigger than the max value we've seen so far
-                     PetscScalar val = Kokkos::abs(device_local_vals[device_local_i[i] + j]);
+                     PetscScalar val = Kokkos::abs(device_local_vals(device_local_i[i] + j));
                      // If we're not comparing against the diagonal when computing relative residual
                      if (not_include_diag && is_diagonal) val = -1.0;
                      if (val > thread_max) thread_max = val;
@@ -276,7 +274,7 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
                         const bool is_diagonal = (colmap_input_d(device_nonlocal_j[device_nonlocal_i[i] + j]) == row_index_global);
 
                         // If our current tolerance is bigger than the max value we've seen so far
-                        PetscScalar val = Kokkos::abs(device_nonlocal_vals[device_nonlocal_i[i] + j]);
+                        PetscScalar val = Kokkos::abs(device_nonlocal_vals(device_nonlocal_i[i] + j));
                         // If we're not comparing against the diagonal when computing relative residual
                         if (not_include_diag && is_diagonal) val = -1.0;                  
                         if (val > thread_max) thread_max = val;
@@ -341,7 +339,7 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
             }
             
             // If the value is bigger than the tolerance, we keep it
-            if (Kokkos::abs(device_local_vals[device_local_i[i] + j]) >= rel_row_tol_d(i)) {
+            if (Kokkos::abs(device_local_vals(device_local_i[i] + j)) >= rel_row_tol_d(i)) {
                // If this is the diagonal and we're dropping all diagonals don't add it
                if (!(allow_drop_diagonal_int == -1 && is_diagonal)) thread_data.count++;
             }
@@ -416,7 +414,7 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
                   }                  
 
                   // If the value is bigger than the tolerance, we keep it
-                  if (Kokkos::abs(device_nonlocal_vals[device_nonlocal_i[i] + j]) >= rel_row_tol_d(i)) {
+                  if (Kokkos::abs(device_nonlocal_vals(device_nonlocal_i[i] + j)) >= rel_row_tol_d(i)) {
                      // If this is the diagonal and we're dropping all diagonals don't add it
                      if (!(allow_drop_diagonal_int == -1 && is_diagonal)) thread_data.count++;
                   }
@@ -572,10 +570,10 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
          const bool is_diagonal = (device_local_j[device_local_i[i] + j] + global_col_start == row_index_global);
 
          // If we hit a diagonal put it in the lump'd value
-         if (is_diagonal && lump_int) thread_sum += device_local_vals[device_local_i[i] + j];           
+         if (is_diagonal && lump_int) thread_sum += device_local_vals(device_local_i[i] + j);           
          
          // Check if we keep this column because of size
-         if (Kokkos::abs(device_local_vals[device_local_i[i] + j]) >= rel_row_tol_d(i)) {
+         if (Kokkos::abs(device_local_vals(device_local_i[i] + j)) >= rel_row_tol_d(i)) {
             // If this is the diagonal and we're dropping all diagonals don't add it
             if (!(allow_drop_diagonal_int == -1 && is_diagonal)) keep_col = true;
          }
@@ -589,7 +587,7 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
             scratch_indices(j) = 1;
          }
          // If we're not on the diagonal and we're small enough to lump
-         else if (lump_int && !is_diagonal) thread_sum += device_local_vals[device_local_i[i] + j];       
+         else if (lump_int && !is_diagonal) thread_sum += device_local_vals(device_local_i[i] + j);       
          },
          Kokkos::Sum<PetscScalar>(lump_val_local)
       ); 
@@ -604,10 +602,10 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
             const bool is_diagonal = (colmap_input_d(device_nonlocal_j[device_nonlocal_i[i] + j]) == row_index_global);
       
             // If we hit a diagonal put it in the lump'd value
-            if (is_diagonal && lump_int) thread_sum += device_nonlocal_vals[device_nonlocal_i[i] + j];
+            if (is_diagonal && lump_int) thread_sum += device_nonlocal_vals(device_nonlocal_i[i] + j);
 
             // Check if we keep this column because of size
-            if (Kokkos::abs(device_nonlocal_vals[device_nonlocal_i[i] + j]) >= rel_row_tol_d(i)) {
+            if (Kokkos::abs(device_nonlocal_vals(device_nonlocal_i[i] + j)) >= rel_row_tol_d(i)) {
                // If this is the diagonal and we're dropping all diagonals don't add it
                if (!(allow_drop_diagonal_int == -1 && is_diagonal)) keep_col = true;
             }
@@ -621,7 +619,7 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
                scratch_indices_nonlocal(j) = 1;             
             }
             // If we're not on the diagonal and we're small enough to lump
-            else if (lump_int && !is_diagonal) thread_sum += device_nonlocal_vals[device_nonlocal_i[i] + j];
+            else if (lump_int && !is_diagonal) thread_sum += device_nonlocal_vals(device_nonlocal_i[i] + j);
             },
             Kokkos::Sum<PetscScalar>(lump_val_nonlocal)
          );
@@ -667,7 +665,7 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
          if (scratch_indices(j+1) > scratch_indices(j))
          {
             j_local_d(i_local_d(i) + scratch_indices(j)) = device_local_j[device_local_i[i] + j];
-            a_local_d(i_local_d(i) + scratch_indices(j)) = device_local_vals[device_local_i[i] + j];            
+            a_local_d(i_local_d(i) + scratch_indices(j)) = device_local_vals(device_local_i[i] + j);            
          }
       });
 
@@ -678,7 +676,7 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
             {
                // Writing the global column indices, this will get compactified below
                j_nonlocal_d(i_nonlocal_d(i) + scratch_indices_nonlocal(j)) = colmap_input_d(device_nonlocal_j[device_nonlocal_i[i] + j]);
-               a_nonlocal_d(i_nonlocal_d(i) + scratch_indices_nonlocal(j)) = device_nonlocal_vals[device_nonlocal_i[i] + j];     
+               a_nonlocal_d(i_nonlocal_d(i) + scratch_indices_nonlocal(j)) = device_nonlocal_vals(device_nonlocal_i[i] + j);     
             }
          });         
       }
@@ -801,12 +799,15 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
 
       // We can now create our MPI matrix
       PetscCallVoid(MatCreateMPIAIJWithSeqAIJ(MPI_COMM_MATRIX, global_rows, global_cols, output_mat_local, output_mat_nonlocal, garray_host, output_mat));
-   }     
-   // If in serial 
+   }
+   // If in serial
    else
    {
       *output_mat = output_mat_local;
    }
+
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    return;
 }
@@ -880,23 +881,26 @@ PETSC_INTERN void remove_from_sparse_match_kokkos(Mat *input_mat, Mat *output_ma
    }
 
    // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
+   // Get pointers to the i,j on the device and Kokkos views to the values
    // ~~~~~~~~~~~~
    const PetscInt *device_local_i = nullptr, *device_local_j = nullptr, *device_nonlocal_i = nullptr, *device_nonlocal_j = nullptr;
    PetscMemType mtype;
-   PetscScalar *device_local_vals = nullptr, *device_nonlocal_vals = nullptr;  
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, &device_local_vals, &mtype));  
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, &device_nonlocal_vals, &mtype));          
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals;
+   Kokkos::View<const PetscScalar *> device_nonlocal_vals;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    // Get the output pointers
    const PetscInt *device_local_i_output = nullptr, *device_local_j_output = nullptr, *device_nonlocal_i_output = nullptr, *device_nonlocal_j_output = nullptr;
-   PetscScalar *device_local_vals_output = nullptr, *device_nonlocal_vals_output = nullptr;  
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, &device_local_j_output, &device_local_vals_output, &mtype));  
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_output, &device_nonlocal_j_output, &device_nonlocal_vals_output, &mtype)); 
-
-   Mat_SeqAIJKokkos *aijkok_local_output = static_cast<Mat_SeqAIJKokkos *>(mat_local_output->spptr);
-   Mat_SeqAIJKokkos *aijkok_nonlocal_output = NULL;
-   if (mpi) aijkok_nonlocal_output = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_output->spptr);
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, &device_local_j_output, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_output, &device_nonlocal_j_output, NULL, &mtype));
+   // Output values are read-modify-write (+= and conditional =)
+   Kokkos::View<PetscScalar *> device_local_vals_output;
+   Kokkos::View<PetscScalar *> device_nonlocal_vals_output;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local_output, &device_local_vals_output));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal_output, &device_nonlocal_vals_output));
 
    // Find maximum non-zeros per row of the input mat for sizing scratch memory
    PetscInt max_nnz_local = 0, max_nnz_nonlocal = 0;
@@ -1039,7 +1043,7 @@ PETSC_INTERN void remove_from_sparse_match_kokkos(Mat *input_mat, Mat *output_ma
             [&](const PetscInt j, PetscScalar& thread_sum) {          
 
                // If this is not being put into output then we lump it
-               if (scratch_indices(j) == -1) thread_sum += alpha * device_local_vals[device_local_i[i] + j];
+               if (scratch_indices(j) == -1) thread_sum += alpha * device_local_vals(device_local_i[i] + j);
             },
             Kokkos::Sum<PetscScalar>(lump_val_local)
          );   
@@ -1052,7 +1056,7 @@ PETSC_INTERN void remove_from_sparse_match_kokkos(Mat *input_mat, Mat *output_ma
                [&](const PetscInt j, PetscScalar& thread_sum) {           
 
                   // If this is not being put into output then we lump it
-                  if (scratch_indices_nonlocal(j) == -1) thread_sum += alpha * device_nonlocal_vals[device_nonlocal_i[i] + j];
+                  if (scratch_indices_nonlocal(j) == -1) thread_sum += alpha * device_nonlocal_vals(device_nonlocal_i[i] + j);
                },
                Kokkos::Sum<PetscScalar>(lump_val_nonlocal)
             );              
@@ -1068,11 +1072,11 @@ PETSC_INTERN void remove_from_sparse_match_kokkos(Mat *input_mat, Mat *output_ma
          {
             if (alpha_int)
             {
-               device_local_vals_output[device_local_i_output[i] + scratch_indices(j)] += alpha * device_local_vals[device_local_i[i] + j];
+               device_local_vals_output(device_local_i_output[i] + scratch_indices(j)) += alpha * device_local_vals(device_local_i[i] + j);
             }
             else
             {
-               device_local_vals_output[device_local_i_output[i] + scratch_indices(j)] = device_local_vals[device_local_i[i] + j];
+               device_local_vals_output(device_local_i_output[i] + scratch_indices(j)) = device_local_vals(device_local_i[i] + j);
             }
          }
       }); 
@@ -1087,11 +1091,11 @@ PETSC_INTERN void remove_from_sparse_match_kokkos(Mat *input_mat, Mat *output_ma
                // Writing the global column indices, this will get compactified below
                if (alpha_int)
                {
-                  device_nonlocal_vals_output[device_nonlocal_i_output[i] + scratch_indices_nonlocal(j)] += alpha * device_nonlocal_vals[device_nonlocal_i[i] + j];
+                  device_nonlocal_vals_output(device_nonlocal_i_output[i] + scratch_indices_nonlocal(j)) += alpha * device_nonlocal_vals(device_nonlocal_i[i] + j);
                }
                else
                {
-                  device_nonlocal_vals_output[device_nonlocal_i_output[i] + scratch_indices_nonlocal(j)] = device_nonlocal_vals[device_nonlocal_i[i] + j];
+                  device_nonlocal_vals_output(device_nonlocal_i_output[i] + scratch_indices_nonlocal(j)) = device_nonlocal_vals(device_nonlocal_i[i] + j);
                }
             }
          });          
@@ -1117,7 +1121,7 @@ PETSC_INTERN void remove_from_sparse_match_kokkos(Mat *input_mat, Mat *output_ma
                const bool is_diagonal = device_local_j_output[device_local_i_output[i] + j] + global_col_start == row_index_global;
 
                // Will only happen for one thread
-               if (is_diagonal) device_local_vals_output[device_local_i_output[i] + j] += lump_val;
+               if (is_diagonal) device_local_vals_output(device_local_i_output[i] + j) += lump_val;
             });   
          }
          else
@@ -1129,28 +1133,20 @@ PETSC_INTERN void remove_from_sparse_match_kokkos(Mat *input_mat, Mat *output_ma
                const bool is_diagonal = colmap_output_d(device_nonlocal_j_output[device_nonlocal_i_output[i] + j]) == row_index_global;
 
                // Will only happen for one thread
-               if (is_diagonal) device_nonlocal_vals_output[device_nonlocal_i_output[i] + j] += lump_val;
+               if (is_diagonal) device_nonlocal_vals_output(device_nonlocal_i_output[i] + j) += lump_val;
             });               
          }
       }       
    });
    Kokkos::fence();
 
-   // Have to specify we've modifed data on the device
-   // Want to call MatSeqAIJKokkosModifyDevice but its PETSC_INTERN
-   aijkok_local_output->a_dual.clear_sync_state();
-   aijkok_local_output->a_dual.modify_device();
-   aijkok_local_output->transpose_updated = PETSC_FALSE;
-   aijkok_local_output->hermitian_updated = PETSC_FALSE;
-   // Invalidate diagonals
-   if (mpi)
-   {
-      aijkok_nonlocal_output->a_dual.clear_sync_state();
-      aijkok_nonlocal_output->a_dual.modify_device();
-      aijkok_nonlocal_output->transpose_updated = PETSC_FALSE;
-      aijkok_nonlocal_output->hermitian_updated = PETSC_FALSE;
-   }        
-   PetscCallVoid(PetscObjectStateIncrease((PetscObject)(*output_mat)));
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal, &device_nonlocal_vals));
+
+   // The matching restore handles MatSeqAIJKokkosModifyDevice (clears sync state,
+   // marks device modified, invalidates transpose/hermitian, bumps object state).
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local_output, &device_local_vals_output));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal_output, &device_nonlocal_vals_output));
 
    return;
 }
@@ -1175,54 +1171,25 @@ PETSC_INTERN void MatSetAllValues_kokkos(Mat *input_mat, PetscReal val)
    {
       mat_local = *input_mat;
    }
-   PetscInt local_rows, local_cols;
-   PetscCallVoid(MatGetLocalSize(*input_mat, &local_rows, &local_cols));
 
-   Mat_SeqAIJKokkos *aijkok_nonlocal = NULL;
-   Mat_SeqAIJKokkos *aijkok_local = static_cast<Mat_SeqAIJKokkos *>(mat_local->spptr);
-   if(mpi) aijkok_nonlocal = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal->spptr);
    auto exec = PetscGetKokkosExecutionSpace();
 
-   // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
-   // ~~~~~~~~~~~~
-   const PetscInt *device_local_i = nullptr, *device_local_j = nullptr, *device_nonlocal_i = nullptr, *device_nonlocal_j = nullptr;
-   PetscMemType mtype;
-   PetscScalar *device_local_vals = nullptr, *device_nonlocal_vals = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, &device_local_vals, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, &device_nonlocal_vals, &mtype));
+   Kokkos::View<PetscScalar *> device_local_vals;
+   Kokkos::View<PetscScalar *> device_nonlocal_vals;
+   PetscCallVoid(MatSeqAIJGetKokkosViewWrite(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosViewWrite(mat_nonlocal, &device_nonlocal_vals));
 
-   PetscScalarKokkosView a_local_d, a_nonlocal_d;
-   a_local_d = PetscScalarKokkosView(device_local_vals, aijkok_local->csrmat.nnz());
-   if (mpi) a_nonlocal_d = PetscScalarKokkosView(device_nonlocal_vals, aijkok_nonlocal->csrmat.nnz());
-   // Copy in the val
-   Kokkos::deep_copy(exec, a_local_d, val);
-   // Log copy with petsc
-   size_t bytes = sizeof(PetscReal);
-   PetscCallVoid(PetscLogCpuToGpu(bytes));
+   // Set all values to val
+   Kokkos::deep_copy(exec, device_local_vals, val);
    if (mpi)
    {
-      Kokkos::deep_copy(exec, a_nonlocal_d, val); 
-      PetscCallVoid(PetscLogCpuToGpu(bytes));   
+      Kokkos::deep_copy(exec, device_nonlocal_vals, val);
    }
 
-   // Have to specify we've modifed data on the device
-   // Want to call MatSeqAIJKokkosModifyDevice but its PETSC_INTERN
-
-   aijkok_local->a_dual.clear_sync_state();
-   aijkok_local->a_dual.modify_device();
-   aijkok_local->transpose_updated = PETSC_FALSE;
-   aijkok_local->hermitian_updated = PETSC_FALSE;
-   // Invalidate diagonals
-
-   if (mpi)
-   {
-      aijkok_nonlocal->a_dual.clear_sync_state();
-      aijkok_nonlocal->a_dual.modify_device();
-      aijkok_nonlocal->transpose_updated = PETSC_FALSE;
-      aijkok_nonlocal->hermitian_updated = PETSC_FALSE;
-   }
-   PetscCallVoid(PetscObjectStateIncrease((PetscObject)(*input_mat)));
+   // The matching restore handles MatSeqAIJKokkosModifyDevice (clears sync state,
+   // marks device modified, invalidates transpose/hermitian, bumps object state).
+   PetscCallVoid(MatSeqAIJRestoreKokkosViewWrite(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosViewWrite(mat_nonlocal, &device_nonlocal_vals));
 
    return;
 }
@@ -1271,13 +1238,16 @@ PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *input_mat, const int 
    auto exec = PetscGetKokkosExecutionSpace();
 
    // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
+   // Get pointers to the i,j on the device and Kokkos views to the values
    // ~~~~~~~~~~~~
    const PetscInt *device_local_i = nullptr, *device_local_j = nullptr, *device_nonlocal_i = nullptr, *device_nonlocal_j = nullptr;
    PetscMemType mtype;
-   PetscScalar *device_local_vals = nullptr, *device_nonlocal_vals = nullptr;  
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, &device_local_vals, &mtype));  
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, &device_nonlocal_vals, &mtype));          
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals;
+   Kokkos::View<const PetscScalar *> device_nonlocal_vals;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    PetscIntKokkosView nnz_match_local_row_d;
    PetscIntKokkosView nnz_match_nonlocal_row_d;
@@ -1453,7 +1423,7 @@ PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *input_mat, const int 
 
                // Want the local col indices for the local block
                j_local_d(i_local_d(i) + j) = device_local_j[device_local_i[i] + j];
-               a_local_d(i_local_d(i) + j) = device_local_vals[device_local_i[i] + j];
+               a_local_d(i_local_d(i) + j) = device_local_vals(device_local_i[i] + j);
                      
             });     
 
@@ -1467,7 +1437,7 @@ PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *input_mat, const int 
 
                   // We keep the existing local indices in the off-diagonal block here
                   j_nonlocal_d(i_nonlocal_d(i) + j) = device_nonlocal_j[device_nonlocal_i[i] + j];
-                  a_nonlocal_d(i_nonlocal_d(i) + j) = device_nonlocal_vals[device_nonlocal_i[i] + j];
+                  a_nonlocal_d(i_nonlocal_d(i) + j) = device_nonlocal_vals(device_nonlocal_i[i] + j);
                         
                });          
             }
@@ -1496,28 +1466,21 @@ PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *input_mat, const int 
       {
          mat_local_output = *output_mat;
       }     
-      Mat_SeqAIJKokkos *aijkok_local_output = static_cast<Mat_SeqAIJKokkos *>(mat_local_output->spptr);
-      Mat_SeqAIJKokkos *aijkok_nonlocal_output = NULL;
-      if (mpi) aijkok_nonlocal_output = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_output->spptr);
+      // Get device pointers for the existing i and j arrays
+      const PetscInt *device_local_i_output = nullptr, *device_local_j_output = nullptr, *device_nonlocal_i_output = nullptr;
+      PetscMemType mtype;
+      PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, &device_local_j_output, NULL, &mtype));
+      if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_output, NULL, NULL, &mtype));
 
-      // Annoying we can't just call MatSeqAIJGetKokkosView
-      a_local_d = aijkok_local_output->a_dual.view_device();
-      if (mpi) a_nonlocal_d = aijkok_nonlocal_output->a_dual.view_device();
+      // Output values are fully overwritten below (zeroed first, then assigned)
+      Kokkos::View<PetscScalar *> device_local_a_output;
+      Kokkos::View<PetscScalar *> device_nonlocal_a_output;
+      PetscCallVoid(MatSeqAIJGetKokkosViewWrite(mat_local_output, &device_local_a_output));
+      if (mpi) PetscCallVoid(MatSeqAIJGetKokkosViewWrite(mat_nonlocal_output, &device_nonlocal_a_output));
+
       // Because we might be missing diagonals and we're going to skip some of them
       // in the writing loop below
-      Kokkos::deep_copy(exec, a_local_d, 0.0);
-
-      // Annoyingly there isn't currently the ability to get views for i (or j)
-      const PetscInt *device_local_i_output = nullptr, *device_local_j_output = nullptr, *device_nonlocal_i_ouput = nullptr;
-      PetscMemType mtype;
-      PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, &device_local_j_output, NULL, &mtype));  
-      if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_ouput, NULL, NULL, &mtype));  
-
-      // Have these point at the existing i pointers - we only need the local j
-      ConstMatRowMapKokkosView i_local_const_d = ConstMatRowMapKokkosView(device_local_i_output, local_rows+1);
-      ConstMatRowMapKokkosView j_local_const_d = ConstMatRowMapKokkosView(device_local_j_output, aijkok_local_output->csrmat.nnz());
-      ConstMatRowMapKokkosView i_nonlocal_const_d;
-      if (mpi) i_nonlocal_const_d = ConstMatRowMapKokkosView(device_nonlocal_i_ouput, local_rows+1);         
+      Kokkos::deep_copy(exec, device_local_a_output, 0.0);
 
       // Only have to write a but have to be careful as we may not have diagonals in some rows
       // in the input, but they are in the output
@@ -1530,7 +1493,7 @@ PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *input_mat, const int 
             const PetscInt i = t.league_rank();
 
             // Still using i here (the local index into input)
-            const PetscInt ncols_local = device_local_i[i + 1] - device_local_i[i];         
+            const PetscInt ncols_local = device_local_i[i + 1] - device_local_i[i];
 
             // For over local columns - copy in input
             // We have to skip over the identity entries, which we know are always C points
@@ -1540,48 +1503,36 @@ PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *input_mat, const int 
                PetscInt offset = 0;
 
                // If we're at or after the diagonal and there isn't actually a diagonal in the input
-               // we know the output has a diagonal, so we skip ahead one in the output and 
+               // we know the output has a diagonal, so we skip ahead one in the output and
                // leave it unassigned in the output (it gets set to zero above)
-               if (j_local_const_d(i_local_const_d(i) + j) >= i && \
+               if (device_local_j_output[device_local_i_output[i] + j] >= i && \
                      !found_diag_row_d(i)) offset = 1;
 
-               a_local_d(i_local_const_d(i) + j + offset) = device_local_vals[device_local_i[i] + j];
-            });  
-           
+               device_local_a_output(device_local_i_output[i] + j + offset) = device_local_vals(device_local_i[i] + j);
+            });
+
             // For over nonlocal columns - copy in input - identical structure in the off-diag block
             if (mpi)
             {
-               PetscInt ncols_nonlocal = device_nonlocal_i[i + 1] - device_nonlocal_i[i];         
+               PetscInt ncols_nonlocal = device_nonlocal_i[i + 1] - device_nonlocal_i[i];
 
                Kokkos::parallel_for(
                   Kokkos::TeamVectorRange(t, ncols_nonlocal), [&](const PetscInt j) {
 
                   // We keep the existing local indices in the off-diagonal block here
                   // we have all the same columns as input and hence the same garray
-                  a_nonlocal_d(i_nonlocal_const_d(i) + j) = device_nonlocal_vals[device_nonlocal_i[i] + j];
-                        
-               });          
+                  device_nonlocal_a_output(device_nonlocal_i_output[i] + j) = device_nonlocal_vals(device_nonlocal_i[i] + j);
+
+               });
             }
-      });  
-      
+      });
+
       Kokkos::fence();
 
-      // Have to specify we've modifed data on the device
-      // Want to call MatSeqAIJKokkosModifyDevice but its PETSC_INTERN
-      aijkok_local_output->a_dual.clear_sync_state();
-      aijkok_local_output->a_dual.modify_device();
-      aijkok_local_output->transpose_updated = PETSC_FALSE;
-      aijkok_local_output->hermitian_updated = PETSC_FALSE;
-      // Invalidate diagonals
-
-      if (mpi)
-      {
-         aijkok_nonlocal_output->a_dual.clear_sync_state();
-         aijkok_nonlocal_output->a_dual.modify_device();
-         aijkok_nonlocal_output->transpose_updated = PETSC_FALSE;
-         aijkok_nonlocal_output->hermitian_updated = PETSC_FALSE;
-      }        
-      PetscCallVoid(PetscObjectStateIncrease((PetscObject)(*output_mat)));    
+      // The matching restore handles MatSeqAIJKokkosModifyDevice (clears sync state,
+      // marks device modified, invalidates transpose/hermitian, bumps object state).
+      PetscCallVoid(MatSeqAIJRestoreKokkosViewWrite(mat_local_output, &device_local_a_output));
+      if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosViewWrite(mat_nonlocal_output, &device_nonlocal_a_output));
 
     }
 
@@ -1620,13 +1571,16 @@ PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *input_mat, const int 
 
          // We can now create our MPI matrix
          PetscCallVoid(MatCreateMPIAIJWithSeqAIJ(MPI_COMM_MATRIX, global_rows, global_cols, output_mat_local, output_mat_nonlocal, garray_host, output_mat));
-      }    
-      // If in serial 
+      }
+      // If in serial
       else
       {
          *output_mat = output_mat_local;
       }
-   }  
+   }
+
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local, &device_local_vals));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal, &device_nonlocal_vals));
 
    return;
 }
@@ -1643,34 +1597,6 @@ PETSC_INTERN void MatAXPY_kokkos(Mat *Y, PetscScalar alpha, Mat *X)
    const PetscInt *colmap_y, *colmap_x;
    PetscCallVoid(MatMPIAIJGetSeqAIJ(*Y, &mat_local_y, &mat_nonlocal_y, &colmap_y));
    PetscCallVoid(MatMPIAIJGetSeqAIJ(*X, &mat_local_x, &mat_nonlocal_x, &colmap_x));
-
-   Mat_SeqAIJKokkos *mat_local_ykok = static_cast<Mat_SeqAIJKokkos *>(mat_local_y->spptr);
-   Mat_SeqAIJKokkos *mat_nonlocal_ykok = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_y->spptr);
-   Mat_SeqAIJKokkos *mat_local_xkok = static_cast<Mat_SeqAIJKokkos *>(mat_local_x->spptr);
-   Mat_SeqAIJKokkos *mat_nonlocal_xkok = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_x->spptr);
-
-   // Equivalent to calling MatSeqAIJKokkosSyncDevice which is petsc intern
-   // We have to make sure the device data is up to date before we do the axpy
-   if (mat_local_ykok->a_dual.need_sync_device()) {
-      mat_local_ykok->a_dual.sync_device();
-      mat_local_ykok->transpose_updated = PETSC_FALSE; /* values of the transpose is out-of-date */
-      mat_local_ykok->hermitian_updated = PETSC_FALSE;
-    }  
-    if (mat_nonlocal_ykok->a_dual.need_sync_device()) {
-      mat_nonlocal_ykok->a_dual.sync_device();
-      mat_nonlocal_ykok->transpose_updated = PETSC_FALSE; /* values of the transpose is out-of-date */
-      mat_nonlocal_ykok->hermitian_updated = PETSC_FALSE;
-    } 
-    if (mat_local_xkok->a_dual.need_sync_device()) {
-      mat_local_xkok->a_dual.sync_device();
-      mat_local_xkok->transpose_updated = PETSC_FALSE; /* values of the transpose is out-of-date */
-      mat_local_xkok->hermitian_updated = PETSC_FALSE;
-    }           
-    if (mat_nonlocal_xkok->a_dual.need_sync_device()) {
-      mat_nonlocal_xkok->a_dual.sync_device();
-      mat_nonlocal_xkok->transpose_updated = PETSC_FALSE; /* values of the transpose is out-of-date */
-      mat_nonlocal_xkok->hermitian_updated = PETSC_FALSE;
-    }  
 
    PetscInt rows_ao_y, cols_ao_y, rows_ao_x, cols_ao_x;
    auto exec = PetscGetKokkosExecutionSpace();
@@ -1701,132 +1627,136 @@ PETSC_INTERN void MatAXPY_kokkos(Mat *Y, PetscScalar alpha, Mat *X)
    PetscCallVoid(MatGetSize(*Y, &global_rows, &global_cols));
 
    // ~~~~~~~~~~~~~~~
-   // Let's go and add the local components together
+   // Local block: hand off to PETSc's MatAXPY on a duplicate of mat_local_y
+   // (the duplicate becomes the diagonal block of the new MPI matrix)
+   // ~~~~~~~~~~~~~~~
+   Mat Z_local;
+   PetscCallVoid(MatDuplicate(mat_local_y, MAT_COPY_VALUES, &Z_local));
+   PetscCallVoid(MatAXPY(Z_local, alpha, mat_local_x, DIFFERENT_NONZERO_PATTERN));
+
+   // ~~~~~~~~~~~~~~~
+   // Nonlocal block: build the merged garray = union(garray_y, garray_x) and use it as
+   // the column space of temporary SeqAIJKokkos matrices, then call PETSc's MatAXPY.
+   // Because spadd produces a nonzero in column c iff X or Y had one there, the union
+   // garray is exactly the output garray - no second remap is needed afterward.
    // ~~~~~~~~~~~~~~~
 
-   Mat_SeqAIJKokkos *xkok_local, *ykok_local;
-   ykok_local = static_cast<Mat_SeqAIJKokkos *>(mat_local_y->spptr);
-   xkok_local = static_cast<Mat_SeqAIJKokkos *>(mat_local_x->spptr);   
+   // Concatenate the two garrays on the device, then run them through rewrite_j_global_to_local.
+   // After it returns:
+   //   concat[0 .. cols_ao_y)               = merged-local indices for each garray_y entry
+   //   concat[cols_ao_y .. cols_ao_y+cols_ao_x) = merged-local indices for each garray_x entry
+   //   garray_host[0 .. col_ao_output)      = sorted-unique global indices of garray_y, garray_x
+   PetscInt cols_ao_concat = cols_ao_y + cols_ao_x;
+   PetscIntKokkosView concat = PetscIntKokkosView("concat", cols_ao_concat);
+   PetscInt zero = 0;
+   Kokkos::deep_copy(exec, Kokkos::subview(concat, Kokkos::make_pair(zero, cols_ao_y)), colmap_input_d_y);
+   Kokkos::deep_copy(exec, Kokkos::subview(concat, Kokkos::make_pair(cols_ao_y, cols_ao_concat)), colmap_input_d_x);
 
-   Kokkos::View<PetscScalar *> a_local_d_copy;
-   Kokkos::View<PetscInt *> i_local_d_copy, j_local_d_copy;
-   // Scope so the zcsr_local is destroyed once we copy 
+   PetscInt col_ao_output = 0;
+   PetscInt *garray_host = NULL;
+   rewrite_j_global_to_local(cols_ao_concat, col_ao_output, concat, &garray_host);
+
+   // Pull device CSR pointers for the original nonlocal blocks (we never mutate them).
+   const PetscInt *device_nonlocal_y_i = nullptr, *device_nonlocal_y_j = nullptr;
+   const PetscInt *device_nonlocal_x_i = nullptr, *device_nonlocal_x_j = nullptr;
+   PetscMemType mtype;
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_y, &device_nonlocal_y_i, &device_nonlocal_y_j, NULL, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_x, &device_nonlocal_x_i, &device_nonlocal_x_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> a_y_orig;
+   Kokkos::View<const PetscScalar *> a_x_orig;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal_y, &a_y_orig));
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal_x, &a_x_orig));
+
+   // Read the nnz of each nonlocal block from its host i pointer
+   PetscInt nnz_y, nnz_x;
    {
-      KokkosCsrMatrix zcsr_local;
-      KernelHandle    kh_local;      
-      kh_local.create_spadd_handle(true); // X, Y are sorted
-
-      KokkosSparse::spadd_symbolic(&kh_local, xkok_local->csrmat, ykok_local->csrmat, zcsr_local);
-      KokkosSparse::spadd_numeric(&kh_local, alpha, xkok_local->csrmat, (PetscScalar)1.0, ykok_local->csrmat, zcsr_local);
-
-      kh_local.destroy_spadd_handle();
-      
-      // Get the Kokkos Views from zcsr_local - annoyingly we can't just call MatCreateSeqAIJKokkosWithCSRMatrix
-      // as it's petsc intern
-      auto a_local_d_z = zcsr_local.values;
-      auto i_local_d_z = zcsr_local.graph.row_map;
-      auto j_local_d_z = zcsr_local.graph.entries;   
-
-      a_local_d_copy = Kokkos::View<PetscScalar *>("a_local_d_copy", a_local_d_z.extent(0));
-      i_local_d_copy = Kokkos::View<PetscInt *>("i_local_d_copy", i_local_d_z.extent(0));
-      j_local_d_copy = Kokkos::View<PetscInt *>("j_local_d_copy", j_local_d_z.extent(0));   
-
-      Kokkos::deep_copy(exec, a_local_d_copy, a_local_d_z);
-      Kokkos::deep_copy(exec, i_local_d_copy, i_local_d_z);
-      Kokkos::deep_copy(exec, j_local_d_copy, j_local_d_z);
+      PetscInt n;
+      PetscBool symmetric = PETSC_FALSE, inodecompressed = PETSC_FALSE, done;
+      const PetscInt *ia;
+      PetscCallVoid(MatGetRowIJ(mat_nonlocal_y, 0, symmetric, inodecompressed, &n, &ia, NULL, &done));
+      nnz_y = ia[n];
+      PetscCallVoid(MatRestoreRowIJ(mat_nonlocal_y, 0, symmetric, inodecompressed, &n, &ia, NULL, &done));
+      PetscCallVoid(MatGetRowIJ(mat_nonlocal_x, 0, symmetric, inodecompressed, &n, &ia, NULL, &done));
+      nnz_x = ia[n];
+      PetscCallVoid(MatRestoreRowIJ(mat_nonlocal_x, 0, symmetric, inodecompressed, &n, &ia, NULL, &done));
    }
 
-   // We can create our local diagonal block matrix directly on the device
-   Mat Z_local;
-   PetscCallVoid(MatCreateSeqAIJKokkosWithKokkosViews(PETSC_COMM_SELF, local_rows, local_cols, i_local_d_copy, j_local_d_copy, a_local_d_copy, &Z_local));
-   
-   // ~~~~~~~~~~~~~~~
-   // Now let's go and add the non-local components together
-   // We first rewrite the j indices to be global as the nonlocal components of Y and X
-   // might have different non-local non-zeros (and different numbers of non-local non-zeros)
-   // ~~~~~~~~~~~~~~~
-
-   // We need to duplicate the nonlocal part of x first as we are going to overwrite the 
-   // column indices
-   // Don't need to copy y as we destroy it anyway
-   Mat mat_nonlocal_x_copy;
-   PetscCallVoid(MatDuplicate(mat_nonlocal_x, MAT_COPY_VALUES, &mat_nonlocal_x_copy));
-
-   Mat_SeqAIJKokkos *xkok_nonlocal, *ykok_nonlocal; 
-   ykok_nonlocal = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_y->spptr);
-   xkok_nonlocal = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_x_copy->spptr);          
-
-   PetscInt *device_nonlocal_x_j = xkok_nonlocal->j_device_data();
-   PetscInt *device_nonlocal_y_j = ykok_nonlocal->j_device_data();
-
-   // Rewrite the Y nonlocal indices to be global
+   // Build owned (i, j, a) copies for each side. j is rewritten from original-local
+   // straight into merged-local via the concat lookup.
+   Kokkos::View<PetscInt *> i_y_temp("i_y_temp", local_rows + 1);
+   Kokkos::View<PetscInt *> j_y_temp("j_y_temp", nnz_y);
+   Kokkos::View<PetscScalar *> a_y_temp("a_y_temp", nnz_y);
+   Kokkos::View<const PetscInt *, DefaultMemorySpace, Kokkos::MemoryUnmanaged> i_y_orig(device_nonlocal_y_i, local_rows + 1);
+   Kokkos::deep_copy(exec, i_y_temp, i_y_orig);
+   Kokkos::deep_copy(exec, a_y_temp, a_y_orig);
    Kokkos::parallel_for(
-      Kokkos::RangePolicy<>(exec, 0, ykok_nonlocal->csrmat.nnz()), KOKKOS_LAMBDA(PetscInt i) { 
+      Kokkos::RangePolicy<>(exec, 0, nnz_y), KOKKOS_LAMBDA(const PetscInt k) {
+         j_y_temp(k) = concat(device_nonlocal_y_j[k]);
+      });
 
-         device_nonlocal_y_j[i] = colmap_input_d_y(device_nonlocal_y_j[i]);
-   }); 
-
-   // Rewrite the X nonlocal indices to be global
+   Kokkos::View<PetscInt *> i_x_temp("i_x_temp", local_rows + 1);
+   Kokkos::View<PetscInt *> j_x_temp("j_x_temp", nnz_x);
+   Kokkos::View<PetscScalar *> a_x_temp("a_x_temp", nnz_x);
+   Kokkos::View<const PetscInt *, DefaultMemorySpace, Kokkos::MemoryUnmanaged> i_x_orig(device_nonlocal_x_i, local_rows + 1);
+   Kokkos::deep_copy(exec, i_x_temp, i_x_orig);
+   Kokkos::deep_copy(exec, a_x_temp, a_x_orig);
+   const PetscInt offset_x = cols_ao_y;
    Kokkos::parallel_for(
-      Kokkos::RangePolicy<>(exec, 0, xkok_nonlocal->csrmat.nnz()), KOKKOS_LAMBDA(PetscInt i) { 
+      Kokkos::RangePolicy<>(exec, 0, nnz_x), KOKKOS_LAMBDA(const PetscInt k) {
+         j_x_temp(k) = concat(offset_x + device_nonlocal_x_j[k]);
+      });
 
-         device_nonlocal_x_j[i] = colmap_input_d_x(device_nonlocal_x_j[i]);
-   });    
-   // Ensure everything is finished before we hit the spadd below
    Kokkos::fence();
 
-   // ~~~~~~~~~
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal_y, &a_y_orig));
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal_x, &a_x_orig));
 
-   Kokkos::View<PetscScalar *> a_nonlocal_d_copy;
-   Kokkos::View<PetscInt *> i_nonlocal_d_copy, j_nonlocal_d_copy;
-   PetscInt *garray_host = NULL;
-   PetscInt col_ao_output = 0;
+   // concat is no longer needed - both j-rewrite kernels have completed.
+   concat = PetscIntKokkosView();
 
-   // Scope so the zcsr_nonlocal is destroyed once we copy 
+   // Wrap the rewritten CSR as temporary SeqAIJKokkos matrices with col_ao_output cols
+   // and let PETSc's MatAXPY run the spadd.
+   Mat temp_y, temp_x;
+   PetscCallVoid(MatCreateSeqAIJKokkosWithKokkosViews(PETSC_COMM_SELF, local_rows, col_ao_output, i_y_temp, j_y_temp, a_y_temp, &temp_y));
+   PetscCallVoid(MatCreateSeqAIJKokkosWithKokkosViews(PETSC_COMM_SELF, local_rows, col_ao_output, i_x_temp, j_x_temp, a_x_temp, &temp_x));
+
+   PetscCallVoid(MatAXPY(temp_y, alpha, temp_x, DIFFERENT_NONZERO_PATTERN));
+
+   // temp_x is no longer needed; free it
+   PetscCallVoid(MatDestroy(&temp_x));
+
+   // Extract the result from temp_y so we can own it independently.
+   const PetscInt *device_z_i = nullptr, *device_z_j = nullptr;
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(temp_y, &device_z_i, &device_z_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> a_z_unm;
+   PetscCallVoid(MatSeqAIJGetKokkosView(temp_y, &a_z_unm));
+
+   // Read the spadd-result nnz from its host i pointer
+   PetscInt nnz_z;
    {
-      // Now we can add the non-local components together
-      KokkosCsrMatrix zcsr_nonlocal;
-      // Global indices are sorted
-      KernelHandle    kh_nonlocal;      
-      kh_nonlocal.create_spadd_handle(true); 
-
-      KokkosSparse::spadd_symbolic(&kh_nonlocal, xkok_nonlocal->csrmat, ykok_nonlocal->csrmat, zcsr_nonlocal);
-      KokkosSparse::spadd_numeric(&kh_nonlocal, alpha, xkok_nonlocal->csrmat, (PetscScalar)1.0, ykok_nonlocal->csrmat, zcsr_nonlocal);
-
-      kh_nonlocal.destroy_spadd_handle();
-
-      // Can now destroy the copy
-      PetscCallVoid(MatDestroy(&mat_nonlocal_x_copy));
-
-      // Get the Kokkos Views from zcsr_nonlocal - annoyingly we can't just call MatCreateSeqAIJKokkosWithCSRMatrix
-      // as it's petsc intern
-      auto a_nonlocal_d_z = zcsr_nonlocal.values;
-      auto i_nonlocal_d_z = zcsr_nonlocal.graph.row_map;
-      auto j_nonlocal_d_z = zcsr_nonlocal.graph.entries;
-
-      // We know the most nonlocal indices we can have are the addition of x and y
-      // (some might be the same)
-      PetscInt cols_ao = cols_ao_x + cols_ao_y;
-
-      // ~~~~~~~~~
-
-      // Let's make sure everything on the device is finished
-      Kokkos::fence();   
-
-      // Now we need to build garray on the host and rewrite the j_nonlocal_d_z indices so they are local
-      // This fences internally
-      rewrite_j_global_to_local(cols_ao, col_ao_output, j_nonlocal_d_z, &garray_host);  
-
-      a_nonlocal_d_copy = Kokkos::View<PetscScalar *>("a_local_d_copy", a_nonlocal_d_z.extent(0));
-      i_nonlocal_d_copy = Kokkos::View<PetscInt *>("i_local_d_copy", i_nonlocal_d_z.extent(0));
-      j_nonlocal_d_copy = Kokkos::View<PetscInt *>("j_local_d_copy", j_nonlocal_d_z.extent(0));   
-
-      Kokkos::deep_copy(exec, a_nonlocal_d_copy, a_nonlocal_d_z);
-      Kokkos::deep_copy(exec, i_nonlocal_d_copy, i_nonlocal_d_z);
-      Kokkos::deep_copy(exec, j_nonlocal_d_copy, j_nonlocal_d_z);
+      PetscInt n;
+      PetscBool symmetric = PETSC_FALSE, inodecompressed = PETSC_FALSE, done;
+      const PetscInt *ia;
+      PetscCallVoid(MatGetRowIJ(temp_y, 0, symmetric, inodecompressed, &n, &ia, NULL, &done));
+      nnz_z = ia[n];
+      PetscCallVoid(MatRestoreRowIJ(temp_y, 0, symmetric, inodecompressed, &n, &ia, NULL, &done));
    }
 
-   // We can create our nonlocal diagonal block matrix directly on the device
+   Kokkos::View<PetscInt *> i_nonlocal_d_copy("i_nonlocal_d_copy", local_rows + 1);
+   Kokkos::View<PetscInt *> j_nonlocal_d_copy("j_nonlocal_d_copy", nnz_z);
+   Kokkos::View<PetscScalar *> a_nonlocal_d_copy("a_nonlocal_d_copy", nnz_z);
+   Kokkos::View<const PetscInt *, DefaultMemorySpace, Kokkos::MemoryUnmanaged> i_z_unm(device_z_i, local_rows + 1);
+   Kokkos::View<const PetscInt *, DefaultMemorySpace, Kokkos::MemoryUnmanaged> j_z_unm(device_z_j, nnz_z);
+   Kokkos::deep_copy(exec, i_nonlocal_d_copy, i_z_unm);
+   Kokkos::deep_copy(exec, j_nonlocal_d_copy, j_z_unm);
+   Kokkos::deep_copy(exec, a_nonlocal_d_copy, a_z_unm);
+   Kokkos::fence();
+
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(temp_y, &a_z_unm));
+
+   // temp_y's data has been copied out; free it before allocating Z_nonlocal.
+   PetscCallVoid(MatDestroy(&temp_y));
+
    Mat Z_nonlocal;
    PetscCallVoid(MatCreateSeqAIJKokkosWithKokkosViews(PETSC_COMM_SELF, local_rows, col_ao_output, i_nonlocal_d_copy, j_nonlocal_d_copy, a_nonlocal_d_copy, &Z_nonlocal));
 
@@ -1855,12 +1785,13 @@ PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosVi
    PetscInt local_rows_row = is_row_d_d.extent(0), local_cols_col = is_col_d_d.extent(0);
    
    // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
+   // Get pointers to the i,j on the device and Kokkos view to the values
    // ~~~~~~~~~~~~
    const PetscInt *device_local_i = nullptr, *device_local_j = nullptr;
    PetscMemType mtype;
-   PetscScalar *device_local_vals = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(*input_mat, &device_local_i, &device_local_j, &device_local_vals, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(*input_mat, &device_local_i, &device_local_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals;
+   PetscCallVoid(MatSeqAIJGetKokkosView(*input_mat, &device_local_vals));
 
    PetscIntKokkosView nnz_match_local_row_d;
 
@@ -2049,7 +1980,7 @@ PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosVi
             {
                // Be careful to use the correct i_idx_is_row index into i_local_d here
                j_local_d(i_local_d(i_idx_is_row) + scratch_indices(j)) = smap_d(device_local_j[device_local_i[i] + j]) - 1;
-               a_local_d(i_local_d(i_idx_is_row) + scratch_indices(j)) = device_local_vals[device_local_i[i] + j];            
+               a_local_d(i_local_d(i_idx_is_row) + scratch_indices(j)) = device_local_vals(device_local_i[i] + j);            
             }
          });
       });  
@@ -2057,18 +1988,13 @@ PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosVi
    // If we're reusing, we can just write directly to the existing views
    else
    {
-      Mat_SeqAIJKokkos *aijkok_local_output = static_cast<Mat_SeqAIJKokkos *>((*output_mat)->spptr);
-
-      // Annoying we can't just call MatSeqAIJGetKokkosView
-      a_local_d = aijkok_local_output->a_dual.view_device();
-
-      // Annoyingly there isn't currently the ability to get views for i (or j)
+      // Get device pointers for the existing i array
       const PetscInt *device_local_i_output = nullptr;
       PetscMemType mtype;
       PetscCallVoid(MatSeqAIJGetCSRAndMemType(*output_mat, &device_local_i_output, NULL, NULL, &mtype));
-
-      // Have these point at the existing i pointers
-      ConstMatRowMapKokkosView i_local_const_d = ConstMatRowMapKokkosView(device_local_i_output, local_rows_row+1);     
+      // Output values are fully overwritten below (one write per output entry)
+      Kokkos::View<PetscScalar *> device_local_a_output;
+      PetscCallVoid(MatSeqAIJGetKokkosViewWrite(*output_mat, &device_local_a_output));
 
       // Execute with scratch memory
       Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const KokkosTeamMemberType& t) {
@@ -2127,21 +2053,17 @@ PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosVi
             // of the exclusive scan for this index and the next one
             if (scratch_indices(j+1) > scratch_indices(j))
             {
-               // Be careful to use the correct i_idx_is_row index into i_local_const_d here
-               a_local_d(i_local_const_d(i_idx_is_row) + scratch_indices(j)) = device_local_vals[device_local_i[i] + j];            
+               // Be careful to use the correct i_idx_is_row index into device_local_i_output here
+               device_local_a_output(device_local_i_output[i_idx_is_row] + scratch_indices(j)) = device_local_vals(device_local_i[i] + j);
             }
          });
       });
-      
-      Kokkos::fence();      
 
-      // Have to specify we've modifed data on the device
-      // Want to call MatSeqAIJKokkosModifyDevice but its PETSC_INTERN
-      aijkok_local_output->a_dual.clear_sync_state();
-      aijkok_local_output->a_dual.modify_device();
-      aijkok_local_output->transpose_updated = PETSC_FALSE;
-      aijkok_local_output->hermitian_updated = PETSC_FALSE;
-      PetscObjectStateIncrease((PetscObject)(*output_mat));    
+      Kokkos::fence();
+
+      // The matching restore handles MatSeqAIJKokkosModifyDevice (clears sync state,
+      // marks device modified, invalidates transpose/hermitian, bumps object state).
+      PetscCallVoid(MatSeqAIJRestoreKokkosViewWrite(*output_mat, &device_local_a_output));
 
    }
 
@@ -2152,10 +2074,12 @@ PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosVi
    // ~~~~~~~~~~~~~~~   
 
    if (!reuse_int)
-   {   
+   {
       // Create the matrix given the sorted csr
       PetscCallVoid(MatCreateSeqAIJKokkosWithKokkosViews(PETSC_COMM_SELF, local_rows_row, local_cols_col, i_local_d, j_local_d, a_local_d, output_mat));
-   }  
+   }
+
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(*input_mat, &device_local_vals));
 
    return;
 }
@@ -2163,11 +2087,12 @@ PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosVi
 //------------------------------------------------------------------------------------------------------------------------
 
 // Does a MatGetSubMatrix for a Kokkos matrix - the petsc version currently uses the host making it very slow
-// This version only works  works if the input IS have the same parallel row/column distribution 
+// This version only works  works if the input IS have the same parallel row/column distribution
 // as the matrices, ie equivalent to MatCreateSubMatrix_MPIAIJ_SameRowDist
 // is_col must be sorted
 // This one uses the views is_row_d_d and is_col_d_d directly, rewritten to be the local indices
-PETSC_INTERN void MatCreateSubMatrix_kokkos_view(Mat *input_mat, PetscIntKokkosView &is_row_d_d, PetscInt global_rows_row, \
+PETSC_INTERN void MatCreateSubMatrix_kokkos_view(Mat *input_mat, \
+         PetscIntKokkosView &is_row_d_d, PetscInt global_rows_row, \
          PetscIntKokkosView &is_col_d_d, PetscInt global_cols_col, const int reuse_int, Mat *output_mat)
 {
    PetscInt local_rows, local_cols;
@@ -2182,22 +2107,24 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos_view(Mat *input_mat, PetscIntKokkosV
    MPI_Comm MPI_COMM_MATRIX;
    PetscCallVoid(MatGetType(*input_mat, &mat_type));
 
-   const bool mpi = strcmp(mat_type, MATMPIAIJKOKKOS) == 0;   
+   const bool mpi = strcmp(mat_type, MATMPIAIJKOKKOS) == 0;
    PetscCallVoid(PetscObjectGetComm((PetscObject)*input_mat, &MPI_COMM_MATRIX));
    PetscCallVoid(MatGetSize(*input_mat, &global_rows, &global_cols));
    PetscCallVoid(MatGetLocalSize(*input_mat, &local_rows, &local_cols));
 
-   Mat_MPIAIJ *mat_mpi = nullptr;
-   Mat mat_local = NULL, mat_nonlocal = NULL;   
+   Mat mat_local = NULL, mat_nonlocal = NULL;
    Mat output_mat_local, output_mat_nonlocal;
-  
+   // The matrix's own mult SF (the borrowed mvctx) drives the halo scatter;
+   // we build a matching leaf Vec locally and destroy it at the end.
+   PetscSF sf = NULL;
+   Vec leaf_vec = NULL;
+
    PetscInt rows_ao, cols_ao;
    if (mpi)
    {
-      mat_mpi = (Mat_MPIAIJ *)(*input_mat)->data;
       PetscCallVoid(MatMPIAIJGetSeqAIJ(*input_mat, &mat_local, &mat_nonlocal, NULL));
-      PetscCallVoid(MatGetSize(mat_nonlocal, &rows_ao, &cols_ao)); 
-      
+      PetscCallVoid(MatGetSize(mat_nonlocal, &rows_ao, &cols_ao));
+
       if (reuse_int)
       {
          PetscCallVoid(MatMPIAIJGetSeqAIJ(*output_mat, &output_mat_local, &output_mat_nonlocal, NULL));
@@ -2238,6 +2165,10 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos_view(Mat *input_mat, PetscIntKokkosV
          // Uses VecScatter with PetscScalar Vecs (matching PETSc's own pattern)
          // instead of direct PetscSFBcast with MPIU_INT on temporary views.
 
+         // Borrowed mult SF + locally-built leaf Vec (sized/typed to match Ao)
+         PetscCallVoid(MatGetMultPetscSF(*input_mat, &sf));
+         PetscCallVoid(MatCreateVecs(mat_nonlocal, &leaf_vec, NULL));
+
          /* (1) iscol is a sub-column vector of mat, pad it with '-1.' to form a full vector x */
          Vec x_vec, cmap_vec;
          PetscCallVoid(MatCreateVecs(*input_mat, &x_vec, NULL));
@@ -2255,12 +2186,13 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos_view(Mat *input_mat, PetscIntKokkosV
             PetscCallVoid(VecRestoreKokkosViewWrite(x_vec, &x_scalar_d));
          }
 
-         /* (2) Scatter x and cmap using Mvctx to get their off-process portions */
-         // Keep at most one active communication on Mvctx at a time.
+         /* (2) Scatter x and cmap using the matrix mult SF + local leaf Vec to get their
+            off-process portions. Same single SF drives both scatters. */
+         // Keep at most one active communication on the SF at a time.
          // While Begin/End is in flight, do not touch the corresponding send/recv buffers.
          // Ensure send/receive buffers are stable before Begin.
-         Kokkos::fence();         
-         PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, x_vec, mat_mpi->lvec, INSERT_VALUES, SCATTER_FORWARD));
+         Kokkos::fence();
+         PetscCallVoid(VecScatterBegin(sf, x_vec, leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
 
          // Fill cmap_vec on device: cmap[is_col(i)] = i + isstart, rest = -1
          {
@@ -2272,10 +2204,10 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos_view(Mat *input_mat, PetscIntKokkosV
                   cmap_scalar_d(is_col_d_d(i)) = (PetscScalar)(i + isstart);
             });
             PetscCallVoid(VecRestoreKokkosViewWrite(cmap_vec, &cmap_scalar_d));
-         }         
+         }
 
          Vec lcmap_vec;
-         PetscCallVoid(VecDuplicate(mat_mpi->lvec, &lcmap_vec));
+         PetscCallVoid(VecDuplicate(leaf_vec, &lcmap_vec));
 
          /* (3) Count how many off-local columns match */
          PetscInt col_ao_output = 0;
@@ -2284,18 +2216,18 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos_view(Mat *input_mat, PetscIntKokkosV
          auto is_col_o_match_d = PetscIntKokkosView("is_col_o_match_d", cols_ao+1);
          Kokkos::deep_copy(exec, is_col_o_match_d, 0);
 
-         // x scatter completed: mat_mpi->lvec is now safe to read.
-         PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, x_vec, mat_mpi->lvec, INSERT_VALUES, SCATTER_FORWARD));
+         // x scatter completed: leaf_vec is now safe to read.
+         PetscCallVoid(VecScatterEnd(sf, x_vec, leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
 
-         // Start cmap scatter only after finishing x scatter on the same Mvctx.
+         // Start cmap scatter only after finishing x scatter on the same SF.
          // Ensure send/receive buffers are stable before Begin.
-         Kokkos::fence();         
-         PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, cmap_vec, lcmap_vec, INSERT_VALUES, SCATTER_FORWARD));
+         Kokkos::fence();
+         PetscCallVoid(VecScatterBegin(sf, cmap_vec, lcmap_vec, INSERT_VALUES, SCATTER_FORWARD));
 
          if (cols_ao > 0)
          {
             ConstPetscScalarKokkosView lvec_scalar_d;
-            PetscCallVoid(VecGetKokkosView(mat_mpi->lvec, &lvec_scalar_d));
+            PetscCallVoid(VecGetKokkosView(leaf_vec, &lvec_scalar_d));
 
             Kokkos::parallel_reduce("FindMatches", Kokkos::RangePolicy<>(exec, 0, cols_ao),
                KOKKOS_LAMBDA(const PetscInt i, PetscInt& thread_sum) {
@@ -2309,7 +2241,7 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos_view(Mat *input_mat, PetscIntKokkosV
                Kokkos::Sum<PetscInt>(col_ao_output)
             );
 
-            PetscCallVoid(VecRestoreKokkosView(mat_mpi->lvec, &lvec_scalar_d));
+            PetscCallVoid(VecRestoreKokkosView(leaf_vec, &lvec_scalar_d));
          }
 
          // Need to do an exclusive scan on is_col_o_match_d to get the new local indices
@@ -2330,7 +2262,7 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos_view(Mat *input_mat, PetscIntKokkosV
          garray_output_d = PetscIntKokkosView("garray_output_d", col_ao_output);
 
          // cmap scatter completed: lcmap_vec is now safe to read.
-         PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, cmap_vec, lcmap_vec, INSERT_VALUES, SCATTER_FORWARD));
+         PetscCallVoid(VecScatterEnd(sf, cmap_vec, lcmap_vec, INSERT_VALUES, SCATTER_FORWARD));
 
          // Loop over all the cols in the input matrix
          {
@@ -2358,6 +2290,7 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos_view(Mat *input_mat, PetscIntKokkosV
          PetscCallVoid(VecDestroy(&x_vec));
          PetscCallVoid(VecDestroy(&cmap_vec));
          PetscCallVoid(VecDestroy(&lcmap_vec));
+         PetscCallVoid(VecDestroy(&leaf_vec));
       }
       // If we're reusing we have the iscol_o associated with the output_mat
       else

--- a/src/PMISR_Module.F90
+++ b/src/PMISR_Module.F90
@@ -31,30 +31,30 @@ module pmisr_module
       integer, dimension(:), allocatable, target, intent(inout) :: cf_markers_local
       logical, optional, intent(in)       :: zero_measure_c_point
 
-#if defined(PETSC_HAVE_KOKKOS)                     
-      integer(c_long_long) :: A_array
+#if defined(PETSC_HAVE_KOKKOS)
       PetscErrorCode :: ierr
+      MPIU_Comm :: MPI_COMM_MATRIX
+      integer(c_long_long) :: A_array
       MatType :: mat_type
       integer :: pmis_int, zero_measure_c_point_int, seed_size, kfree, comm_rank, errorcode
       integer, dimension(:), allocatable :: seed
       PetscReal, dimension(:), allocatable, target :: measure_local
       PetscInt :: local_rows, local_cols
-      MPIU_Comm :: MPI_COMM_MATRIX    
       type(c_ptr)  :: measure_local_ptr, cf_markers_local_ptr
       integer, dimension(:), allocatable :: cf_markers_local_two
-#endif        
+#endif
       ! ~~~~~~~~~~
 
-#if defined(PETSC_HAVE_KOKKOS)    
+#if defined(PETSC_HAVE_KOKKOS)
 
       call MatGetType(strength_mat, mat_type, ierr)
       if (mat_type == MATMPIAIJKOKKOS .OR. mat_type == MATSEQAIJKOKKOS .OR. &
-            mat_type == MATAIJKOKKOS) then  
+            mat_type == MATAIJKOKKOS) then
 
-         call PetscObjectGetComm(strength_mat, MPI_COMM_MATRIX, ierr)    
-         call MPI_Comm_rank(MPI_COMM_MATRIX, comm_rank, errorcode)                  
+         call PetscObjectGetComm(strength_mat, MPI_COMM_MATRIX, ierr)
+         call MPI_Comm_rank(MPI_COMM_MATRIX, comm_rank, errorcode)
 
-         A_array = strength_mat%v  
+         A_array = strength_mat%v
          pmis_int = 0
          if (pmis) pmis_int = 1
          zero_measure_c_point_int = 0
@@ -65,67 +65,65 @@ module pmisr_module
          ! Let's generate the random values on the host for now so they match
          ! for comparisons with pmisr_cpu
          call MatGetLocalSize(strength_mat, local_rows, local_cols, ierr)
-         allocate(measure_local(local_rows))   
+         allocate(measure_local(local_rows))
          call random_seed(size=seed_size)
          allocate(seed(seed_size))
          do kfree = 1, seed_size
             seed(kfree) = comm_rank + 1 + kfree
-         end do   
-         call random_seed(put=seed) 
+         end do
+         call random_seed(put=seed)
          ! Fill the measure with random numbers
          call random_number(measure_local)
-         deallocate(seed)   
-         
+         deallocate(seed)
+
          measure_local_ptr = c_loc(measure_local)
 
-         allocate(cf_markers_local(local_rows))  
+         allocate(cf_markers_local(local_rows))
          cf_markers_local_ptr = c_loc(cf_markers_local)
 
          ! Creates a cf_markers on the device
          call pmisr_kokkos(A_array, max_luby_steps, pmis_int, measure_local_ptr, zero_measure_c_point_int)
 
          ! If debugging do a comparison between CPU and Kokkos results
-         if (kokkos_debug()) then         
+         if (kokkos_debug()) then
 
-            ! Kokkos PMISR by default now doesn't copy back to the host, as any following ddc calls 
+            ! Kokkos PMISR by default now doesn't copy back to the host, as any following ddc calls
             ! use the device data
             call copy_cf_markers_d2h(cf_markers_local_ptr)
-            call pmisr_cpu(strength_mat, max_luby_steps, pmis, cf_markers_local_two, zero_measure_c_point)  
-            
-            if (any(cf_markers_local /= cf_markers_local_two)) then
+            call pmisr_cpu(strength_mat, max_luby_steps, pmis, &
+                           cf_markers_local_two, zero_measure_c_point)
 
-               ! do kfree = 1, local_rows
-               !    if (cf_markers_local(kfree) /= cf_markers_local_two(kfree)) then
-               !       print *, kfree, "no match", cf_markers_local(kfree), cf_markers_local_two(kfree)
-               !    end if
-               ! end do
+            if (any(cf_markers_local /= cf_markers_local_two)) then
                print *, "Kokkos and CPU versions of pmisr do not match"
-               call MPI_Abort(MPI_COMM_WORLD, MPI_ERR_OTHER, errorcode) 
+               call MPI_Abort(MPI_COMM_WORLD, MPI_ERR_OTHER, errorcode)
             end if
             deallocate(cf_markers_local_two)
          end if
 
       else
-         call pmisr_cpu(strength_mat, max_luby_steps, pmis, cf_markers_local, zero_measure_c_point)       
+         call pmisr_cpu(strength_mat, max_luby_steps, pmis, &
+                        cf_markers_local, zero_measure_c_point)
       end if
 #else
-      call pmisr_cpu(strength_mat, max_luby_steps, pmis, cf_markers_local, zero_measure_c_point)
-#endif        
+      call pmisr_cpu(strength_mat, max_luby_steps, pmis, &
+                     cf_markers_local, zero_measure_c_point)
+#endif
 
-      ! ~~~~~~ 
+      ! ~~~~~~
 
    end subroutine pmisr
    
 ! -------------------------------------------------------------------------------------------------------------------------------
 
-   subroutine pmisr_cpu(strength_mat, max_luby_steps, pmis, cf_markers_local, zero_measure_c_point)
+   subroutine pmisr_cpu(strength_mat, max_luby_steps, pmis, &
+                        cf_markers_local, zero_measure_c_point)
 
       ! Let's do our own independent set with a Luby algorithm
       ! If PMIS is true, this is a traditional PMIS algorithm
       ! If PMIS is false, this is a PMISR
-      ! PMISR swaps the C-F definition compared to a PMIS and 
+      ! PMISR swaps the C-F definition compared to a PMIS and
       ! also checks the measure from smallest, rather than the largest
-      ! PMISR should give an Aff with no off-diagonal strong connections 
+      ! PMISR should give an Aff with no off-diagonal strong connections
       ! If you set positive max_luby_steps, it will avoid all parallel reductions
       ! by taking a fixed number of times in the Luby top loop
 
@@ -253,7 +251,8 @@ module pmisr_module
       ! in our Luby below
       if (pmis) measure_local = measure_local * (-1)
       
-      call pmisr_existing_measure_cf_markers(strength_mat, max_luby_steps, pmis, &
+      call pmisr_existing_measure_cf_markers(strength_mat, &
+               max_luby_steps, pmis, &
                measure_local, cf_markers_local, zero_measure_c_point)
 
       deallocate(measure_local)
@@ -266,11 +265,16 @@ module pmisr_module
 
    ! -------------------------------------------------------------------------------------------------------------------------------
 
-   subroutine pmisr_existing_measure_cf_markers(strength_mat, max_luby_steps, pmis, &
+   subroutine pmisr_existing_measure_cf_markers(strength_mat, &
+                  max_luby_steps, pmis, &
                   measure_local, cf_markers_local, zero_measure_c_point)
 
-      ! PMISR implementation that takes an existing measure_local and cf_markers_local 
+      ! PMISR implementation that takes an existing measure_local and cf_markers_local
       ! and then does the Luby algorithm to assign the rest of the CF markers
+      !
+      ! The halo scatters use strength_mat's own mult PetscSF (via
+      ! MatGetMultPetscSF inside the C scatter routines); we build a matching
+      ! leaf Vec locally for the measure scatter and destroy it at the end.
 
       ! ~~~~~~
 
@@ -288,44 +292,45 @@ module pmisr_module
       PetscInt :: rows_ao, cols_ao, n_ad, n_ao
       PetscInt :: counter_undecided, counter_in_set_start, counter_parallel
       integer :: comm_size, loops_through
-      integer :: comm_rank, errorcode       
+      integer :: comm_rank, errorcode
       PetscErrorCode :: ierr
-      MPIU_Comm :: MPI_COMM_MATRIX      
+      MPIU_Comm :: MPI_COMM_MATRIX
       PetscBool, dimension(:), allocatable :: in_set_this_loop
       PetscBool, dimension(:), allocatable, target :: assigned_local, assigned_nonlocal
       type(c_ptr) :: measure_nonlocal_ptr=c_null_ptr, assigned_local_ptr=c_null_ptr, assigned_nonlocal_ptr=c_null_ptr
       real(c_double), pointer :: measure_nonlocal(:) => null()
       type(tMat) :: Ad, Ao
-      type(tVec) :: measure_vec
+      type(tVec) :: measure_vec, leaf_vec
       PetscInt, dimension(:), pointer :: colmap
-      integer(c_long_long) :: A_array, vec_long
+      integer(c_long_long) :: vec_long, leaf_vec_array
+      integer(c_long_long) :: A_array
       PetscInt, dimension(:), pointer :: ad_ia, ad_ja, ao_ia, ao_ja
       PetscInt :: shift = 0
       PetscBool :: symmetric = PETSC_FALSE, inodecompressed = PETSC_FALSE, done
-      logical :: zero_measure_c = .FALSE.  
+      logical :: zero_measure_c = .FALSE.
       PetscInt, parameter :: nz_ignore = -1, one=1, zero=0
 
-      ! ~~~~~~           
+      ! ~~~~~~
 
       if (present(zero_measure_c_point)) zero_measure_c = zero_measure_c_point
 
-      ! Get the comm size 
-      call PetscObjectGetComm(strength_mat, MPI_COMM_MATRIX, ierr)    
+      ! Get the comm size
+      call PetscObjectGetComm(strength_mat, MPI_COMM_MATRIX, ierr)
       call MPI_Comm_size(MPI_COMM_MATRIX, comm_size, errorcode)
-      ! Get the comm rank 
-      call MPI_Comm_rank(MPI_COMM_MATRIX, comm_rank, errorcode)      
+      ! Get the comm rank
+      call MPI_Comm_rank(MPI_COMM_MATRIX, comm_rank, errorcode)
 
       ! Get the local sizes
       call MatGetLocalSize(strength_mat, local_rows, local_cols, ierr)
-      call MatGetSize(strength_mat, global_rows, global_cols, ierr)      
-      call MatGetOwnershipRange(strength_mat, global_row_start, global_row_end_plus_one, ierr)   
+      call MatGetSize(strength_mat, global_rows, global_cols, ierr)
+      call MatGetOwnershipRange(strength_mat, global_row_start, global_row_end_plus_one, ierr)
 
       if (comm_size /= 1) then
-         call MatMPIAIJGetSeqAIJ(strength_mat, Ad, Ao, colmap, ierr) 
+         call MatMPIAIJGetSeqAIJ(strength_mat, Ad, Ao, colmap, ierr)
          ! We know the col size of Ao is the size of colmap, the number of non-zero offprocessor columns
-         call MatGetSize(Ao, rows_ao, cols_ao, ierr)    
+         call MatGetSize(Ao, rows_ao, cols_ao, ierr)
       else
-         Ad = strength_mat    
+         Ad = strength_mat
       end if
 
       ! ~~~~~~~~
@@ -350,7 +355,8 @@ module pmisr_module
       allocate(assigned_local(local_rows))
         
       ! ~~~~~~~~~~~~
-      ! Create parallel vec and scatter the measure
+      ! Create parallel vec and scatter the measure using strength_mat's mult SF
+      ! and a locally-built leaf Vec (matches the off-diagonal block layout)
       ! ~~~~~~~~~~~~
       if (comm_size/=1) then
 
@@ -358,14 +364,14 @@ module pmisr_module
          call VecCreateMPIWithArray(MPI_COMM_MATRIX, one, &
             local_rows, global_rows, measure_local, measure_vec, ierr)
 
-         A_array = strength_mat%v
+         ! Leaf Vec sized/typed to match the off-diagonal block
+         call MatCreateVecs(Ao, leaf_vec, PETSC_NULL_VEC, ierr)
+         leaf_vec_array = leaf_vec%v
+
          vec_long = measure_vec%v
-         ! We're just going to use the existing lvec to scatter the measure
-         ! Have to call restore after we're done with lvec (ie measure_nonlocal_ptr)
-         call vecscatter_mat_begin_c(A_array, vec_long, measure_nonlocal_ptr)
-         call vecscatter_mat_end_c(A_array, vec_long, measure_nonlocal_ptr)
-         ! This is the lvec so we have to make sure we don't do a matvec anywhere 
-         ! before calling restore
+         A_array = strength_mat%v
+         call vecscatter_mat_begin_c(A_array, vec_long, leaf_vec_array)
+         call vecscatter_mat_end_c(A_array, vec_long, leaf_vec_array, measure_nonlocal_ptr)
          call c_f_pointer(measure_nonlocal_ptr, measure_nonlocal, shape=[cols_ao])
 
          allocate(assigned_nonlocal(cols_ao))
@@ -521,11 +527,11 @@ module pmisr_module
          ! ~~~~~~~~
          if (comm_size /= 1) then
             call boolscatter_mat_end_c(A_array, assigned_local_ptr, assigned_nonlocal_ptr)
-         end if     
-                 
+         end if
+
          ! ~~~~~~~~
          ! Now go through and do the non-local part of the matrix
-         ! ~~~~~~~~            
+         ! ~~~~~~~~
          if (comm_size /= 1) then
 
             node_loop: do ifree = 1, local_rows   
@@ -583,7 +589,7 @@ module pmisr_module
             ! After this comms finishes any local node in another processors halo 
             ! that has been assigned on another process will be correctly marked in assigned_local
             ! ~~~~~~~~~~~    
-            call boolscatter_mat_reverse_begin_c(A_array, assigned_local_ptr, assigned_nonlocal_ptr)       
+            call boolscatter_mat_reverse_begin_c(A_array, assigned_local_ptr, assigned_nonlocal_ptr)
 
          end if
 
@@ -608,7 +614,7 @@ module pmisr_module
          ! ~~~~~~~~~
          if (comm_size /= 1) then
             ! Finishes the reduce LOR, assigned_local will now be correct
-            call boolscatter_mat_reverse_end_c(A_array, assigned_local_ptr, assigned_nonlocal_ptr)       
+            call boolscatter_mat_reverse_end_c(A_array, assigned_local_ptr, assigned_nonlocal_ptr)
          end if
 
          ! ~~~~~~~~~~~~
@@ -649,17 +655,18 @@ module pmisr_module
       ! ~~~~~~~~~      
       deallocate(in_set_this_loop, assigned_local)
       if (comm_size/=1) then
-         call VecDestroy(measure_vec, ierr)    
-         ! Don't forget to restore on lvec from our matrix
-         call vecscatter_mat_restore_c(A_array, measure_nonlocal_ptr)             
+         call vecscatter_mat_restore_c(leaf_vec_array, measure_nonlocal_ptr)
+         call VecDestroy(measure_vec, ierr)
+         call VecDestroy(leaf_vec, ierr)
       end if
-      deallocate(assigned_nonlocal)    
+      deallocate(assigned_nonlocal)
 
-   end subroutine pmisr_existing_measure_cf_markers  
+   end subroutine pmisr_existing_measure_cf_markers
 
    ! -------------------------------------------------------------------------------------------------------------------------------
 
-   subroutine pmisr_existing_measure_implicit_transpose(strength_mat, max_luby_steps, pmis, &
+   subroutine pmisr_existing_measure_implicit_transpose(strength_mat, &
+                  max_luby_steps, pmis, &
                   measure_local, cf_markers_local, zero_measure_c_point)
 
       ! ~~~~~~~~~~~~~~~~~~~~~
@@ -716,9 +723,10 @@ module pmisr_module
       type(c_ptr) :: veto_local_ptr=c_null_ptr, veto_nonlocal_ptr=c_null_ptr, in_set_ptr=c_null_ptr
       real(c_double), pointer :: measure_nonlocal(:) => null()
       type(tMat) :: Ad, Ao, Ad_spst, Ao_transpose
-      type(tVec) :: measure_vec
+      type(tVec) :: measure_vec, leaf_vec
       PetscInt, dimension(:), pointer :: colmap
-      integer(c_long_long) :: A_array, vec_long
+      integer(c_long_long) :: vec_long, leaf_vec_array
+      integer(c_long_long) :: A_array
       PetscInt, dimension(:), pointer :: ad_ia, ad_ja, ao_ia, ao_ja
       PetscInt, dimension(:), pointer :: spst_ia, spst_ja, aot_ia, aot_ja
       PetscInt :: shift = 0
@@ -818,7 +826,8 @@ module pmisr_module
       allocate(veto_local(local_rows))
 
       ! ~~~~~~~~~~~~
-      ! Create parallel vec and scatter the measure
+      ! Create parallel vec and scatter the measure using strength_mat's mult SF
+      ! and a locally-built leaf Vec (matches the off-diagonal block layout)
       ! ~~~~~~~~~~~~
       if (comm_size/=1) then
 
@@ -826,14 +835,14 @@ module pmisr_module
          call VecCreateMPIWithArray(MPI_COMM_MATRIX, one, &
             local_rows, global_rows, measure_local, measure_vec, ierr)
 
-         A_array = strength_mat%v
+         ! Leaf Vec sized/typed to match the off-diagonal block
+         call MatCreateVecs(Ao, leaf_vec, PETSC_NULL_VEC, ierr)
+         leaf_vec_array = leaf_vec%v
+
          vec_long = measure_vec%v
-         ! We're just going to use the existing lvec to scatter the measure
-         ! Have to call restore after we're done with lvec (ie measure_nonlocal_ptr)
-         call vecscatter_mat_begin_c(A_array, vec_long, measure_nonlocal_ptr)
-         call vecscatter_mat_end_c(A_array, vec_long, measure_nonlocal_ptr)
-         ! This is the lvec so we have to make sure we don't do a matvec anywhere
-         ! before calling restore
+         A_array = strength_mat%v
+         call vecscatter_mat_begin_c(A_array, vec_long, leaf_vec_array)
+         call vecscatter_mat_end_c(A_array, vec_long, leaf_vec_array, measure_nonlocal_ptr)
          call c_f_pointer(measure_nonlocal_ptr, measure_nonlocal, shape=[cols_ao])
 
          allocate(assigned_nonlocal(cols_ao))
@@ -1221,9 +1230,9 @@ module pmisr_module
 
       deallocate(in_set_this_loop, assigned_local, veto_local)
       if (comm_size/=1) then
+         call vecscatter_mat_restore_c(leaf_vec_array, measure_nonlocal_ptr)
          call VecDestroy(measure_vec, ierr)
-         ! Don't forget to restore on lvec from our matrix
-         call vecscatter_mat_restore_c(A_array, measure_nonlocal_ptr)
+         call VecDestroy(leaf_vec, ierr)
       end if
       deallocate(assigned_nonlocal, veto_nonlocal)
 

--- a/src/PMISR_Modulek.kokkos.cxx
+++ b/src/PMISR_Modulek.kokkos.cxx
@@ -1,8 +1,6 @@
 // Our petsc kokkos definitions - has to go first
 #include "kokkos_helper.hpp"
 #include <iostream>
-#include <../src/mat/impls/aij/seq/aij.h>
-#include <../src/mat/impls/aij/mpi/mpiaij.h>
 
 // The definition of the device copy of the cf markers on a given level
 // is stored in Device_Datak.kokkos.cxx and imported as extern from
@@ -26,14 +24,18 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
    // Are we in parallel?
    const bool mpi = strcmp(mat_type, MATMPIAIJKOKKOS) == 0;
 
-   Mat_MPIAIJ *mat_mpi = nullptr;
    Mat mat_local = NULL, mat_nonlocal = NULL;
+   // The matrix's own mult SF (the borrowed mvctx) drives the halo scatters;
+   // we build a matching leaf Vec locally and destroy it at the end.
+   PetscSF sf = NULL;
+   Vec leaf_vec = NULL;
 
    if (mpi)
    {
-      mat_mpi = (Mat_MPIAIJ *)(*strength_mat)->data;
       PetscCallVoid(MatMPIAIJGetSeqAIJ(*strength_mat, &mat_local, &mat_nonlocal, NULL));
       PetscCallVoid(MatGetSize(mat_nonlocal, &rows_ao, &cols_ao));
+      PetscCallVoid(MatGetMultPetscSF(*strength_mat, &sf));
+      PetscCallVoid(MatCreateVecs(mat_nonlocal, &leaf_vec, NULL));
    }
    else
    {
@@ -48,13 +50,12 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
    PetscCallVoid(MatGetOwnershipRange(*strength_mat, &global_row_start, &global_row_end_plus_one));
 
    // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
+   // Get pointers to the i,j on the device
    // ~~~~~~~~~~~~
    const PetscInt *device_local_i = nullptr, *device_local_j = nullptr, *device_nonlocal_i = nullptr, *device_nonlocal_j = nullptr;
    PetscMemType mtype;
-   PetscScalar *device_local_vals = nullptr, *device_nonlocal_vals = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, &device_local_vals, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, &device_nonlocal_vals, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, NULL, &mtype));
 
    intKokkosView cf_markers_nonlocal_d;
    // Scratch buffer used for local update bookkeeping during overlap with reverse scatter.
@@ -72,7 +73,7 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
    boolKokkosView mark_d("mark_d", local_rows);
    auto exec = PetscGetKokkosExecutionSpace();
 
-   // Scatter the measure using VecScatter (matching PETSc's own buffer management)
+   // Scatter the measure using the caller-supplied SF/leaf Vec
    if (mpi)
    {
       Vec measure_root_vec;
@@ -84,14 +85,14 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
          PetscCallVoid(VecRestoreKokkosViewWrite(measure_root_vec, &root_scalar_d));
       }
       // Ensure send/receive buffers are stable before Begin.
-      Kokkos::fence();      
-      PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, measure_root_vec, mat_mpi->lvec, INSERT_VALUES, SCATTER_FORWARD));
-      PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, measure_root_vec, mat_mpi->lvec, INSERT_VALUES, SCATTER_FORWARD));
+      Kokkos::fence();
+      PetscCallVoid(VecScatterBegin(sf, measure_root_vec, leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
+      PetscCallVoid(VecScatterEnd(sf, measure_root_vec, leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
       {
          ConstPetscScalarKokkosView lvec_scalar_d;
-         PetscCallVoid(VecGetKokkosView(mat_mpi->lvec, &lvec_scalar_d));
+         PetscCallVoid(VecGetKokkosView(leaf_vec, &lvec_scalar_d));
          Kokkos::deep_copy(exec, measure_nonlocal_d, lvec_scalar_d);
-         PetscCallVoid(VecRestoreKokkosView(mat_mpi->lvec, &lvec_scalar_d));
+         PetscCallVoid(VecRestoreKokkosView(leaf_vec, &lvec_scalar_d));
       }
       PetscCallVoid(VecDestroy(&measure_root_vec));
    }
@@ -154,11 +155,12 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
    // Now go through the outer Luby loop
    // ~~~~~~~~~~~~
 
-   // Create reusable Vecs for VecScatter inside the loop (cf_markers int → PetscScalar)
-   Vec scatter_root_vec = NULL, scatter_leaf_vec = NULL;
+   // Create reusable root Vec for VecScatter inside the loop (cf_markers int → PetscScalar).
+   // Our local leaf_vec doubles as the leaf for the loop scatters.
+   Vec scatter_root_vec = NULL;
+   Vec scatter_leaf_vec = mpi ? leaf_vec : NULL;
    if (mpi) {
       PetscCallVoid(MatCreateVecs(*strength_mat, &scatter_root_vec, NULL));
-      PetscCallVoid(VecDuplicate(mat_mpi->lvec, &scatter_leaf_vec));
    }
 
    // Let's keep track of how many times we go through the loops
@@ -194,7 +196,7 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
          }
          // Ensure the root buffer is no longer being written before Begin.
          Kokkos::fence();
-         PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
+         PetscCallVoid(VecScatterBegin(sf, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
       }
 
 
@@ -262,7 +264,7 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
       if (mpi) {
 
          // Complete the in-flight forward scatter before reading the receive buffer.
-         PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
+         PetscCallVoid(VecScatterEnd(sf, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
 
          // Convert PetscScalar → int after End, when the receive buffer is complete.
          {
@@ -381,7 +383,7 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
          }
          // Ensure send/receive buffers are stable before Begin.
          Kokkos::fence();
-         PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
+         PetscCallVoid(VecScatterBegin(sf, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
 
          // While reverse scatter is in-flight, do local-only updates in cf_markers_temp_d.
          // This must not touch scatter_root_vec/scatter_leaf_vec.
@@ -411,7 +413,7 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
          });
 
          // Complete reverse scatter before reading reduced root buffer.
-         PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
+         PetscCallVoid(VecScatterEnd(sf, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
 
          // Convert PetscScalar → int back to cf_markers_d after End.
          {
@@ -483,9 +485,9 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
    }
    while (counter_undecided != 0);
 
-   // Cleanup loop Vecs
+   // Cleanup loop Vecs (scatter_leaf_vec aliases our local leaf_vec, destroyed below)
    PetscCallVoid(VecDestroy(&scatter_root_vec));
-   PetscCallVoid(VecDestroy(&scatter_leaf_vec));
+   PetscCallVoid(VecDestroy(&leaf_vec));
 
    // ~~~~~~~~~
    // Now assign our final cf markers
@@ -533,8 +535,11 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
    // Are we in parallel?
    const bool mpi = strcmp(mat_type, MATMPIAIJKOKKOS) == 0;
 
-   Mat_MPIAIJ *mat_mpi = nullptr;
    Mat mat_local = NULL, mat_nonlocal = NULL, mat_local_spst = NULL, mat_nonlocal_transpose = NULL;
+   // The matrix's own mult SF (the borrowed mvctx) drives the halo scatters;
+   // we build a matching leaf Vec locally and destroy it at the end.
+   PetscSF sf = NULL;
+   Vec leaf_vec = NULL;
 
    // ~~~~~~~~~~~~~~~~~~~~~
    // PMISR needs to work with S+S^T to keep out large entries from Aff
@@ -552,19 +557,25 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
    // for the non-local components)
    // ~~~~~~~~~~~~~~~~~~~~~
 
-   Mat_SeqAIJKokkos *mat_nonlocal_kok, *mat_local_kok;
-   PetscInt zero = 0;
    bool destroy_nonlocal_transpose = false;
    bool destroy_spst = false;
 
    if (mpi)
    {
-      mat_mpi = (Mat_MPIAIJ *)(*strength_mat)->data;
       PetscCallVoid(MatMPIAIJGetSeqAIJ(*strength_mat, &mat_local, &mat_nonlocal, NULL));
       PetscCallVoid(MatGetSize(mat_nonlocal, &rows_ao, &cols_ao));
-      mat_nonlocal_kok = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal->spptr);
+      // Borrowed mult SF + locally-built leaf Vec (sized/typed to match Ao)
+      PetscCallVoid(MatGetMultPetscSF(*strength_mat, &sf));
+      PetscCallVoid(MatCreateVecs(mat_nonlocal, &leaf_vec, NULL));
+      // Read the nnz from the host i pointer
+      PetscInt n;
+      PetscBool symmetric = PETSC_FALSE, inodecompressed = PETSC_FALSE, done;
+      const PetscInt *ao_ia;
+      PetscCallVoid(MatGetRowIJ(mat_nonlocal, 0, symmetric, inodecompressed, &n, &ao_ia, NULL, &done));
+      const PetscInt nonlocal_nnz = ao_ia[n];
+      PetscCallVoid(MatRestoreRowIJ(mat_nonlocal, 0, symmetric, inodecompressed, &n, &ao_ia, NULL, &done));
       // The transpose can crash if mat_nonlocal is empty
-      if (mat_nonlocal_kok->csrmat.nnz() > zero)
+      if (nonlocal_nnz > 0)
       {
          PetscCallVoid(MatTranspose(mat_nonlocal, MAT_INITIAL_MATRIX, &mat_nonlocal_transpose));
          destroy_nonlocal_transpose = true;
@@ -574,7 +585,6 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
    {
       mat_local = *strength_mat;
    }
-   mat_local_kok = static_cast<Mat_SeqAIJKokkos *>(mat_local->spptr);
 
    // Get the comm
    PetscCallVoid(PetscObjectGetComm((PetscObject)*strength_mat, &MPI_COMM_MATRIX));
@@ -583,13 +593,24 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
    // This returns the global index of the local portion of the matrix
    PetscCallVoid(MatGetOwnershipRange(*strength_mat, &global_row_start, &global_row_end_plus_one));
 
+   // Read the nnz from the host i pointer of the local block
+   PetscInt local_nnz;
+   {
+      PetscInt n;
+      PetscBool symmetric = PETSC_FALSE, inodecompressed = PETSC_FALSE, done;
+      const PetscInt *ad_ia;
+      PetscCallVoid(MatGetRowIJ(mat_local, 0, symmetric, inodecompressed, &n, &ad_ia, NULL, &done));
+      local_nnz = ad_ia[n];
+      PetscCallVoid(MatRestoreRowIJ(mat_local, 0, symmetric, inodecompressed, &n, &ad_ia, NULL, &done));
+   }
+
    // ~~~~~~~~~~~~
    // Form the local S+S^T and get CSR pointers
    // We explicitly compute the local part of S+S^T so we don't have to
    // match the row/column indices - could do this as a symbolic as we don't need the values
    // ~~~~~~~~~~~~
    PetscScalar one = 1.0;
-   if (mat_local_kok->csrmat.nnz() > zero)
+   if (local_nnz > 0)
    {
       PetscCallVoid(MatTranspose(mat_local, MAT_INITIAL_MATRIX, &mat_local_spst));
       PetscCallVoid(MatAXPY(mat_local_spst, one, mat_local, DIFFERENT_NONZERO_PATTERN));
@@ -643,14 +664,14 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
          PetscCallVoid(VecRestoreKokkosViewWrite(measure_root_vec, &root_scalar_d));
       }
       // Ensure send/receive buffers are stable before Begin.
-      Kokkos::fence();      
-      PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, measure_root_vec, mat_mpi->lvec, INSERT_VALUES, SCATTER_FORWARD));
-      PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, measure_root_vec, mat_mpi->lvec, INSERT_VALUES, SCATTER_FORWARD));
+      Kokkos::fence();
+      PetscCallVoid(VecScatterBegin(sf, measure_root_vec, leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
+      PetscCallVoid(VecScatterEnd(sf, measure_root_vec, leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
       {
          ConstPetscScalarKokkosView lvec_scalar_d;
-         PetscCallVoid(VecGetKokkosView(mat_mpi->lvec, &lvec_scalar_d));
+         PetscCallVoid(VecGetKokkosView(leaf_vec, &lvec_scalar_d));
          Kokkos::deep_copy(exec, measure_nonlocal_d, lvec_scalar_d);
-         PetscCallVoid(VecRestoreKokkosView(mat_mpi->lvec, &lvec_scalar_d));
+         PetscCallVoid(VecRestoreKokkosView(leaf_vec, &lvec_scalar_d));
       }
       PetscCallVoid(VecDestroy(&measure_root_vec));
    }
@@ -715,11 +736,12 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
    // Now go through the outer Luby loop
    // ~~~~~~~~~~~~
 
-   // Create reusable Vecs for VecScatter inside the loop
-   Vec scatter_root_vec = NULL, scatter_leaf_vec = NULL;
+   // Create reusable root Vec for VecScatter inside the loop. Our local leaf_vec
+   // doubles as the leaf for every loop scatter.
+   Vec scatter_root_vec = NULL;
+   Vec scatter_leaf_vec = mpi ? leaf_vec : NULL;
    if (mpi) {
       PetscCallVoid(MatCreateVecs(*strength_mat, &scatter_root_vec, NULL));
-      PetscCallVoid(VecDuplicate(mat_mpi->lvec, &scatter_leaf_vec));
    }
 
    // Let's keep track of how many times we go through the loops
@@ -754,8 +776,8 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
          }
          // Ensure send/receive buffers are stable before Begin.
          Kokkos::fence();         
-         PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
-         PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
+         PetscCallVoid(VecScatterBegin(sf, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
+         PetscCallVoid(VecScatterEnd(sf, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
          // Convert PetscScalar → int
          {
             ConstPetscScalarKokkosView leaf_scalar_d;
@@ -904,8 +926,8 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
          }
          // Ensure send/receive buffers are stable before Begin.
          Kokkos::fence();         
-         PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
-         PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
+         PetscCallVoid(VecScatterBegin(sf, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
+         PetscCallVoid(VecScatterEnd(sf, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
          {
             ConstPetscScalarKokkosView root_scalar_d;
             PetscCallVoid(VecGetKokkosView(scatter_root_vec, &root_scalar_d));
@@ -1022,8 +1044,8 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
          }
          // Ensure send/receive buffers are stable before Begin.
          Kokkos::fence();         
-         PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
-         PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
+         PetscCallVoid(VecScatterBegin(sf, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
+         PetscCallVoid(VecScatterEnd(sf, scatter_root_vec, scatter_leaf_vec, INSERT_VALUES, SCATTER_FORWARD));
          {
             ConstPetscScalarKokkosView leaf_scalar_d;
             PetscCallVoid(VecGetKokkosView(scatter_leaf_vec, &leaf_scalar_d));
@@ -1084,8 +1106,8 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
          }
          // Ensure send/receive buffers are stable before Begin.
          Kokkos::fence();         
-         PetscCallVoid(VecScatterBegin(mat_mpi->Mvctx, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
-         PetscCallVoid(VecScatterEnd(mat_mpi->Mvctx, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
+         PetscCallVoid(VecScatterBegin(sf, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
+         PetscCallVoid(VecScatterEnd(sf, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
          {
             ConstPetscScalarKokkosView root_scalar_d;
             PetscCallVoid(VecGetKokkosView(scatter_root_vec, &root_scalar_d));
@@ -1192,9 +1214,9 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
    }
    while (counter_undecided != 0);
 
-   // Cleanup loop Vecs
+   // Cleanup loop Vecs (scatter_leaf_vec aliases our local leaf_vec, destroyed below)
    PetscCallVoid(VecDestroy(&scatter_root_vec));
-   PetscCallVoid(VecDestroy(&scatter_leaf_vec));
+   PetscCallVoid(VecDestroy(&leaf_vec));
 
    // Cleanup the local transposes
    if (destroy_spst) PetscCallVoid(MatDestroy(&mat_local_spst));
@@ -1236,7 +1258,6 @@ PETSC_INTERN void pmisr_kokkos(Mat *strength_mat, const int max_luby_steps, cons
 
    MPI_Comm MPI_COMM_MATRIX;
    PetscInt local_rows, local_cols, global_rows, global_cols;
-   PetscInt rows_ao, cols_ao;
    MatType mat_type;
 
    PetscCallVoid(MatGetType(*strength_mat, &mat_type));
@@ -1248,7 +1269,6 @@ PETSC_INTERN void pmisr_kokkos(Mat *strength_mat, const int max_luby_steps, cons
    if (mpi)
    {
       PetscCallVoid(MatMPIAIJGetSeqAIJ(*strength_mat, &mat_local, &mat_nonlocal, NULL));
-      PetscCallVoid(MatGetSize(mat_nonlocal, &rows_ao, &cols_ao));
    }
    else
    {
@@ -1261,13 +1281,12 @@ PETSC_INTERN void pmisr_kokkos(Mat *strength_mat, const int max_luby_steps, cons
    PetscCallVoid(MatGetSize(*strength_mat, &global_rows, &global_cols));
 
    // ~~~~~~~~~~~~
-   // Get pointers to the i,j,vals on the device
+   // Get pointers to the i,j on the device
    // ~~~~~~~~~~~~
    const PetscInt *device_local_i = nullptr, *device_local_j = nullptr, *device_nonlocal_i = nullptr, *device_nonlocal_j = nullptr;
    PetscMemType mtype;
-   PetscScalar *device_local_vals = nullptr, *device_nonlocal_vals = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, &device_local_vals, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, &device_nonlocal_vals, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, NULL, &mtype));
 
    // Device memory for the global variable cf_markers_local_d - be careful these aren't petsc ints
    cf_markers_local_d = intKokkosView("cf_markers_local_d", local_rows);
@@ -1310,7 +1329,7 @@ PETSC_INTERN void pmisr_kokkos(Mat *strength_mat, const int max_luby_steps, cons
       if (pmis_int == 1) measure_local_d(i) *= -1;
    });
 
-   // Call the existing measure cf markers function
+   // The callee obtains the halo SF from strength_mat via MatGetMultPetscSF.
    pmisr_existing_measure_cf_markers_kokkos(strength_mat, max_luby_steps, pmis_int, measure_local_d, cf_markers_d, zero_measure_c_point_int);
 
    // If PMIS then we swap the CF markers from PMISR

--- a/src/SAI_Zk.kokkos.cxx
+++ b/src/SAI_Zk.kokkos.cxx
@@ -210,42 +210,51 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
    }
 
    // ~~~~~~~~~~~~~~
-   // Get device CSR pointers for all matrices
+   // Get device CSR pointers for i,j and Kokkos views to the values
    // ~~~~~~~~~~~~~~
    PetscMemType mtype;
 
    // Submatrix (non-local rows of A_ff)
    const PetscInt *device_submat_i = nullptr, *device_submat_j = nullptr;
-   PetscScalar *device_submat_vals = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(submatrices[0], &device_submat_i, &device_submat_j, &device_submat_vals, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(submatrices[0], &device_submat_i, &device_submat_j, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_submat_vals;
+   PetscCallVoid(MatSeqAIJGetKokkosView(submatrices[0], &device_submat_vals));
 
    // A_ff local + nonlocal
    const PetscInt *device_local_i_ff = nullptr, *device_local_j_ff = nullptr;
    const PetscInt *device_nonlocal_i_ff = nullptr, *device_nonlocal_j_ff = nullptr;
-   PetscScalar *device_local_vals_ff = nullptr, *device_nonlocal_vals_ff = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_ff, &device_local_i_ff, &device_local_j_ff, &device_local_vals_ff, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_ff, &device_nonlocal_i_ff, &device_nonlocal_j_ff, &device_nonlocal_vals_ff, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_ff, &device_local_i_ff, &device_local_j_ff, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_ff, &device_nonlocal_i_ff, &device_nonlocal_j_ff, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals_ff;
+   Kokkos::View<const PetscScalar *> device_nonlocal_vals_ff;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local_ff, &device_local_vals_ff));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal_ff, &device_nonlocal_vals_ff));
 
    // A_cf local + nonlocal
    const PetscInt *device_local_i_cf = nullptr, *device_local_j_cf = nullptr;
    const PetscInt *device_nonlocal_i_cf = nullptr, *device_nonlocal_j_cf = nullptr;
-   PetscScalar *device_local_vals_cf = nullptr, *device_nonlocal_vals_cf = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_cf, &device_local_i_cf, &device_local_j_cf, &device_local_vals_cf, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_cf, &device_nonlocal_i_cf, &device_nonlocal_j_cf, &device_nonlocal_vals_cf, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_cf, &device_local_i_cf, &device_local_j_cf, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_cf, &device_nonlocal_i_cf, &device_nonlocal_j_cf, NULL, &mtype));
+   Kokkos::View<const PetscScalar *> device_local_vals_cf;
+   Kokkos::View<const PetscScalar *> device_nonlocal_vals_cf;
+   PetscCallVoid(MatSeqAIJGetKokkosView(mat_local_cf, &device_local_vals_cf));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosView(mat_nonlocal_cf, &device_nonlocal_vals_cf));
 
-   // Sparsity matrix local + nonlocal
+   // Sparsity matrix local + nonlocal (values not used in this routine)
    const PetscInt *device_local_i_sparsity = nullptr, *device_local_j_sparsity = nullptr;
    const PetscInt *device_nonlocal_i_sparsity = nullptr, *device_nonlocal_j_sparsity = nullptr;
-   PetscScalar *device_local_vals_sparsity = nullptr, *device_nonlocal_vals_sparsity = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_sparsity, &device_local_i_sparsity, &device_local_j_sparsity, &device_local_vals_sparsity, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_sparsity, &device_nonlocal_i_sparsity, &device_nonlocal_j_sparsity, &device_nonlocal_vals_sparsity, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_sparsity, &device_local_i_sparsity, &device_local_j_sparsity, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_sparsity, &device_nonlocal_i_sparsity, &device_nonlocal_j_sparsity, NULL, &mtype));
 
-   // Z output local + nonlocal
+   // Z output local + nonlocal - every entry is overwritten by the solve below
    const PetscInt *device_local_i_z = nullptr, *device_local_j_z = nullptr;
    const PetscInt *device_nonlocal_i_z = nullptr, *device_nonlocal_j_z = nullptr;
-   PetscScalar *device_local_vals_z = nullptr, *device_nonlocal_vals_z = nullptr;
-   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_z, &device_local_i_z, &device_local_j_z, &device_local_vals_z, &mtype));
-   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_z, &device_nonlocal_i_z, &device_nonlocal_j_z, &device_nonlocal_vals_z, &mtype));
+   PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local_z, &device_local_i_z, &device_local_j_z, NULL, &mtype));
+   if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal_z, &device_nonlocal_i_z, &device_nonlocal_j_z, NULL, &mtype));
+   Kokkos::View<PetscScalar *> device_local_vals_z;
+   Kokkos::View<PetscScalar *> device_nonlocal_vals_z;
+   PetscCallVoid(MatSeqAIJGetKokkosViewWrite(mat_local_z, &device_local_vals_z));
+   if (mpi) PetscCallVoid(MatSeqAIJGetKokkosViewWrite(mat_nonlocal_z, &device_nonlocal_vals_z));
 
    // ~~~~~~~~~~~~~~
    // Find per-row j_size = local_nnz + nonlocal_nnz and split into:
@@ -394,7 +403,7 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
       Kokkos::parallel_for(Kokkos::TeamThreadRange(member, ncols_local_cf),
          [&](const PetscInt k) {
             PetscInt col_local = device_local_j_cf[device_local_i_cf[i] + k];
-            PetscScalar val = device_local_vals_cf[device_local_i_cf[i] + k];
+            PetscScalar val = device_local_vals_cf(device_local_i_cf[i] + k);
             PetscInt global_col = col_local + global_row_start_ff;
             PetscInt pos = binary_search_sorted(j_global, j_size, global_col);
             if (pos >= 0) rhs(pos) = -val;
@@ -404,7 +413,7 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
          Kokkos::parallel_for(Kokkos::TeamThreadRange(member, ncols_nonlocal_cf),
             [&](const PetscInt k) {
                PetscInt col_nonlocal = device_nonlocal_j_cf[device_nonlocal_i_cf[i] + k];
-               PetscScalar val = device_nonlocal_vals_cf[device_nonlocal_i_cf[i] + k];
+               PetscScalar val = device_nonlocal_vals_cf(device_nonlocal_i_cf[i] + k);
                PetscInt global_col = colmap_cf_d(col_nonlocal);
                PetscInt pos = binary_search_sorted(j_global, j_size, global_col);
                if (pos >= 0) rhs(pos) = -val;
@@ -432,7 +441,7 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
                for (PetscInt k = 0; k < ncols; k++) {
                   PetscInt global_col = device_local_j_ff[device_local_i_ff[local_row] + k]
                                         + global_row_start_ff;
-                  PetscScalar val = device_local_vals_ff[device_local_i_ff[local_row] + k];
+                  PetscScalar val = device_local_vals_ff(device_local_i_ff[local_row] + k);
                   PetscInt pos = binary_search_sorted(j_global, j_size, global_col);
                   if (pos >= 0) dense_mat(pos, j) = val;
                }
@@ -443,8 +452,8 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
                   for (PetscInt k = 0; k < ncols_nl; k++) {
                      PetscInt col_nonlocal = device_nonlocal_j_ff[
                         device_nonlocal_i_ff[local_row] + k];
-                     PetscScalar val = device_nonlocal_vals_ff[
-                        device_nonlocal_i_ff[local_row] + k];
+                     PetscScalar val = device_nonlocal_vals_ff(
+                        device_nonlocal_i_ff[local_row] + k);
                      PetscInt global_col = colmap_ff_d(col_nonlocal);
                      PetscInt pos = binary_search_sorted(j_global, j_size, global_col);
                      if (pos >= 0) dense_mat(pos, j) = val;
@@ -460,8 +469,8 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
                for (PetscInt k = 0; k < ncols_sub; k++) {
                   PetscInt submat_col = device_submat_j[
                      device_submat_i[submat_row] + k];
-                  PetscScalar val = device_submat_vals[
-                     device_submat_i[submat_row] + k];
+                  PetscScalar val = device_submat_vals(
+                     device_submat_i[submat_row] + k);
                   PetscInt global_col = col_indices_off_proc_d(submat_col);
                   PetscInt pos = binary_search_sorted(j_global, j_size, global_col);
                   if (pos >= 0) dense_mat(pos, j) = val;
@@ -491,10 +500,10 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
          [&](const PetscInt k) {
             PetscInt orig_pos = j_perm(k);
             if (orig_pos < ncols_local_sparsity)
-               device_local_vals_z[device_local_i_z[i] + orig_pos] = sol(k);
+               device_local_vals_z(device_local_i_z[i] + orig_pos) = sol(k);
             else if (mpi)
-               device_nonlocal_vals_z[device_nonlocal_i_z[i]
-                  + (orig_pos - ncols_local_sparsity)] = sol(k);
+               device_nonlocal_vals_z(device_nonlocal_i_z[i]
+                  + (orig_pos - ncols_local_sparsity)) = sol(k);
          });
    });
 
@@ -609,7 +618,7 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
                   for (PetscInt k = 0; k < ncols; k++) {
                      PetscInt global_col = device_local_j_ff[device_local_i_ff[local_row] + k]
                                            + global_row_start_ff;
-                     PetscScalar val = device_local_vals_ff[device_local_i_ff[local_row] + k];
+                     PetscScalar val = device_local_vals_ff(device_local_i_ff[local_row] + k);
                      PetscInt pos = binary_search_sorted(j_global, j_size, global_col);
                      if (pos >= 0) dense_mat(pos, j) = val;
                   }
@@ -619,8 +628,8 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
                      for (PetscInt k = 0; k < ncols_nl; k++) {
                         PetscInt col_nonlocal = device_nonlocal_j_ff[
                            device_nonlocal_i_ff[local_row] + k];
-                        PetscScalar val = device_nonlocal_vals_ff[
-                           device_nonlocal_i_ff[local_row] + k];
+                        PetscScalar val = device_nonlocal_vals_ff(
+                           device_nonlocal_i_ff[local_row] + k);
                         PetscInt global_col = colmap_ff_d(col_nonlocal);
                         PetscInt pos = binary_search_sorted(j_global, j_size, global_col);
                         if (pos >= 0) dense_mat(pos, j) = val;
@@ -702,35 +711,27 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
             [&](const PetscInt k) {
                PetscInt orig_pos = j_perm(k);
                if (orig_pos < ncols_local_sparsity)
-                  device_local_vals_z[device_local_i_z[i] + orig_pos] = sol(k);
+                  device_local_vals_z(device_local_i_z[i] + orig_pos) = sol(k);
                else if (mpi)
-                  device_nonlocal_vals_z[device_nonlocal_i_z[i]
-                     + (orig_pos - ncols_local_sparsity)] = sol(k);
+                  device_nonlocal_vals_z(device_nonlocal_i_z[i]
+                     + (orig_pos - ncols_local_sparsity)) = sol(k);
             });
       });
    }
 
-   // ~~~~~~~~~~~~~~
-   // Mark Z's device data as modified
-   // ~~~~~~~~~~~~~~
-   Mat_SeqAIJKokkos *aijkok_local_z = static_cast<Mat_SeqAIJKokkos *>(mat_local_z->spptr);
-   Mat_SeqAIJKokkos *aijkok_nonlocal_z = NULL;
-   if (mpi) aijkok_nonlocal_z = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_z->spptr);
-
    Kokkos::fence();
 
-   // Have to specify we've modified data on the device
-   aijkok_local_z->a_dual.clear_sync_state();
-   aijkok_local_z->a_dual.modify_device();
-   aijkok_local_z->transpose_updated = PETSC_FALSE;
-   aijkok_local_z->hermitian_updated = PETSC_FALSE;
-   if (mpi)
-   {
-      aijkok_nonlocal_z->a_dual.clear_sync_state();
-      aijkok_nonlocal_z->a_dual.modify_device();
-      aijkok_nonlocal_z->transpose_updated = PETSC_FALSE;
-      aijkok_nonlocal_z->hermitian_updated = PETSC_FALSE;
-   }
+   // Restore the read-only input views
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(submatrices[0], &device_submat_vals));
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local_ff, &device_local_vals_ff));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal_ff, &device_nonlocal_vals_ff));
+   PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_local_cf, &device_local_vals_cf));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosView(mat_nonlocal_cf, &device_nonlocal_vals_cf));
+
+   // The matching restore handles MatSeqAIJKokkosModifyDevice (clears sync state,
+   // marks device modified, invalidates transpose/hermitian, bumps object state).
+   PetscCallVoid(MatSeqAIJRestoreKokkosViewWrite(mat_local_z, &device_local_vals_z));
+   if (mpi) PetscCallVoid(MatSeqAIJRestoreKokkosViewWrite(mat_nonlocal_z, &device_nonlocal_vals_z));
 
    // ~~~~~~~~~~~~~~
    // Cleanup


### PR DESCRIPTION
PFLARE no longer depends on the PETSc vendored source (private headers such as mpiaij.h / aij.h / aijkok.hpp / veckokkosimpl.hpp), so it can be built against a normal PETSc install. This switches to public PETSc APIs:

- MatSeqAIJGetKokkosView and related, instead of Mat_SeqAIJKokkos
- MatGetMultPetscSF to obtain the matrix's mult SF (the mvctx), instead of reading Mat_MPIAIJ::Mvctx/lvec directly; the returned SF is borrowed and owned by the matrix so it must not be destroyed, and each consumer recreates the cheap leaf Vec locally where needed
- MatAXPY without KokkosSparse::spadd
- deep copy for initialising matrix values

Build instructions and CI updated (the CI now also does a petsc prefix build to verify no vendoring).