### PR TITLE
Honour KSPSetReusePreconditioner in PCAIR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ tests/ilu_factors_kokkos
 tests/mat_diag
 tests/matrandom
 tests/matrandom_check_reset
+tests/reuse_preconditioner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ for earlier changes please see the git history.
 
 ## Unreleased
 
+- Fixed PCAIR silently ignoring `KSPSetReusePreconditioner` /
+  `-ksp_reuse_preconditioner`: a values-only change to the pmat between
+  solves rebuilt the full AIR hierarchy despite the flag; a frozen PCAIR
+  now stays frozen (even across sparsity pattern changes, matching PETSc
+  semantics) until the flag is unset (#264)
 - New compatible relaxation CF splitting (`-pc_air_cf_splitting_type cr`),
   which coarsens from scratch with no strength matrix until one application
   of AIR's F-point smoothing contracts a random error on Aff by the target

--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,8 @@ export TEST_TARGETS = ex12f \
 		  mat_diag \
 		  adv_dg_upwind \
 		  ex6_two_airg \
-		  ilu_factors
+		  ilu_factors \
+		  reuse_preconditioner
 # Include kokkos examples
 ifeq ($(PETSC_HAVE_KOKKOS),1)
 export TEST_TARGETS := $(TEST_TARGETS) adv_1dk

--- a/src/PCAIR.c
+++ b/src/PCAIR.c
@@ -152,6 +152,14 @@ static PetscErrorCode PCApply_AIR_c(PC pc, Vec x, Vec y)
    PetscFunctionBegin;
    PC *pc_air_shell = (PC *)pc->data;
 
+   // The shell tracks the pmat state itself, so it must also see the
+   // reusepreconditioner flag: when it is set the outer PCSetUp is skipped
+   // entirely, but the PCApply below calls PCSetUp on the shell, which would
+   // otherwise rebuild the hierarchy after any change to the pmat
+   // This mirrors petsc semantics: once set up, a frozen pc stays frozen
+   // even if the sparsity pattern changes
+   PetscCall(PCSetReusePreconditioner(*pc_air_shell, pc->reusepreconditioner));
+
    // Just call the underlying pcshell apply
    PetscCall(PCApply(*pc_air_shell, x, y));
    PetscFunctionReturn(PETSC_SUCCESS);
@@ -176,10 +184,15 @@ static PetscErrorCode PCSetUp_AIR_c(PC pc)
    PetscFunctionBegin;
    PC *pc_air_shell = (PC *)pc->data;
 
-   // The pc_air_shell doesn't have any operators yet 
+   // The pc_air_shell doesn't have any operators yet
    // as they are not available yet in pccreate
    // so we have to set them
    PetscCall(PCSetOperators(*pc_air_shell, pc->mat, pc->pmat));
+
+   // Keep the shell's reusepreconditioner flag in sync - if the flag has
+   // been unset after a frozen solve the shell must be allowed
+   // to rebuild again
+   PetscCall(PCSetReusePreconditioner(*pc_air_shell, pc->reusepreconditioner));
 
    // Now we should be able to call the pcshell setup
    // that builds the air hierarchy

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -290,7 +290,11 @@ run_tests_no_load_short_serial:
 	./matrandom_check_reset -ksp_max_it 7
 	@echo "Test PCPFLAREINV with parameter resets on random diagonally dominant matrix"
 	./matrandom_check_reset -ksp_max_it 12 -check_airg 0
-#	
+#
+	@echo ""
+	@echo "Test PCAIR honours KSPSetReusePreconditioner when the pmat values change in place"
+	./reuse_preconditioner
+#
 	@echo ""
 	@echo "Test AIRG with advection and fc smoothing"
 	./adv_diff_fd -da_grid_x 8 -da_grid_y 8 -pc_type air -ksp_max_it 3 -pc_air_smooth_type fc
@@ -734,8 +738,12 @@ else
 	$(MPIEXEC) -n 2 ./ex6f_reuse_amount -m 10 -n 10 -pc_type air -pc_air_inverse_type arnoldi -ksp_max_it 5
 	$(MPIEXEC) -n 2 ./ex6f_reuse_amount -m 10 -n 10 -pc_type air -pc_air_inverse_type newton -ksp_max_it 5
 	@echo "Test PCAIR reuse_amount (1=CF splitting only, 2=+SpGEMMs, 3=everything) in Fortran with diagonal Aff"
-	$(MPIEXEC) -n 2 ./ex6f_reuse_amount -m 10 -n 10 -pc_type air -pc_air_strong_threshold 0.0 -ksp_max_it 5	
-#	
+	$(MPIEXEC) -n 2 ./ex6f_reuse_amount -m 10 -n 10 -pc_type air -pc_air_strong_threshold 0.0 -ksp_max_it 5
+#
+	@echo ""
+	@echo "Test PCAIR honours KSPSetReusePreconditioner when the pmat values change in place in parallel"
+	$(MPIEXEC) -n 2 ./reuse_preconditioner
+#
 	@echo ""
 	@echo "Test AIRG with advection and fc smoothing in parallel"
 	$(MPIEXEC) -n 2 ./adv_diff_fd -da_grid_x 8 -da_grid_y 8 -pc_type air -ksp_max_it 3 -pc_air_smooth_type fc

--- a/tests/ex6f.F90
+++ b/tests/ex6f.F90
@@ -218,8 +218,12 @@
 ! Set operators, keeping the identical preconditioner matrix for
 ! all linear solves.  This approach is often effective when the
 ! linear systems do not change very much between successive steps.
+! Note we do not need KSPSetReusePreconditioner here: A2 is a copy
+! that is never modified after step 1, and petsc only triggers a PC
+! re-setup off the pmat's object state, so the preconditioner is
+! naturally reused. See reuse_preconditioner.c for a test of
+! KSPSetReusePreconditioner with a pmat whose values change in place.
       if (.NOT. regen) then
-         call KSPSetReusePreconditioner(ksp,PETSC_TRUE,ierr)
          call KSPSetOperators(ksp,A,A2,ierr)
       else
          ! Otherwise this should trigger same_nonzero_pattern

--- a/tests/reuse_preconditioner.c
+++ b/tests/reuse_preconditioner.c
@@ -1,0 +1,112 @@
+static char help[] = "Tests KSPSetReusePreconditioner with PCAIR freezes the hierarchy \n\
+when the values of the same pmat object change between solves.\n\n";
+
+#include <petscksp.h>
+#include "pflare.h"
+
+int main(int argc, char **args)
+{
+  Mat       A;
+  Vec       x, b;
+  KSP       ksp;
+  PC        pc;
+  PetscInt  n = 1000, Istart, Iend, i;
+  PetscInt  its_first, its_frozen, its_rebuilt;
+  PetscReal shift = 10.0;
+  PetscReal gc_first, cc_first, gc_frozen, cc_frozen, gc_rebuilt, cc_rebuilt;
+
+  PetscCall(PetscInitialize(&argc, &args, (char *)0, help));
+
+  // Register the pflare types
+  PCRegister_PFLARE();
+
+  PetscCall(PetscOptionsGetInt(NULL, NULL, "-n", &n, NULL));
+  PetscCall(PetscOptionsGetReal(NULL, NULL, "-shift", &shift, NULL));
+
+  // Nonsymmetric 1D advection-diffusion tridiagonal matrix
+  PetscCall(MatCreate(PETSC_COMM_WORLD, &A));
+  PetscCall(MatSetSizes(A, PETSC_DECIDE, PETSC_DECIDE, n, n));
+  PetscCall(MatSetFromOptions(A));
+  PetscCall(MatSeqAIJSetPreallocation(A, 3, NULL));
+  PetscCall(MatMPIAIJSetPreallocation(A, 3, NULL, 2, NULL));
+  PetscCall(MatGetOwnershipRange(A, &Istart, &Iend));
+  for (i = Istart; i < Iend; i++) {
+    PetscScalar v[3]    = {-1.5, 3.0, -0.5};
+    PetscInt    cols[3] = {i - 1, i, i + 1};
+    if (i == 0) PetscCall(MatSetValues(A, 1, &i, 2, &cols[1], &v[1], INSERT_VALUES));
+    else if (i == n - 1) PetscCall(MatSetValues(A, 1, &i, 2, cols, v, INSERT_VALUES));
+    else PetscCall(MatSetValues(A, 1, &i, 3, cols, v, INSERT_VALUES));
+  }
+  PetscCall(MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY));
+  PetscCall(MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY));
+
+  PetscCall(MatCreateVecs(A, &x, &b));
+  PetscCall(VecSet(b, 1.0));
+
+  PetscCall(KSPCreate(PETSC_COMM_WORLD, &ksp));
+  // A is both the amat and the pmat
+  PetscCall(KSPSetOperators(ksp, A, A));
+  PetscCall(KSPGetPC(ksp, &pc));
+  PetscCall(PCSetType(pc, PCAIR));
+  PetscCall(KSPSetFromOptions(ksp));
+
+  // ~~~~~~~~~~~~~~~~~~
+  // First solve - builds the hierarchy
+  // ~~~~~~~~~~~~~~~~~~
+  PetscCall(KSPSolve(ksp, b, x));
+  PetscCall(KSPGetIterationNumber(ksp, &its_first));
+  PetscCall(PCAIRGetGridComplexity(pc, &gc_first));
+  PetscCall(PCAIRGetCycleComplexity(pc, &cc_first));
+
+  // ~~~~~~~~~~~~~~~~~~
+  // Freeze the preconditioner, then change the values of the
+  // same pmat object (sparsity pattern unchanged) and solve again
+  // No new hierarchy should be built
+  // ~~~~~~~~~~~~~~~~~~
+  PetscCall(KSPSetReusePreconditioner(ksp, PETSC_TRUE));
+  PetscCall(MatShift(A, shift));
+  PetscCall(VecSet(x, 0.0));
+  PetscCall(KSPSolve(ksp, b, x));
+  PetscCall(KSPGetIterationNumber(ksp, &its_frozen));
+  PetscCall(PCAIRGetGridComplexity(pc, &gc_frozen));
+  PetscCall(PCAIRGetCycleComplexity(pc, &cc_frozen));
+
+  // The frozen hierarchy must be untouched, so the complexities are
+  // bit-identical to the first solve
+  PetscCheck(gc_frozen == gc_first && cc_frozen == cc_first, PETSC_COMM_WORLD, PETSC_ERR_PLIB, \
+     "Reused preconditioner was rebuilt - complexities changed (grid %f -> %f, cycle %f -> %f)", \
+     (double)gc_first, (double)gc_frozen, (double)cc_first, (double)cc_frozen);
+
+  // ~~~~~~~~~~~~~~~~~~
+  // Unfreeze and solve the same shifted system again - this must
+  // trigger a rebuild on the shifted matrix
+  // ~~~~~~~~~~~~~~~~~~
+  PetscCall(KSPSetReusePreconditioner(ksp, PETSC_FALSE));
+  PetscCall(VecSet(x, 0.0));
+  PetscCall(KSPSolve(ksp, b, x));
+  PetscCall(KSPGetIterationNumber(ksp, &its_rebuilt));
+  PetscCall(PCAIRGetGridComplexity(pc, &gc_rebuilt));
+  PetscCall(PCAIRGetCycleComplexity(pc, &cc_rebuilt));
+
+  // The rebuilt hierarchy on the (strongly diagonally dominant) shifted
+  // matrix differs from the original one - this also proves the frozen
+  // complexity check above is not vacuous
+  PetscCheck(gc_rebuilt != gc_first || cc_rebuilt != cc_first, PETSC_COMM_WORLD, PETSC_ERR_PLIB, \
+     "Rebuild after unfreezing did not change the hierarchy - test cannot detect reuse");
+
+  // The frozen preconditioner was built for the unshifted matrix so it
+  // must take more iterations on the shifted system than the rebuilt one
+  PetscCheck(its_frozen > its_rebuilt, PETSC_COMM_WORLD, PETSC_ERR_PLIB, \
+     "Frozen preconditioner iteration count (%" PetscInt_FMT ") does not exceed rebuilt (%" PetscInt_FMT ")", \
+     its_frozen, its_rebuilt);
+
+  PetscCall(PetscPrintf(PETSC_COMM_WORLD, "Iterations: first %" PetscInt_FMT ", frozen %" PetscInt_FMT ", rebuilt %" PetscInt_FMT "\n", \
+     its_first, its_frozen, its_rebuilt));
+
+  PetscCall(KSPDestroy(&ksp));
+  PetscCall(MatDestroy(&A));
+  PetscCall(VecDestroy(&x));
+  PetscCall(VecDestroy(&b));
+  PetscCall(PetscFinalize());
+  return 0;
+}


