### PR TITLE
Replace C mat_mat_symbolic_c shim with pure Fortran mat_mat_symbolic

### DIFF
--- a/src/AIR_Operators_Setup.F90
+++ b/src/AIR_Operators_Setup.F90
@@ -17,13 +17,12 @@ module air_operators_setup
          PFLARE_MINUS_ONE, PFLARE_PTAP_FILL
    use timers, only: timer_start, timer_finish
    use air_data_type, only: air_multigrid_data, REUSE_MAT_ACTIVE, REUSE_IS_ACTIVE
-   use c_petsc_interfaces, only: mat_mat_symbolic_c
    use grid_transfer, only: generate_one_point_with_one_entry_from_sparse, &
          compute_P_from_W, compute_R_from_Z
    use grid_transfer_improve, only: improve_w, improve_z
    use sai_z, only: calculate_and_build_sai_z
    use petsc_helper, only: MatCreateSubMatrixWrapper, remove_small_from_sparse, &
-         remove_from_sparse_match
+         remove_from_sparse_match, mat_mat_symbolic
 
 #include "petsc/finclude/petscksp.h"
 
@@ -315,7 +314,7 @@ module air_operators_setup
       type(tVec), dimension(:), allocatable   :: left_null_vecs_f, right_null_vecs_f
       integer :: comm_size, errorcode, order, i_loc
       MPIU_Comm :: MPI_COMM_MATRIX
-      integer(c_long_long) :: A_array, B_array, C_array
+      type(tMat) :: C_mat
       PetscInt :: global_row_start, global_row_end_plus_one
       PetscInt, parameter :: nz_ignore = -1
       logical :: destroy_mat, reuse_grid_transfer
@@ -762,24 +761,20 @@ module air_operators_setup
                do order = 3, air_data%options%lair_distance
                   
                   ! Call a symbolic mult as we don't need the values, just the resulting sparsity  
-                  A_array = air_data%reuse(our_level)%reuse_mat(MAT_AFF_DROP)%v
-                  B_array = A_ff_power%v
-                  call mat_mat_symbolic_c(A_array, B_array, C_array)
+                  call mat_mat_symbolic(air_data%reuse(our_level)%reuse_mat(MAT_AFF_DROP), A_ff_power, C_mat)
                   ! Don't delete the original power - ie A_ff
                   if (destroy_mat) call MatDestroy(A_ff_power, ierr)
-                  A_ff_power%v = C_array  
+                  A_ff_power = C_mat
                   destroy_mat = .TRUE.
       
                end do
       
                ! Call a symbolic mult as we don't need the values, just the resulting sparsity  
                ! A_cf * A_ff^(distance - 1)
-               A_array = air_data%reuse(our_level)%reuse_mat(MAT_ACF_DROP)%v
-               B_array = A_ff_power%v
-               call mat_mat_symbolic_c(A_array, B_array, C_array)
+               call mat_mat_symbolic(air_data%reuse(our_level)%reuse_mat(MAT_ACF_DROP), A_ff_power, C_mat)
                if (destroy_mat) call MatDestroy(A_ff_power, ierr)
 
-               sparsity_mat_cf%v = C_array    
+               sparsity_mat_cf = C_mat
 
             end if
          end if

--- a/src/C_PETSc_Interfaces.F90
+++ b/src/C_PETSc_Interfaces.F90
@@ -18,18 +18,6 @@ module c_petsc_interfaces
 
    interface
 
-      subroutine mat_mat_symbolic_c(A_array, B_array, C_array) &
-         bind(c, name="mat_mat_symbolic_c")
-         use iso_c_binding
-         integer(c_long_long) :: A_array
-         integer(c_long_long) :: B_array
-         integer(c_long_long) :: C_array
-      end subroutine mat_mat_symbolic_c
-
-   end interface
-
-   interface
-      
       subroutine GenerateIS_ProcAgglomeration_c(proc_stride, global_size, local_size_reduced, start) &
          bind(c, name="GenerateIS_ProcAgglomeration_c")
          use iso_c_binding

--- a/src/C_PETSc_Routines.c
+++ b/src/C_PETSc_Routines.c
@@ -219,53 +219,6 @@ PETSC_INTERN void GenerateIS_ProcAgglomeration_c(PetscInt proc_stride, PetscInt 
    return;
 }
 
