### PR TITLE
Update after MPIUNI changes in petsc main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# Compiled Fortran/C objects and module files
+*.o
+*.mod
+
+# Build output
+lib/
+
+# Python bytecode
+__pycache__/
+*.pyc
+
+# Editor/IDE
+.vscode/
+
+# Run artifacts
+tools/slurm-*.out
+tests/solution.vts
+
+# Compiled test executables (add new ones here as tests are added)
+tests/adv_1d
+tests/adv_1dk
+tests/adv_dg_upwind
+tests/adv_diff_2d
+tests/adv_diff_cg_supg
+tests/adv_diff_fd
+tests/ex12f
+tests/ex12f_gmres_poly
+tests/ex6
+tests/ex6_cf_splitting
+tests/ex6_getcoeffs
+tests/ex6_two_airg
+tests/ex6f
+tests/ex6f_getcoeffs
+tests/ex6f_pcmatapply
+tests/ex6f_reuse_amount
+tests/ilu_factors
+tests/ilu_factors_kokkos
+tests/mat_diag
+tests/matrandom
+tests/matrandom_check_reset

--- a/src/Approx_Inverse_Setup.F90
+++ b/src/Approx_Inverse_Setup.F90
@@ -367,19 +367,15 @@ module approx_inverse_setup
             ! Some of the ranks on MPI_COMM_MATRIX will already have the coefficients, but I'm not going 
             ! to bother creating an intercommunicator to send the coefficients from any rank on the comm of buffers%matrix
             ! to the comm of ranks which aren't in MPI_COMM_MATRIX but are in buffers%matrix
