### PR TITLE
Kokkos audit: add missing fences after async H2D copies, fix view/index bugs

### DIFF
--- a/include/kokkos_helper.hpp
+++ b/include/kokkos_helper.hpp
@@ -72,16 +72,9 @@ struct ReduceData {
       // Add all the counts
       count += src.count;
       // If we have found a diagonal entry at any point in this row
-      // found_diagonal becomes true      
+      // found_diagonal becomes true
       found_diagonal |= src.found_diagonal;
    }
-
-   // Required for Kokkos reduction
-   KOKKOS_INLINE_FUNCTION
-   static void join(volatile ReduceData& dest, const volatile ReduceData& src) {
-      dest.count = dest.count + src.count;
-      dest.found_diagonal = dest.found_diagonal || src.found_diagonal;
-   }   
 };
 
 namespace Kokkos {
@@ -111,15 +104,6 @@ struct ReduceDataMaxRow {
          col = src.col;
       }
    }
-
-   // Required for Kokkos reduction
-   KOKKOS_INLINE_FUNCTION
-   static void join(volatile ReduceDataMaxRow& dest, const volatile ReduceDataMaxRow& src) {
-      if (src.val > dest.val) {
-         dest.val = src.val;
-         dest.col = src.col;
-      }
-   }   
 };
 
 namespace Kokkos {

--- a/src/Gmres_Poly_Newtonk.kokkos.cxx
+++ b/src/Gmres_Poly_Newtonk.kokkos.cxx
@@ -261,6 +261,8 @@ PETSC_INTERN void mat_mult_powers_share_sparsity_newton_kokkos(Mat *input_mat, M
       // Log copy with petsc
       bytes = input_nonlocal_to_submat_col_h.extent(0) * sizeof(PetscInt);
       PetscCallVoid(PetscLogCpuToGpu(bytes));
+      // Fence after the async copy of the input->submat colmap mapping to the device - the host mirror is freed at scope exit
+      Kokkos::fence();
    }
 
    // ~~~~~~~~~~~~~~
@@ -754,7 +756,7 @@ PETSC_INTERN void mat_mult_powers_share_sparsity_newton_kokkos(Mat *input_mat, M
    // to fortran - to prevent leaking memory we destroy the submatrices pointer ourself, and if we come back
    // into this routine with reuse we just create a new submatrices array
    if (mpi && !reuse_int_reuse_mat) PetscCallVoid(PetscFree(submatrices));
-   (void)PetscFree(col_indices_off_proc_array);
+   PetscCallVoid(PetscFree(col_indices_off_proc_array));
 
    return;
 }

--- a/src/Gmres_Polyk.kokkos.cxx
+++ b/src/Gmres_Polyk.kokkos.cxx
@@ -256,6 +256,8 @@ PETSC_INTERN void mat_mult_powers_share_sparsity_kokkos(Mat *input_mat, const in
       // Log copy with petsc
       bytes = input_nonlocal_to_submat_col_h.extent(0) * sizeof(PetscInt);
       PetscCallVoid(PetscLogCpuToGpu(bytes));
+      // Fence after the async copy of the input->submat colmap mapping to the device - the host mirror is freed at scope exit
+      Kokkos::fence();
    }
 
    // ~~~~~~~~~~~~~~
@@ -587,7 +589,7 @@ PETSC_INTERN void mat_mult_powers_share_sparsity_kokkos(Mat *input_mat, const in
    // to fortran - to prevent leaking memory we destroy the submatrices pointer ourself, and if we come back
    // into this routine with reuse we just create a new submatrices array    
    if (mpi && !reuse_int_reuse_mat) PetscCallVoid(PetscFree(submatrices));
-   (void)PetscFree(col_indices_off_proc_array);
+   PetscCallVoid(PetscFree(col_indices_off_proc_array));
 
    return;
 }

--- a/src/Grid_Transferk.kokkos.cxx
+++ b/src/Grid_Transferk.kokkos.cxx
@@ -747,7 +747,7 @@ PETSC_INTERN void compute_R_from_Z_kokkos(Mat *input_mat, PetscInt global_row_st
    if (mpi)
    {
       PetscCallVoid(MatMPIAIJGetSeqAIJ(*input_mat, &mat_local, &mat_nonlocal, &colmap_input));
-      PetscCallVoid(MatGetSize(mat_nonlocal, &rows_ao, &cols_ao););
+      PetscCallVoid(MatGetSize(mat_nonlocal, &rows_ao, &cols_ao));
 
       // We also copy the input mat colmap over to the device as we need it
       colmap_input_h = PetscIntConstKokkosViewHost(colmap_input, cols_ao);
@@ -822,7 +822,7 @@ PETSC_INTERN void compute_R_from_Z_kokkos(Mat *input_mat, PetscInt global_row_st
 
       // We've now built the original fine indices
       PetscCallVoid(ISDestroy(&col_indices));
-      (void)PetscFree(col_indices_off_proc_array);
+      PetscCallVoid(PetscFree(col_indices_off_proc_array));
    }
    else
    {
@@ -1092,7 +1092,8 @@ PETSC_INTERN void compute_R_from_Z_kokkos(Mat *input_mat, PetscInt global_row_st
 
                // If we're at or after the C point identity, our index into R gets a +1
                // so we skip over writing to that index in R
-               if (device_local_j_output[device_local_i_output[row_index] + j] >= coarse_view_d(i) - global_row_start) offset = 1;
+               // Only applies if the identity was included when the matrix was created
+               if (identity_int && device_local_j_output[device_local_i_output[row_index] + j] >= coarse_view_d(i) - global_row_start) offset = 1;
                device_local_a_output(device_local_i_output[row_index] + j + offset) = device_local_vals(device_local_i[i] + j);
             });
 

--- a/src/MatDiagDomk.kokkos.cxx
+++ b/src/MatDiagDomk.kokkos.cxx
@@ -172,9 +172,10 @@ PETSC_INTERN void MatDiagDomRatio_kokkos(Mat *input_mat, PetscReal *max_dd_ratio
          });
          PetscCallVoid(VecRestoreKokkosView(leaf_vec, &lvec_scalar_d));
       }
+      // Fence after the kernel converting the scattered leaf values to ints - the Vecs backing its views are destroyed next
+      Kokkos::fence();
       PetscCallVoid(VecDestroy(&scatter_root_vec));
       PetscCallVoid(VecDestroy(&leaf_vec));
-      Kokkos::fence();
    }
 
    // ~~~~~~~~~~~~~~~