-// Computes a symbolic mat mat mult - the fortran interface doesn't have
-// MATPRODUCT_AB or MatProductSetFromOptions set
-PETSC_INTERN void mat_mat_symbolic_c(Mat *A, Mat *B, Mat *result)
-{
-   MPI_Comm comm;
-   int comm_size;
-   MatType mat_type_a, mat_type_b;
-
-   // Get the comm
-   PetscCallVoid(PetscObjectGetComm((PetscObject)*A, &comm));
-   PetscCallMPIAbort(comm, MPI_Comm_size(comm, &comm_size));
-
-   PetscCallVoid(MatGetType(*A, &mat_type_a));
-   PetscCallVoid(MatGetType(*B, &mat_type_b));
-
-   if (strcmp(mat_type_a, MATDIAGONAL) == 0)
-   {
-      PetscCallVoid(MatDuplicate(*B, MAT_DO_NOT_COPY_VALUES, result));
-   }
-   else if (strcmp(mat_type_b, MATDIAGONAL) == 0)
-   {  
-      PetscCallVoid(MatDuplicate(*A, MAT_DO_NOT_COPY_VALUES, result));
-   }
-   else
-   {
-      // For some reason in serial matduplicate is not defined on unassembled matrices
-      // ie we call a matduplicate on the symbolic sparsity_mat returned from this
-      // So we just do an ordinary matmatmult in serial
-      if (comm_size == 1) 
-      {
-         PetscCallVoid(MatMatMult(*A, *B, MAT_INITIAL_MATRIX, 1.0, result));
-      }
-      else
-      {
-         PetscCallVoid(MatProductCreate(*A, *B, NULL, result));
-         PetscCallVoid(MatProductSetType(*result, MATPRODUCT_AB));
-         PetscCallVoid(MatProductSetAlgorithm(*result, "default"));
-         PetscCallVoid(MatProductSetFill(*result, PETSC_DEFAULT));
-         PetscCallVoid(MatProductSetFromOptions(*result));
-         PetscCallVoid(MatProductSymbolic(*result));
-         PetscCallVoid(MatProductClear(*result));
-      }
-   }
-
-   return;
-}
-
 // Takes a Mat and returns a Mat on a subcomm without ranks with no rows
 // If there are no empty ranks, then it returns the same matrix
 // If not there is a new copy that must be destroyed

--- a/src/PETSc_Helper.F90
+++ b/src/PETSc_Helper.F90
@@ -1633,5 +1633,49 @@ logical, protected :: kokkos_debug_global = .FALSE.
 
    !-------------------------------------------------------------------------------------------------------------------------------
 
+   ! Computes the symbolic sparsity of A*B (values not needed).
+   ! Replaces the old C shim mat_mat_symbolic_c now that the PETSc
+   ! Fortran MatProduct interface (incl. MATPRODUCT_AB) exists.
+   subroutine mat_mat_symbolic(A, B, C)
+
+      type(tMat), intent(in)  :: A, B
+      type(tMat), intent(out) :: C
+
+      MatType :: mat_type_a, mat_type_b
+      MPIU_Comm :: MPI_COMM_MATRIX
+      integer :: comm_size, errorcode
+      PetscErrorCode :: ierr
+
+      ! ~~~~~~~~~~
+
+      call PetscObjectGetComm(A, MPI_COMM_MATRIX, ierr)
+      call MPI_Comm_size(MPI_COMM_MATRIX, comm_size, errorcode)
+
+      call MatGetType(A, mat_type_a, ierr)
+      call MatGetType(B, mat_type_b, ierr)
+
+      if (mat_type_a == MATDIAGONAL) then
+         call MatDuplicate(B, MAT_DO_NOT_COPY_VALUES, C, ierr)
+      else if (mat_type_b == MATDIAGONAL) then
+         call MatDuplicate(A, MAT_DO_NOT_COPY_VALUES, C, ierr)
+      else if (comm_size == 1) then
+         ! For some reason in serial matduplicate is not defined on unassembled matrices
+         ! ie we call a matduplicate on the symbolic sparsity_mat returned from this
+         ! So we just do an ordinary matmatmult in serial
+         call MatMatMult(A, B, MAT_INITIAL_MATRIX, PETSC_DEFAULT_REAL, C, ierr)
+      else
+         call MatProductCreate(A, B, PETSC_NULL_MAT, C, ierr)
+         call MatProductSetType(C, MATPRODUCT_AB, ierr)
+         call MatProductSetAlgorithm(C, 'default', ierr)
+         call MatProductSetFill(C, PETSC_DEFAULT_REAL, ierr)
+         call MatProductSetFromOptions(C, ierr)
+         call MatProductSymbolic(C, ierr)
+         call MatProductClear(C, ierr)
+      end if
+
+   end subroutine mat_mat_symbolic
+
+   !-------------------------------------------------------------------------------------------------------------------------------
+
 end module petsc_helper
 