-#if !defined(PETSC_HAVE_MPIUNI)
-            call MPI_IBcast(coefficients, size(coefficients, 1), MPIU_REAL, 0, &
+            call MPI_Ibcast(coefficients, size(coefficients, 1), MPIU_REAL, 0, &
                      MPI_COMM_MATRIX, buffers%request, errorcode)
-#endif
 
          ! Gmres polynomial with Newton basis - Can only use matrix-free
          else if (inverse_type == PFLAREINV_NEWTON .OR. inverse_type == PFLAREINV_NEWTON_NO_EXTRA) then
 
             ! Have to broadcast the 2D real and imaginary roots
-#if !defined(PETSC_HAVE_MPIUNI)
-            call MPI_IBcast(coefficients, size(coefficients, 1) * size(coefficients, 2), MPIU_REAL, 0, &
+            call MPI_Ibcast(coefficients, size(coefficients, 1) * size(coefficients, 2), MPIU_REAL, 0, &
                      MPI_COMM_MATRIX, buffers%request, errorcode)
-#endif
          end if
       end if  
 

--- a/src/PMISR_Module.F90
+++ b/src/PMISR_Module.F90
@@ -590,12 +590,9 @@ module pmisr_module
             ! After this comms finishes any local node in another processors halo 
             ! that has been assigned on another process will be correctly marked in assigned_local
             ! ~~~~~~~~~~~    
-#if !defined(PETSC_HAVE_MPIUNI)
             ! MPIUNI's Fortran headers do not provide MPI_LOR; this branch only
             ! runs when comm_size /= 1, i.e. never in a serial MPIUNI build
             call PetscSFReduceBegin(sf, MPI_C_BOOL, assigned_nonlocal, assigned_local, MPI_LOR, ierr)
-#endif
-
          end if
 
          ! ~~~~~~~~~~~~~~
@@ -619,9 +616,7 @@ module pmisr_module
          ! ~~~~~~~~~
          if (comm_size /= 1) then
             ! Finishes the reduce LOR, assigned_local will now be correct
-#if !defined(PETSC_HAVE_MPIUNI)
             call PetscSFReduceEnd(sf, MPI_C_BOOL, assigned_nonlocal, assigned_local, MPI_LOR, ierr)
-#endif
          end if
 
          ! ~~~~~~~~~~~~
@@ -1055,11 +1050,9 @@ module pmisr_module
             ! After this, veto_local(i) is TRUE if any non-local transpose neighbour
             ! vetoes local node i
             ! ~~~~~~~~
-#if !defined(PETSC_HAVE_MPIUNI)
             call PetscSFReduceBegin(sf, MPI_C_BOOL, veto_nonlocal, veto_local, MPI_LOR, ierr)
             ! Not sure we have any chance to overlap this with anything else
             call PetscSFReduceEnd(sf, MPI_C_BOOL, veto_nonlocal, veto_local, MPI_LOR, ierr)
-#endif
 
             ! ~~~~~~~~
             ! Now the comms have finished, we know exactly which local nodes on this rank have no
@@ -1166,10 +1159,8 @@ module pmisr_module
             ! After this comms finishes any local node in another processors halo
             ! that has been assigned on another process will be correctly marked in assigned_local
             ! ~~~~~~~~~~~
-#if !defined(PETSC_HAVE_MPIUNI)
             call PetscSFReduceBegin(sf, MPI_C_BOOL, veto_nonlocal, assigned_local, MPI_LOR, ierr)
             call PetscSFReduceEnd(sf, MPI_C_BOOL, veto_nonlocal, assigned_local, MPI_LOR, ierr)
-#endif
 
             ! ~~~~~~~~~~~~~~
             ! 3. Non-local influences: we need to know which nonlocal nodes were just

--- a/src/TSQR.F90
+++ b/src/TSQR.F90
@@ -42,9 +42,7 @@ module tsqr
       ! Creates our custom reduction
 
       ! ~~~~~~
-#if !defined(PETSC_HAVE_MPIUNI)
       integer :: errorcode
-#endif
       ! ~~~~~~
 
       ! Point at the custom reduction function
@@ -56,9 +54,7 @@ module tsqr
          ! the coefficients on different cores which is not acceptable
          ! MPIUNI does not provide a Fortran MPI_Op_create; the custom reduction is only
          ! ever used in the parallel (comm_size/=1) path in start_tsqr, so skip it in serial
-#if !defined(PETSC_HAVE_MPIUNI)
          call MPI_Op_create(custom_reduction_tsqr, .FALSE., reduction_op_tsqr, errorcode)
-#endif
          built_custom_op_tsqr = .true.
       end if
       
@@ -248,14 +244,13 @@ module tsqr
       ! ~~~~~~~~~~~
       ! MPIUNI provides no Fortran MPI_IAllreduce and comm_size is always 1 in serial,
       ! so this non-blocking reduction only exists for the parallel (real MPI) build
-#if !defined(PETSC_HAVE_MPIUNI)
       if (comm_size/=1) then
 
          ! Only need a single all reduce, this is the only comms outside of the
          ! matvecs above
          buffers%request = MPI_REQUEST_NULL
          ! This is now a non-blocking allreduce, you have to finish this where needed
-         call MPI_IAllreduce(buffers%R_buffer_send, buffers%R_buffer_receive, &
+         call MPI_Iallreduce(buffers%R_buffer_send, buffers%R_buffer_receive, &
                   n_size * n_size + 1, MPIU_REAL, &
                   reduction_op_tsqr, MPI_COMM_MATRIX, buffers%request, errorcode)
          if (errorcode /= MPI_SUCCESS) then
@@ -271,7 +266,6 @@ module tsqr
          ! ~~~~~
 
       end if
-#endif
       
    end subroutine start_tsqr   
 


### PR DESCRIPTION
## Summary
- Use standard-case `MPI_Iallreduce` / `MPI_Ibcast` so MPIUNI's case-sensitive Fortran preprocessor macros rewrite them to the `petsc_mpi_*` stubs; the previous `MPI_IAllreduce` / `MPI_IBcast` spelling only linked against real MPI.
- Drop the now-unnecessary `PETSC_HAVE_MPIUNI` guards around these calls.
- Add a `.gitignore` for build artifacts (objects, module files, `lib/`, test executables, Python bytecode, editor config, run outputs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)