### PR DESCRIPTION
## The bug

`KSPSetReusePreconditioner` / `-ksp_reuse_preconditioner` was silently a no-op for PCAIR. PCAIR's work lives behind an internal PCSHELL: PETSc's generic early-return correctly skipped the outer `PCSetUp`, but `PCApply_AIR_c` calls `PCApply` on the shell, which unconditionally calls `PCSetUp` on the shell itself. The shell tracks the pmat object state on its own and never saw the `reusepreconditioner` flag, so a values-only refill of the pmat still rebuilt the full AIR hierarchy on every solve — anyone measuring "frozen preconditioner" behaviour was silently measuring fresh setups.

## The fix

Mirror the outer `reusepreconditioner` flag onto the internal shell in two places:

- `PCApply_AIR_c` — so a frozen PC stays frozen when the pmat changes. Matching PETSc's own semantics (the early-return fires before any pattern check), a frozen PC also stays frozen across a sparsity-pattern change.
- `PCSetUp_AIR_c` — so *unsetting* the flag propagates and the shell is allowed to rebuild again.

No behaviour change when the flag is unset; the existing `-pc_air_reuse_sparsity`/`-pc_air_reuse_amount` machinery is untouched.

## Regression test

`tests/reuse_preconditioner.c` (serial + 2-rank, in the short no-load groups): solve, freeze, `MatShift` the same pmat in place, solve, unfreeze, solve again. Asserts:
- grid/cycle complexities are bit-identical while frozen (no rebuild),
- the rebuild after unfreezing changes the complexities (so the frozen check is not vacuous),
- the frozen iteration count exceeds the rebuilt one (10 vs 2 on this problem).

Before the fix it fails immediately on the complexity check.

## ex6f

ex6f was never affected: its reuse branch passes `A2` — a copy never modified after step 1 — as the pmat, and PETSc only triggers PC re-setup off the pmat's object state, so the PC was naturally reused regardless of the flag. Removed its redundant `KSPSetReusePreconditioner` call and documented why in the file.

## Testing

- `make -j3 build_tests` clean (no warnings)
- `make check` and `make tests_short` exit 0 (includes the new test and all existing reuse/regen tests)
- No Kokkos code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)