--- a/src/SAI_Z.F90
+++ b/src/SAI_Z.F90
@@ -5,8 +5,9 @@ module sai_z
    use binary_tree, only: itree, itree2vector, flush_tree
    use sorting, only: create_knuth_shuffle_tree_array, intersect_pre_sorted_indices_only, &
          merge_pre_sorted, sorted_binary_search
-   use c_petsc_interfaces, only: mat_mat_symbolic_c, calculate_and_build_sai_z_kokkos
-   use petsc_helper, only: generate_identity, kokkos_debug, destroy_matrix_reuse, MatAXPYWrapper
+   use c_petsc_interfaces, only: calculate_and_build_sai_z_kokkos
+   use petsc_helper, only: generate_identity, kokkos_debug, destroy_matrix_reuse, MatAXPYWrapper, &
+         mat_mat_symbolic
    use pflare_parameters, only: AIR_Z_PRODUCT, AIR_Z_LAIR, AIR_Z_LAIR_SAI, PFLAREINV_SAI, PFLAREINV_ISAI, &
          PFLARE_MINUS_ONE, PFLARE_KSP_RTOL_COARSE, PFLARE_KSP_ATOL_OFF, PFLARE_TOL_MATFREE_4EM11
 
@@ -809,7 +810,7 @@ module sai_z
       integer :: order
       PetscErrorCode :: ierr
       logical :: destroy_mat
-      integer(c_long_long) :: A_array, B_array, C_array
+      type(tMat) :: C_mat
       PetscInt, parameter ::  one=1, zero=0
 
       ! ~~~~~~
@@ -851,17 +852,15 @@ module sai_z
             do order = 2, sparsity_order
                
                ! Call a symbolic mult as we don't need the values, just the resulting sparsity  
-               A_array = matrix%v
-               B_array = A_power%v
-               call mat_mat_symbolic_c(A_array, B_array, C_array)
+               call mat_mat_symbolic(matrix, A_power, C_mat)
                ! Don't delete the original power - ie matrix
                if (destroy_mat) call MatDestroy(A_power, ierr)
-               A_power%v = C_array  
+               A_power = C_mat
                destroy_mat = .TRUE.
 
             end do
 
-            sparsity_mat_cf%v = C_array    
+            sparsity_mat_cf = C_mat
 
          ! Reuse
          else


### PR DESCRIPTION
## Summary

Removes the C `mat_mat_symbolic_c` shim now that PETSc auto-generates the Fortran `MatProduct*` bindings (incl. `MATPRODUCT_AB`), which are present well before PFLARE's 3.25.0 minimum-version floor.

- Adds `mat_mat_symbolic` to the `petsc_helper` module, preserving all three branches exactly:
  - `MATDIAGONAL` inputs → `MatDuplicate` shortcuts
  - serial → ordinary `MatMatMult` (works around serial `MatDuplicate` misbehaving on the unassembled symbolic result — original comment kept verbatim)
  - parallel → `MatProductCreate` → `MATPRODUCT_AB` → `MatProductSymbolic` → `MatProductClear`
- Switches the 3 call sites (`AIR_Operators_Setup.F90` ×2, `SAI_Z.F90` ×1) from the `integer(c_long_long)` pointer-copy pattern to direct `tMat` calls.
- Deletes the C function and its `bind(c)` interface.

Uses `PETSC_DEFAULT_REAL` (the real-typed default-fill constant, already used throughout PFLARE) in place of the C code's `PETSC_DEFAULT`. Fill only affects preallocation estimates, not the resulting sparsity, so behavior is preserved.

## Testing

- `make -j3 build_tests` — clean, no warnings
- `make check` — OK
- `make tests_short` — all serial **and** 2-rank parallel cases pass, covering the lAIR/SAI sparsity-power loops (both the serial `MatMatMult` and parallel `MatProductSymbolic` branches) and `MATDIAGONAL` inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)