--- a/src/PETSc_Helperk.kokkos.cxx
+++ b/src/PETSc_Helperk.kokkos.cxx
@@ -734,8 +734,9 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, const PetscRea
                // lump_val contains the diagonal so we overwrite
                if (expect_local_diagonal)
                {
-                  // Has to be the local column index
-                  j_local_d[i_local_d[i+1] - 1] = i;
+                  // Has to be the local column index - the row and column ownership
+                  // starts can differ so we can't just use i
+                  j_local_d[i_local_d[i+1] - 1] = row_index_global - global_col_start;
                   a_local_d[i_local_d[i+1] - 1] = lump_val;
                }
                else
@@ -1205,6 +1206,8 @@ PETSC_INTERN void MatSetAllValues_kokkos(Mat *input_mat, PetscScalar val)
    {
       Kokkos::deep_copy(exec, device_nonlocal_vals, val);
    }
+   // Fence after the async fill of the matrix values - keep the convention of being finished before we exit
+   Kokkos::fence();
 
    // The matching restore handles MatSeqAIJKokkosModifyDevice (clears sync state,
    // marks device modified, invalidates transpose/hermitian, bumps object state).
@@ -2170,7 +2173,7 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos_view(Mat *input_mat, \
       {
          PetscInt isstart = 0;
          /* Get start indices on each rank for the new columns */
-         MPI_Scan(&local_cols_col, &isstart, 1, MPIU_INT, MPI_SUM, MPI_COMM_MATRIX);
+         PetscCallMPIAbort(MPI_COMM_MATRIX, MPI_Scan(&local_cols_col, &isstart, 1, MPIU_INT, MPI_SUM, MPI_COMM_MATRIX));
          isstart -= local_cols_col;
 
          // cmap values are encoded through PetscScalar and then cast back to PetscInt,
@@ -2335,6 +2338,8 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos_view(Mat *input_mat, \
          bytes = iscol_o_view_h.extent(0) * sizeof(PetscInt);
          PetscCallVoid(PetscLogCpuToGpu(bytes));
 
+         // Fence after the async copy of the iscol_o indices to the device - ISRestoreIndices may free the host array
+         Kokkos::fence();
          PetscCallVoid(ISRestoreIndices(iscol_o, &iscol_o_indices_ptr));
       }
 
@@ -2435,10 +2440,12 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos(Mat *input_mat, IS *is_row, IS *is_c
       size_t bytes = is_row_view_h.extent(0) * sizeof(PetscInt);
       PetscCallVoid(PetscLogCpuToGpu(bytes));        
       bytes = is_col_view_h.extent(0) * sizeof(PetscInt);
-      PetscCallVoid(PetscLogCpuToGpu(bytes));  
+      PetscCallVoid(PetscLogCpuToGpu(bytes));
 
-      PetscCallVoid(ISRestoreIndices(*is_row, &is_row_indices_ptr));   
-      PetscCallVoid(ISRestoreIndices(*is_col, &is_col_indices_ptr));   
+      // Fence after the async copies of the is_row/is_col indices to the device - ISRestoreIndices may free the host arrays
+      Kokkos::fence();
+      PetscCallVoid(ISRestoreIndices(*is_row, &is_row_indices_ptr));
+      PetscCallVoid(ISRestoreIndices(*is_col, &is_col_indices_ptr));
 
       // ~~~~~~~~~~~~
       // Rewrite to local indices

--- a/src/PMISR_Modulek.kokkos.cxx
+++ b/src/PMISR_Modulek.kokkos.cxx
@@ -375,6 +375,11 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
          // We've updated the values in cf_markers_nonlocal
          // Calling a reverse scatter add will then update the values of cf_markers_local
          // Reduce with a sum via VecScatter with ADD_VALUES, SCATTER_REVERSE
+         // Note the resulting marker arithmetic (cf_markers_d(i) + sum of neighbour marks)
+         // only stays consistent because the strength matrix passed in is structurally
+         // symmetric (S+S^T) - every neighbour of an in-set node was marked in the round
+         // that node was selected, so an in-set node can never receive marks later
+         // The nonsymmetric case is handled by pmisr_existing_measure_implicit_transpose_kokkos
          // Convert int → PetscScalar for the leaf (nonlocal) data
          {
             PetscScalarKokkosView leaf_scalar_d;

--- a/src/SAI_Zk.kokkos.cxx
+++ b/src/SAI_Zk.kokkos.cxx
@@ -296,14 +296,8 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
       if (sparsity_max_nnz_iter   < 0) sparsity_max_nnz_iter   = 0;
    }
 
-   // Nothing to do if no rows
-   if (local_rows_cf == 0 || (sparsity_max_nnz_direct == 0 && count_iter == 0))
-   {
-      if (deallocate_submatrices) delete[] submatrices;
-      if (mpi && !reuse_int_reuse_mat) PetscCallVoid(PetscFree(submatrices));
-      (void)PetscFree(col_indices_off_proc_array);
-      return;
-   }
+   // If there are no rows to solve, both kernel sections below are skipped by their
+   // j_max > 0 / count_iter > 0 guards and we fall through to the restores/cleanup
 
    // ~~~~~~~~~~~~~~
    // TeamPolicy: one team per row, with per-team scratch memory
@@ -1180,7 +1174,7 @@ PETSC_INTERN void calculate_and_build_sai_z_kokkos(Mat *A_ff, Mat *A_cf, Mat *sp
    // ~~~~~~~~~~~~~~
    if (deallocate_submatrices) delete[] submatrices;
    if (mpi && !reuse_int_reuse_mat) PetscCallVoid(PetscFree(submatrices));
-   (void)PetscFree(col_indices_off_proc_array);
+   PetscCallVoid(PetscFree(col_indices_off_proc_array));
 
    return;
 }

--- a/src/VecISCopyLocalk.kokkos.cxx
+++ b/src/VecISCopyLocalk.kokkos.cxx
@@ -94,6 +94,8 @@ PETSC_INTERN void set_VecISCopyLocal_kokkos_our_level(void *handle, int our_leve
    // Log copy with petsc
    size_t bytes = fine_view_h.extent(0) * sizeof(PetscInt);
    PetscCallVoid(PetscLogCpuToGpu(bytes));
+   // Fence after the async copy of the fine IS indices to the device - ISRestoreIndices may free the host array
+   Kokkos::fence();
    PetscCallVoid(ISRestoreIndices(*index_fine, &fine_indices_ptr));
 
    // Rewrite the indices as local - save us a minus during VecISCopyLocal_kokkos
@@ -113,6 +115,8 @@ PETSC_INTERN void set_VecISCopyLocal_kokkos_our_level(void *handle, int our_leve
    // Log copy with petsc
    bytes = coarse_view_h.extent(0) * sizeof(PetscInt);
    PetscCallVoid(PetscLogCpuToGpu(bytes));
+   // Fence after the async copy of the coarse IS indices to the device - ISRestoreIndices may free the host array
+   Kokkos::fence();
    PetscCallVoid(ISRestoreIndices(*index_coarse, &coarse_indices_ptr));
 
    // Rewrite the indices as local - save us a minus during VecISCopyLocal_kokkos


### PR DESCRIPTION
## Summary

Full review of all Kokkos code (`src/*.kokkos.cxx` + `include/kokkos_helper.hpp`) for bugs, with emphasis on missing fences.

### Missing fences (use-after-free race class)

Async `Kokkos::deep_copy(exec, device, host)` copies were followed by release of the host source buffer — `ISRestoreIndices` (which frees a temp array for stride/block IS types) or scope exit of a managed `create_mirror_view` host mirror — with no fence in between. These pass on CUDA today only because async copies from pageable host memory block the host; they are genuine races on HIP/SYCL or with pinned mirrors. Each new fence carries a single-line comment stating exactly what it fences after:

- `VecISCopyLocalk.kokkos.cxx` — fine and coarse IS index copies vs `ISRestoreIndices`
- `Gmres_Polyk.kokkos.cxx` / `Gmres_Poly_Newtonk.kokkos.cxx` — input→submat colmap mapping vs host mirror freed at scope exit
- `PETSc_Helperk.kokkos.cxx` — `MatCreateSubMatrix_kokkos` is_row/is_col copies and the `MatCreateSubMatrix_kokkos_view` reuse-path iscol_o copy vs `ISRestoreIndices`

### Other fixes

- `SAI_Zk.kokkos.cxx`: the "nothing to do" early return skipped every `MatSeqAIJRestoreKokkosView`/`RestoreKokkosViewWrite`; control now falls through to the shared restore/cleanup epilogue (the existing `j_max > 0` / `count_iter > 0` guards already skip the kernels)
- `PETSc_Helperk.kokkos.cxx` (`remove_small_from_sparse_kokkos`): a lumped diagonal inserted into the local block used local row index `i` as the column; now uses `row_index_global - global_col_start`, correct when row/col ownership starts differ
- `MatDiagDomk.kokkos.cxx`: fence moved before the `VecDestroy` calls whose device buffers the conversion kernel reads
- `Grid_Transferk.kokkos.cxx` (`compute_R_from_Z_kokkos` reuse path): identity-skip offset now guarded by `identity_int`
- `PMISR_Modulek.kokkos.cxx`: documented that the ADD-reverse-scatter marker merge relies on the strength matrix being structurally symmetric (S+S^T)
- `MatSetAllValues_kokkos`: trailing fence added to match the file convention
- Cleanups: `PetscCallVoid(PetscFree(...))` instead of `(void)PetscFree(...)`, `PetscCallMPIAbort` around an unchecked `MPI_Scan`, removed the deprecated `volatile join()` reducer overloads in `kokkos_helper.hpp`, stray semicolon

## Testing

With `make -j3 build_tests` warning-clean, `make check` + `make tests_short` pass:
1. plain
2. `PETSC_OPTIONS="-mat_type aijkokkos -vec_type kokkos -dm_mat_type aijkokkos -dm_vec_type kokkos -on_error_abort"`
3. same + `PFLARE_KOKKOS_DEBUG=1` (CPU/Kokkos debug-compare)

The fence fixes remove latent races that don't reproduce on a CUDA host (pageable-memory async copies block), so the tests validate no regression rather than reproducing the race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)