### PR TITLE
Multiple RHS support in PCPFLAREINV via PCMatApply, with true block matrix-free applies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ tests/solution.vts
 
 # Compiled test executables (add new ones here as tests are added)
 tests/adv_1d
+tests/adv_1d_multi_rhs
 tests/adv_1dk
 tests/adv_dg_upwind
 tests/adv_diff_2d
@@ -37,7 +38,6 @@ tests/ex6_getcoeffs
 tests/ex6_two_airg
 tests/ex6f
 tests/ex6f_getcoeffs
-tests/ex6f_pcmatapply
 tests/ex6f_reuse_amount
 tests/ilu_factors
 tests/ilu_factors_kokkos

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ tests/mat_diag
 tests/matrandom
 tests/matrandom_check_reset
 tests/reuse_preconditioner
+tests/shell_block_apply

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ for earlier changes please see the git history.
 
 ## Unreleased
 
+- New `PCMatApply` callback for PCPFLAREINV, so a block of right-hand sides is
+  applied with a single sparse matrix by dense matrix product rather than
+  PETSc's default loop over columns; on the GPU backends this keeps the whole
+  multiple-RHS apply on the device. Note that `KSPMatSolve` only reaches
+  `PCMatApply` for `-ksp_type preonly` (or HPDDM) - any other KSP type falls
+  back to solving column by column. PCAIR does not support multiple right-hand
+  sides yet. New `tests/adv_1d_multi_rhs.c` driver builds the block of
+  right-hand sides with `MatCreateDenseFromVecType` and solves with
+  `KSPMatSolve`
 - Fixed PCAIR silently ignoring `KSPSetReusePreconditioner` /
   `-ksp_reuse_preconditioner`: a values-only change to the pmat between
   solves rebuilt the full AIR hierarchy despite the flag; a frozen PCAIR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,17 @@ for earlier changes please see the git history.
   sides yet. New `tests/adv_1d_multi_rhs.c` driver builds the block of
   right-hand sides with `MatCreateDenseFromVecType` and solves with
   `KSPMatSolve`
-- The matrix-free GMRES polynomial inverses (`power`, `arnoldi`, `newton`,
-  `newton_no_extra`) now also apply blockwise in `PCMatApply`: the Horner and
-  Newton-basis kernels run sparse matrix by dense matrix products on the
-  underlying operator instead of looping matvecs, with dense scratch blocks
-  cached in the matshell context. The right diagonally scaled variant
+- The matrix-free polynomial inverses (`power`, `arnoldi`, `newton`,
+  `newton_no_extra`, `neumann`) now also apply blockwise in `PCMatApply`: the
+  Horner and Newton-basis kernels run sparse matrix by dense matrix products
+  on the underlying operator instead of looping matvecs, with dense scratch
+  blocks cached in the matshell context. The right diagonally scaled variant
   `q(D^-1 A) D^-1` used by PCAIR's smoothers is supported ready for future
-  PCAIR multiple-RHS work; Neumann and anything else unsupported falls back
-  to the previous column-by-column apply. New `tests/shell_block_apply.c`
-  driver exercises the block apply directly, including the diagonally
-  scaled mode that PCPFLAREINV itself never builds
+  PCAIR multiple-RHS work, as is the Neumann polynomial's intrinsically
+  scaled `q(I - D^-1 A) D^-1`; anything else unsupported falls back to the
+  previous column-by-column apply. New `tests/shell_block_apply.c` driver
+  exercises the block apply directly, including the diagonally scaled mode
+  that PCPFLAREINV itself never builds
 - Fixed PCAIR silently ignoring `KSPSetReusePreconditioner` /
   `-ksp_reuse_preconditioner`: a values-only change to the pmat between
   solves rebuilt the full AIR hierarchy despite the flag; a frozen PCAIR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ for earlier changes please see the git history.
   sides yet. New `tests/adv_1d_multi_rhs.c` driver builds the block of
   right-hand sides with `MatCreateDenseFromVecType` and solves with
   `KSPMatSolve`
+- The matrix-free GMRES polynomial inverses (`power`, `arnoldi`, `newton`,
+  `newton_no_extra`) now also apply blockwise in `PCMatApply`: the Horner and
+  Newton-basis kernels run sparse matrix by dense matrix products on the
+  underlying operator instead of looping matvecs, with dense scratch blocks
+  cached in the matshell context. The right diagonally scaled variant
+  `q(D^-1 A) D^-1` used by PCAIR's smoothers is supported ready for future
+  PCAIR multiple-RHS work; Neumann and anything else unsupported falls back
+  to the previous column-by-column apply. New `tests/shell_block_apply.c`
+  driver exercises the block apply directly, including the diagonally
+  scaled mode that PCPFLAREINV itself never builds
 - Fixed PCAIR silently ignoring `KSPSetReusePreconditioner` /
   `-ksp_reuse_preconditioner`: a values-only change to the pmat between
   solves rebuilt the full AIR hierarchy despite the flag; a frozen PCAIR

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,7 @@ export TEST_TARGETS = ex12f \
 		  ex6f_reuse_amount \
 		  ex6 \
 		  adv_1d \
+		  adv_1d_multi_rhs \
 		  adv_diff_fd \
 		  ex6_cf_splitting \
 		  adv_diff_cg_supg \

--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ export TEST_TARGETS = ex12f \
 		  ex6 \
 		  adv_1d \
 		  adv_1d_multi_rhs \
+		  shell_block_apply \
 		  adv_diff_fd \
 		  ex6_cf_splitting \
 		  adv_diff_cg_supg \

--- a/src/Approx_Inverse_Setup.F90
+++ b/src/Approx_Inverse_Setup.F90
@@ -512,6 +512,8 @@ module approx_inverse_setup
       integer :: i_loc
       MatType:: mat_type
       type(mat_ctxtype), pointer :: mat_ctx=>null(), mat_ctx_scaled=>null()
+      type(tMat) :: temp_mat
+      type(tVec) :: temp_vec
       ! ~~~~~~
 
       if (.NOT. PetscObjectIsNull(matrix)) then
@@ -526,7 +528,8 @@ module approx_inverse_setup
             call VecDestroy(mat_ctx%mf_temp_vec(MF_VEC_TEMP), ierr)
 
             ! Both newton and neumann polynomials use some extra temporary vectors
-            if (.NOT. PetscObjectIsNull(mat_ctx%mat_scaled) .OR. &
+            temp_mat = mat_ctx%mat_scaled
+            if (.NOT. PetscObjectIsNull(temp_mat) .OR. &
                      associated(mat_ctx%real_roots)) then
                
                call VecDestroy(mat_ctx%mf_temp_vec(MF_VEC_RHS), ierr)
@@ -539,19 +542,22 @@ module approx_inverse_setup
             ! These are only ever created by the block applies, so this is a no-op
             ! for the jacobi/PCAIR matshells
             do i_loc = 1, size(mat_ctx%mf_temp_mat)
-               if (.NOT. PetscObjectIsNull(mat_ctx%mf_temp_mat(i_loc))) then
-                  call MatDestroy(mat_ctx%mf_temp_mat(i_loc), ierr)
+               temp_mat = mat_ctx%mf_temp_mat(i_loc)
+               if (.NOT. PetscObjectIsNull(temp_mat)) then
+                  call MatDestroy(temp_mat, ierr)
                end if
             end do
-            if (.NOT. PetscObjectIsNull(mat_ctx%mf_vec_diag_recip)) then
-               call VecDestroy(mat_ctx%mf_vec_diag_recip, ierr)
+            temp_vec = mat_ctx%mf_vec_diag_recip
+            if (.NOT. PetscObjectIsNull(temp_vec)) then
+               call VecDestroy(temp_vec, ierr)
             end if
 
             ! Neumann polynomial has extra context that needs deleting
-            if (.NOT. PetscObjectIsNull(mat_ctx%mat_scaled)) then
-               call MatShellGetContext(mat_ctx%mat_scaled, mat_ctx_scaled, ierr)
+            temp_mat = mat_ctx%mat_scaled
+            if (.NOT. PetscObjectIsNull(temp_mat)) then
+               call MatShellGetContext(temp_mat, mat_ctx_scaled, ierr)
                deallocate(mat_ctx_scaled)
-               call MatDestroy(mat_ctx%mat_scaled, ierr)
+               call MatDestroy(temp_mat, ierr)
             end if
             deallocate(mat_ctx)
          end if               

--- a/src/Approx_Inverse_Setup.F90
+++ b/src/Approx_Inverse_Setup.F90
@@ -459,7 +459,8 @@ module approx_inverse_setup
 
          coefficients = 1d0
          call calculate_and_build_neumann_polynomial_inverse(matrix, poly_order, &
-                     buffers, inverse_sparsity_order, matrix_free, reuse_mat, reuse_submatrices, inv_matrix)        
+                     buffers, coefficients(:, 1), inverse_sparsity_order, matrix_free, &
+                     reuse_mat, reuse_submatrices, inv_matrix)
                  
       ! Sparse approximate inverse
       else if (inverse_type == PFLAREINV_SAI .OR. inverse_type == PFLAREINV_ISAI) then

--- a/src/Approx_Inverse_Setup.F90
+++ b/src/Approx_Inverse_Setup.F90
@@ -509,6 +509,7 @@ module approx_inverse_setup
       type(tMat), intent(inout) :: matrix
 
       PetscErrorCode :: ierr
+      integer :: i_loc
       MatType:: mat_type
       type(mat_ctxtype), pointer :: mat_ctx=>null(), mat_ctx_scaled=>null()
       ! ~~~~~~
@@ -532,6 +533,18 @@ module approx_inverse_setup
                call VecDestroy(mat_ctx%mf_temp_vec(MF_VEC_DIAG), ierr)
                call VecDestroy(mat_ctx%mf_temp_vec(MF_VEC_TEMP_TWO), ierr)
                call VecDestroy(mat_ctx%mf_temp_vec(MF_VEC_TEMP_THREE), ierr)
+            end if
+
+            ! Any dense scratch blocks built by a multiple rhs (block) apply
+            ! These are only ever created by the block applies, so this is a no-op
+            ! for the jacobi/neumann/PCAIR matshells
+            do i_loc = 1, size(mat_ctx%mf_temp_mat)
+               if (.NOT. PetscObjectIsNull(mat_ctx%mf_temp_mat(i_loc))) then
+                  call MatDestroy(mat_ctx%mf_temp_mat(i_loc), ierr)
+               end if
+            end do
+            if (.NOT. PetscObjectIsNull(mat_ctx%mf_vec_diag_recip)) then
+               call VecDestroy(mat_ctx%mf_vec_diag_recip, ierr)
             end if
 
             ! Neumann polynomial has extra context that needs deleting

--- a/src/Approx_Inverse_Setup.F90
+++ b/src/Approx_Inverse_Setup.F90
@@ -537,7 +537,7 @@ module approx_inverse_setup
 
             ! Any dense scratch blocks built by a multiple rhs (block) apply
             ! These are only ever created by the block applies, so this is a no-op
-            ! for the jacobi/neumann/PCAIR matshells
+            ! for the jacobi/PCAIR matshells
             do i_loc = 1, size(mat_ctx%mf_temp_mat)
                if (.NOT. PetscObjectIsNull(mat_ctx%mf_temp_mat(i_loc))) then
                   call MatDestroy(mat_ctx%mf_temp_mat(i_loc), ierr)

--- a/src/Approx_Inverse_Setup.F90
+++ b/src/Approx_Inverse_Setup.F90
@@ -541,15 +541,21 @@ module approx_inverse_setup
             ! Any dense scratch blocks built by a multiple rhs (block) apply
             ! These are only ever created by the block applies, so this is a no-op
             ! for the jacobi/PCAIR matshells
+            ! The destroys go through local copies of the handles (the context fields
+            ! expand too long inside the PetscObjectIsNull macro), and destroy nulls
+            ! the local copy, not the context field - so always copy the nulled
+            ! handle back so no dangling handles are left in the context
             do i_loc = 1, size(mat_ctx%mf_temp_mat)
                temp_mat = mat_ctx%mf_temp_mat(i_loc)
                if (.NOT. PetscObjectIsNull(temp_mat)) then
                   call MatDestroy(temp_mat, ierr)
+                  mat_ctx%mf_temp_mat(i_loc) = temp_mat
                end if
             end do
             temp_vec = mat_ctx%mf_vec_diag_recip
             if (.NOT. PetscObjectIsNull(temp_vec)) then
                call VecDestroy(temp_vec, ierr)
+               mat_ctx%mf_vec_diag_recip = temp_vec
             end if
 
             ! Neumann polynomial has extra context that needs deleting
@@ -558,6 +564,7 @@ module approx_inverse_setup
                call MatShellGetContext(temp_mat, mat_ctx_scaled, ierr)
                deallocate(mat_ctx_scaled)
                call MatDestroy(temp_mat, ierr)
+               mat_ctx%mat_scaled = temp_mat
             end if
             deallocate(mat_ctx)
          end if               

--- a/src/C_Fortran_Bindings.F90
+++ b/src/C_Fortran_Bindings.F90
@@ -5,6 +5,7 @@ module c_fortran_bindings
    use pcair_data_type, only: pc_air_multigrid_data
    use pcair_shell, only: PCReset_AIR_Shell, create_pc_air_shell
    use approx_inverse_setup, only: calculate_and_build_approximate_inverse, reset_inverse_mat
+   use gmres_poly_newton, only: shell_poly_block_apply
    use cf_splitting, only: compute_cf_splitting
    use matdiagdomsubmatrix, only: compute_diag_dom_submatrix
    use petsc_helper, only: remove_from_sparse_match
@@ -214,8 +215,39 @@ module c_fortran_bindings
       call reset_inverse_mat(mat)
       mat_ptr = mat%v
 
-   end subroutine reset_inverse_mat_c    
-   
+   end subroutine reset_inverse_mat_c
+
+   !------------------------------------------------------------------------------------------------------------------------
+
+   subroutine pflareinv_shell_block_matapply_c(shell_ptr, x_ptr, y_ptr, applied_int) &
+         bind(C,name='pflareinv_shell_block_matapply_c')
+
+      ! Applies one of the matrix-free gmres polynomial matshells to a block of
+      ! right hand sides
+      ! applied_int comes back as 0 if we couldn't do a block apply, in which case
+      ! the caller has to apply column by column instead
+      ! NB - must only be called for the power/arnoldi/newton matshells, see the
+      ! warning in shell_poly_block_apply
+
+      ! ~~~~~~~~
+      integer(c_long_long), intent(in) :: shell_ptr, x_ptr, y_ptr
+      integer(c_int), intent(out)      :: applied_int
+
+      type(tMat)  :: shell_mat, x_mat, y_mat
+      logical     :: block_applied
+      ! ~~~~~~~~
+
+      shell_mat%v = shell_ptr
+      x_mat%v     = x_ptr
+      y_mat%v     = y_ptr
+
+      call shell_poly_block_apply(shell_mat, x_mat, y_mat, block_applied)
+
+      applied_int = 0
+      if (block_applied) applied_int = 1
+
+   end subroutine pflareinv_shell_block_matapply_c
+
    !------------------------------------------------------------------------------------------------------------------------
 
    subroutine compute_cf_splitting_c(input_mat_ptr, symmetric_int, &

--- a/src/C_Fortran_Bindings.F90
+++ b/src/C_Fortran_Bindings.F90
@@ -222,12 +222,11 @@ module c_fortran_bindings
    subroutine pflareinv_shell_block_matapply_c(shell_ptr, x_ptr, y_ptr, applied_int) &
          bind(C,name='pflareinv_shell_block_matapply_c')
 
-      ! Applies one of the matrix-free gmres polynomial matshells to a block of
+      ! Applies one of the matrix-free polynomial matshells to a block of
       ! right hand sides
       ! applied_int comes back as 0 if we couldn't do a block apply, in which case
-      ! the caller has to apply column by column instead
-      ! NB - must only be called for the power/arnoldi/newton matshells, see the
-      ! warning in shell_poly_block_apply
+      ! the caller has to apply column by column instead - that includes being handed
+      ! a matshell whose context isn't one of the polynomials shell_poly_block_apply knows
 
       ! ~~~~~~~~
       integer(c_long_long), intent(in) :: shell_ptr, x_ptr, y_ptr

--- a/src/Gmres_Poly.F90
+++ b/src/Gmres_Poly.F90
@@ -1481,7 +1481,102 @@ end if
          end do
       end if
 
-   end subroutine petsc_horner     
+   end subroutine petsc_horner
+
+! -------------------------------------------------------------------------------------------------------------------------------
+
+   subroutine petsc_horner_block(mat, coefficients, temp_mat, x_mat, y_mat, recip_diag, block_applied)
+
+      ! Uses a horner iteration to apply
+      ! y_mat = (coeff(1) + coeff(2) * A + coeff(3) * A^2 + ...) x_mat
+      ! for a block of right hand sides, x_mat, ie the multiple rhs version of petsc_horner
+      ! The matvecs of petsc_horner become sparse matrix-dense matrix products (SpMM)
+
+      ! If recip_diag is not null we are applying the diagonally scaled polynomial
+      ! q(D^-1 A), with the mat passed in the *unscaled* A and recip_diag = D^-1.
+      ! We do this rather than running the products on the D^-1 A matshell, as every
+      ! product on a shell degrades to a column by column matvec. The caller must have
+      ! already scaled the block of rhs, ie x_mat = D^-1 X
+
+      ! block_applied comes back false (with y_mat untouched) if the block of rhs we've
+      ! been given has no product with mat, so the caller can fall back to a column by
+      ! column apply
+
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      ! Input
+      type(tMat), intent(in)    :: mat
+      PetscReal, dimension(:)   :: coefficients
+      type(tMat)                :: x_mat, temp_mat
+      type(tMat)                :: y_mat
+      type(tVec)                :: recip_diag
+      logical, intent(out)      :: block_applied
+
+      ! Local
+      integer :: order
+      logical :: scaled
+      PetscBool :: has_product
+      PetscErrorCode :: ierr
+
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      block_applied = .FALSE.
+      scaled = .NOT. PetscObjectIsNull(recip_diag)
+
+      ! If we are doing a first order polynomial or above, we have to do an extra
+      ! product per order - attach it to y_mat now
+      ! This has to happen before we write any values into y_mat, as the symbolic
+      ! product may set up y_mat
+      if (size(coefficients, 1) > 1) then
+
+         ! y_mat = mat * temp_mat
+         call MatProductCreateWithMat(mat, temp_mat, PETSC_NULL_MAT, y_mat, ierr)
+         call MatProductSetType(y_mat, MATPRODUCT_AB, ierr)
+         call MatProductSetFromOptions(y_mat, ierr)
+
+         ! If there is no product available for these types we have to let the
+         ! caller do a column by column apply instead
+         call MatHasOperation(y_mat, MATOP_PRODUCTSYMBOLIC, has_product, ierr)
+         if (.NOT. has_product) then
+            call MatProductClear(y_mat, ierr)
+            return
+         end if
+
+         call MatProductSymbolic(y_mat, ierr)
+      end if
+
+      ! Let's do the first y = alpha_n-1 r_0 (ie the highest order term first)
+      call MatCopy(x_mat, y_mat, SAME_NONZERO_PATTERN, ierr)
+      call MatScale(y_mat, coefficients(size(coefficients)), ierr)
+
+      if (size(coefficients, 1) > 1) then
+
+         ! Loop down from the second highest order term down to the constant
+         do order = size(coefficients, 1)-1, 1, -1
+
+            ! Skip this coefficient if zero
+            if (coefficients(order) == 0d0) cycle
+
+            ! Copy y_mat into temp_mat
+            call MatCopy(y_mat, temp_mat, SAME_NONZERO_PATTERN, ierr)
+
+            ! Now do y_mat = A * temp_mat
+            call MatProductNumeric(y_mat, ierr)
+
+            ! This is the arithmetic of the D^-1 A matshell, done blockwise
+            if (scaled) call MatDiagonalScale(y_mat, recip_diag, PETSC_NULL_VEC, ierr)
+
+            ! Compute y_mat = A * temp_mat + alpha_n-i-1 r_0
+            call MatAXPY(y_mat, coefficients(order), x_mat, SAME_NONZERO_PATTERN, ierr)
+         end do
+
+         ! Don't leave y_mat holding references to mat and temp_mat
+         call MatProductClear(y_mat, ierr)
+      end if
+
+      block_applied = .TRUE.
+
+   end subroutine petsc_horner_block
 
 ! -------------------------------------------------------------------------------------------------------------------------------
 

--- a/src/Gmres_Poly.F90
+++ b/src/Gmres_Poly.F90
@@ -1485,18 +1485,24 @@ end if
 
 ! -------------------------------------------------------------------------------------------------------------------------------
 
-   subroutine petsc_horner_block(mat, coefficients, temp_mat, x_mat, y_mat, recip_diag, block_applied)
+   subroutine petsc_horner_block(mat, coefficients, temp_mat, x_mat, y_mat, recip_diag, &
+                  neumann_inner, block_applied)
 
       ! Uses a horner iteration to apply
-      ! y_mat = (coeff(1) + coeff(2) * A + coeff(3) * A^2 + ...) x_mat
+      ! y_mat = (coeff(1) + coeff(2) * B + coeff(3) * B^2 + ...) x_mat
       ! for a block of right hand sides, x_mat, ie the multiple rhs version of petsc_horner
       ! The matvecs of petsc_horner become sparse matrix-dense matrix products (SpMM)
 
-      ! If recip_diag is not null we are applying the diagonally scaled polynomial
-      ! q(D^-1 A), with the mat passed in the *unscaled* A and recip_diag = D^-1.
-      ! We do this rather than running the products on the D^-1 A matshell, as every
-      ! product on a shell degrades to a column by column matvec. The caller must have
-      ! already scaled the block of rhs, ie x_mat = D^-1 X
+      ! There are three different inner operators, B, we can apply, all of them built
+      ! out of real products with the *unscaled* mat we've been given. We do this rather
+      ! than running the products on the matshells the scalar versions use, as every
+      ! product on a shell degrades to a column by column matvec
+      ! 1) recip_diag null                : B = A, the plain polynomial q(A)
+      ! 2) recip_diag non-null            : B = D^-1 A, the diagonally scaled polynomial
+      !                                     q(D^-1 A), with recip_diag = D^-1
+      ! 3) neumann_inner (implies scaled) : B = I - D^-1 A, the Neumann polynomial
+      ! In the scaled cases the caller must have already scaled the block of rhs,
+      ! ie x_mat = D^-1 X
 
       ! block_applied comes back false (with y_mat untouched) if the block of rhs we've
       ! been given has no product with mat, so the caller can fall back to a column by
@@ -1510,6 +1516,7 @@ end if
       type(tMat)                :: x_mat, temp_mat
       type(tMat)                :: y_mat
       type(tVec)                :: recip_diag
+      logical, intent(in)       :: neumann_inner
       logical, intent(out)      :: block_applied
 
       ! Local
@@ -1566,7 +1573,16 @@ end if
             ! This is the arithmetic of the D^-1 A matshell, done blockwise
             if (scaled) call MatDiagonalScale(y_mat, recip_diag, PETSC_NULL_VEC, ierr)
 
-            ! Compute y_mat = A * temp_mat + alpha_n-i-1 r_0
+            ! The inner operator is I - D^-1 A rather than D^-1 A, so finish
+            ! y_mat = temp_mat - D^-1 A temp_mat
+            ! temp_mat still holds the value we did the product with
+            ! This is the arithmetic of the I - D^-1 A matshell, done blockwise
+            if (neumann_inner) then
+               call MatScale(y_mat, PFLARE_MINUS_ONE, ierr)
+               call MatAXPY(y_mat, PFLARE_ONE, temp_mat, SAME_NONZERO_PATTERN, ierr)
+            end if
+
+            ! Compute y_mat = B * temp_mat + alpha_n-i-1 r_0
             call MatAXPY(y_mat, coefficients(order), x_mat, SAME_NONZERO_PATTERN, ierr)
          end do
 

--- a/src/Gmres_Poly_Newton.F90
+++ b/src/Gmres_Poly_Newton.F90
@@ -1070,20 +1070,15 @@ module gmres_poly_newton
       ! block_applied comes back false (with y_mat untouched) whenever we can't do a
       ! block apply, and the caller must then apply column by column instead
 
-      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      ! WARNING - This routine must NEVER be called with a Neumann polynomial matshell
-      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      ! The diagonally scaled gmres polynomials store an inner matshell in mat_ctx%mat_scaled
-      ! whose matvec is D^-1 A, and the block kernels below deliberately bypass that inner
-      ! shell - they do real products with the unscaled mat_ctx%mat and then scale the
-      ! result by D^-1 themselves (a product on a shell would degrade to a column by
-      ! column matvec). The Neumann polynomial reuses the same right scaled outer handler
-      ! but its inner shell is I - D^-1 A (see Neumann_Poly.F90), which is different
-      ! arithmetic, so the bypass would silently give the wrong answer.
-      ! There is nothing in the context that distinguishes the two, so the callers have
-      ! to gate on the inverse type - PCMatApply_PFLAREINV_c only dispatches here for
-      ! POWER/ARNOLDI/NEWTON/NEWTON_NO_EXTRA and any future caller (eg PCAIR) must do the same
-      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ! The polynomials with a right diagonal scaling store an inner matshell in
+      ! mat_ctx%mat_scaled and the block kernels below deliberately bypass it - they do
+      ! real products with the unscaled mat_ctx%mat and then apply the rest of the inner
+      ! shell's arithmetic themselves (a product on a shell would degrade to a column by
+      ! column matvec). That means the kernels have to be told which inner operator they
+      ! are emulating - mat_ctx%neumann_inner picks I - D^-1 A (the Neumann polynomial,
+      ! see Neumann_Poly.F90) rather than D^-1 A (the diagonally scaled gmres polynomials)
+      ! Any new inner operator variant must add to that flag rather than reuse it,
+      ! otherwise the bypass will silently give the wrong answer
 
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1129,9 +1124,18 @@ module gmres_poly_newton
 
       ! ~~~~~~~~~~~~
       ! Dispatch on what sort of polynomial is in the context
-      ! The newton basis needs three dense temporaries, the power/arnoldi basis one
+      ! The newton basis needs three dense temporaries, the power/arnoldi/neumann basis one
+      ! The Neumann polynomial has to be checked first, as it also has coefficients
       ! ~~~~~~~~~~~~
-      if (associated(mat_ctx%real_roots)) then
+      if (mat_ctx%neumann_inner) then
+         ! The Neumann polynomial is q(I - D^-1 A) D^-1 with coefficients of one and is
+         ! always built with its inner matshell, so we should always have a scaled apply
+         ! here - don't rely on that though, we can't emulate the inner operator without
+         ! the diagonal
+         if (.NOT. scaled) return
+         if (.NOT. associated(mat_ctx%coefficients)) return
+         n_temps = 1
+      else if (associated(mat_ctx%real_roots)) then
          n_temps = 3
       else if (associated(mat_ctx%coefficients)) then
          n_temps = 1
@@ -1150,7 +1154,14 @@ module gmres_poly_newton
          kernel_x = mat_ctx%mf_temp_mat(MF_MAT_RHS)
       end if
 
-      if (associated(mat_ctx%real_roots)) then
+      if (mat_ctx%neumann_inner) then
+
+         ! Neumann polynomial - horner with an inner operator of I - D^-1 A
+         call petsc_horner_block(mat_ctx%mat, mat_ctx%coefficients, &
+                  mat_ctx%mf_temp_mat(MF_MAT_TEMP), &
+                  kernel_x, y_mat, kernel_recip, .TRUE., block_applied)
+
+      else if (associated(mat_ctx%real_roots)) then
 
          ! Newton basis
          call petsc_newton_block(mat_ctx%mat, &
@@ -1165,7 +1176,7 @@ module gmres_poly_newton
          ! Power/arnoldi basis
          call petsc_horner_block(mat_ctx%mat, mat_ctx%coefficients, &
                   mat_ctx%mf_temp_mat(MF_MAT_TEMP), &
-                  kernel_x, y_mat, kernel_recip, block_applied)
+                  kernel_x, y_mat, kernel_recip, .FALSE., block_applied)
 
       end if
 

--- a/src/Gmres_Poly_Newton.F90
+++ b/src/Gmres_Poly_Newton.F90
@@ -6,7 +6,9 @@ module gmres_poly_newton
    use pflare_parameters, only: PFLARE_TOL_ZERO, PFLARE_TOL_RCOND, &
          PFLARE_TOL_CONSISTENCY, PFLARE_EPS, PFLARE_TOL_LUCKY, &
          PFLARE_ONE, PFLARE_ZERO, PFLARE_MINUS_ONE, PFLARE_TWO, PFLARE_MATMULT_FILL, &
-         PFLARE_TOL_MATFREE_NEWTON, PFLARE_TOL_LEJA_PERTURB
+         PFLARE_TOL_MATFREE_NEWTON, PFLARE_TOL_LEJA_PERTURB, &
+         MF_MAT_TEMP, MF_MAT_RHS
+   use matshell_data_type, only: ensure_block_temp_mats
 
 #include "petsc/finclude/petscmat.h"
 #include "finclude/pflare_blaslapack.h"
@@ -872,8 +874,106 @@ module gmres_poly_newton
          end if
       end if
 
-   end subroutine petsc_newton  
-   
+   end subroutine petsc_newton
+
+! -------------------------------------------------------------------------------------------------------------------------------
+
+   subroutine shell_poly_block_apply(shell_mat, x_mat, y_mat, block_applied)
+
+      ! Applies one of the matrix-free gmres polynomial inverses to a block of
+      ! right hand sides, x_mat, ie the multiple rhs version of the matvecs
+      ! petsc_matvec_poly_mf / petsc_matvec_right_scale_poly_mf and their newton equivalents
+      ! The shell_mat passed in is the matshell built by build_gmres_polynomial_inverse
+      ! (or its newton equivalent) and we dispatch on what its context contains
+
+      ! block_applied comes back false (with y_mat untouched) whenever we can't do a
+      ! block apply, and the caller must then apply column by column instead
+
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ! WARNING - This routine must NEVER be called with a Neumann polynomial matshell
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ! The diagonally scaled gmres polynomials store an inner matshell in mat_ctx%mat_scaled
+      ! whose matvec is D^-1 A, and the block kernels below deliberately bypass that inner
+      ! shell - they do real products with the unscaled mat_ctx%mat and then scale the
+      ! result by D^-1 themselves (a product on a shell would degrade to a column by
+      ! column matvec). The Neumann polynomial reuses the same right scaled outer handler
+      ! but its inner shell is I - D^-1 A (see Neumann_Poly.F90), which is different
+      ! arithmetic, so the bypass would silently give the wrong answer.
+      ! There is nothing in the context that distinguishes the two, so the callers have
+      ! to gate on the inverse type - PCMatApply_PFLAREINV_c only dispatches here for
+      ! POWER/ARNOLDI/NEWTON/NEWTON_NO_EXTRA and any future caller (eg PCAIR) must do the same
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      ! Input
+      type(tMat), intent(in)    :: shell_mat
+      type(tMat)                :: x_mat
+      type(tMat)                :: y_mat
+      logical, intent(out)      :: block_applied
+
+      ! Local
+      PetscErrorCode :: ierr
+      logical :: scaled
+      type(mat_ctxtype), pointer :: mat_ctx => null()
+      ! The block of rhs and the D^-1 we hand to the kernels
+      ! kernel_recip is left null in the unscaled case
+      type(tMat) :: kernel_x
+      type(tVec) :: kernel_recip
+
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      block_applied = .FALSE.
+      call MatShellGetContext(shell_mat, mat_ctx, ierr)
+
+      ! Are we applying q(D^-1 A) D^-1 rather than just q(A)?
+      scaled = .NOT. PetscObjectIsNull(mat_ctx%mat_scaled)
+
+      kernel_x = x_mat
+
+      if (scaled) then
+
+         ! Lazily build somewhere to store D^-1
+         if (PetscObjectIsNull(mat_ctx%mf_vec_diag_recip)) then
+            call VecDuplicate(mat_ctx%mf_temp_vec(MF_VEC_DIAG), mat_ctx%mf_vec_diag_recip, ierr)
+         end if
+         ! We have to refresh the values every apply - the diagonal in MF_VEC_DIAG is
+         ! updated in place whenever the matshell is reused with the same nonzero
+         ! pattern, and there is no hook that would let us know that has happened
+         call VecCopy(mat_ctx%mf_temp_vec(MF_VEC_DIAG), mat_ctx%mf_vec_diag_recip, ierr)
+         call VecReciprocal(mat_ctx%mf_vec_diag_recip, ierr)
+         kernel_recip = mat_ctx%mf_vec_diag_recip
+      end if
+
+      ! ~~~~~~~~~~~~
+      ! Dispatch on what sort of polynomial is in the context
+      ! ~~~~~~~~~~~~
+      if (associated(mat_ctx%real_roots)) then
+
+         ! Newton basis - the newton block kernel is added in a follow-up, so for now
+         ! we fall back to a column by column apply
+         return
+
+      else if (associated(mat_ctx%coefficients)) then
+
+         ! Power/arnoldi basis - one dense temporary, plus somewhere to put D^-1 X
+         call ensure_block_temp_mats(mat_ctx, x_mat, 1, ierr, need_rhs=scaled)
+
+         ! Do the right diagonal scaling on the whole block, ie MF_MAT_RHS = D^-1 X
+         if (scaled) then
+            call MatCopy(x_mat, mat_ctx%mf_temp_mat(MF_MAT_RHS), SAME_NONZERO_PATTERN, ierr)
+            call MatDiagonalScale(mat_ctx%mf_temp_mat(MF_MAT_RHS), kernel_recip, PETSC_NULL_VEC, ierr)
+            kernel_x = mat_ctx%mf_temp_mat(MF_MAT_RHS)
+         end if
+
+         call petsc_horner_block(mat_ctx%mat, mat_ctx%coefficients, &
+                  mat_ctx%mf_temp_mat(MF_MAT_TEMP), &
+                  kernel_x, y_mat, kernel_recip, block_applied)
+
+      end if
+
+   end subroutine shell_poly_block_apply
+
 ! -------------------------------------------------------------------------------------------------------------------------------
 
    subroutine petsc_matvec_poly_newton_mf(mat, x, y)

--- a/src/Gmres_Poly_Newton.F90
+++ b/src/Gmres_Poly_Newton.F90
@@ -7,7 +7,7 @@ module gmres_poly_newton
          PFLARE_TOL_CONSISTENCY, PFLARE_EPS, PFLARE_TOL_LUCKY, &
          PFLARE_ONE, PFLARE_ZERO, PFLARE_MINUS_ONE, PFLARE_TWO, PFLARE_MATMULT_FILL, &
          PFLARE_TOL_MATFREE_NEWTON, PFLARE_TOL_LEJA_PERTURB, &
-         MF_MAT_TEMP, MF_MAT_RHS
+         MF_MAT_TEMP, MF_MAT_TEMP_TWO, MF_MAT_TEMP_THREE, MF_MAT_RHS
    use matshell_data_type, only: ensure_block_temp_mats
 
 #include "petsc/finclude/petscmat.h"
@@ -878,6 +878,187 @@ module gmres_poly_newton
 
 ! -------------------------------------------------------------------------------------------------------------------------------
 
+   subroutine petsc_newton_block(mat, real_roots, imag_roots, temp_mat, temp_mat_two, temp_mat_three, &
+                  x_mat, y_mat, recip_diag, block_applied)
+
+      ! Applies a gmres polynomial in the newton basis matrix-free as an inverse
+      ! for a block of right hand sides, x_mat, ie the multiple rhs version of petsc_newton
+      ! The roots are stored in real_roots, imag_roots in the input matshell
+      ! Based on Loe 2021 Toward efficient polynomial preconditioning for GMRES
+      ! This is Algorithm 3 in Loe
+      ! The matvecs of petsc_newton become sparse matrix-dense matrix products (SpMM)
+      ! y_mat = A x_mat
+
+      ! If recip_diag is not null we are applying the diagonally scaled polynomial
+      ! q(D^-1 A), with the mat passed in the *unscaled* A and recip_diag = D^-1.
+      ! We do this rather than running the products on the D^-1 A matshell, as every
+      ! product on a shell degrades to a column by column matvec. The caller must have
+      ! already scaled the block of rhs, ie x_mat = D^-1 X
+      ! Every product below is therefore scaled by D^-1 immediately after it is computed
+      ! and before the result is used for anything else - that is exactly the arithmetic
+      ! of the inner D^-1 A matshell, done blockwise
+
+      ! block_applied comes back false (with y_mat untouched) if the block of rhs we've
+      ! been given has no product with mat, so the caller can fall back to a column by
+      ! column apply
+
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      ! Input
+      type(tMat), intent(in)              :: mat
+      PetscReal, dimension(:), intent(in) :: real_roots, imag_roots
+      type(tMat)                          :: temp_mat, temp_mat_two, temp_mat_three
+      type(tMat)                          :: x_mat
+      type(tMat)                          :: y_mat
+      type(tVec)                          :: recip_diag
+      logical, intent(out)                :: block_applied
+
+      ! Local
+      integer :: i, nroots
+      logical :: scaled
+      PetscBool :: has_product
+      PetscErrorCode :: ierr
+
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      block_applied = .FALSE.
+      scaled = .NOT. PetscObjectIsNull(recip_diag)
+      nroots = size(real_roots)
+
+      ! If we have more than one root we have to do products as we iterate over
+      ! the roots - attach them now
+      ! This has to happen before we write any values into the temporaries, as the
+      ! symbolic product may set them up
+      if (nroots > 1) then
+
+         ! temp_mat_two = mat * temp_mat
+         call MatProductCreateWithMat(mat, temp_mat, PETSC_NULL_MAT, temp_mat_two, ierr)
+         call MatProductSetType(temp_mat_two, MATPRODUCT_AB, ierr)
+         call MatProductSetFromOptions(temp_mat_two, ierr)
+
+         ! If there is no product available for these types we have to let the
+         ! caller do a column by column apply instead
+         call MatHasOperation(temp_mat_two, MATOP_PRODUCTSYMBOLIC, has_product, ierr)
+         if (.NOT. has_product) then
+            call MatProductClear(temp_mat_two, ierr)
+            return
+         end if
+
+         call MatProductSymbolic(temp_mat_two, ierr)
+
+         ! temp_mat_three = mat * temp_mat_two
+         ! The types are the same as the product above, so we know this one exists
+         call MatProductCreateWithMat(mat, temp_mat_two, PETSC_NULL_MAT, temp_mat_three, ierr)
+         call MatProductSetType(temp_mat_three, MATPRODUCT_AB, ierr)
+         call MatProductSetFromOptions(temp_mat_three, ierr)
+         call MatProductSymbolic(temp_mat_three, ierr)
+      end if
+
+      ! temp_mat = x_mat
+      call MatCopy(x_mat, temp_mat, SAME_NONZERO_PATTERN, ierr)
+      ! y_mat = 0
+      call MatZeroEntries(y_mat, ierr)
+
+      ! ~~~~~~~~~~~~
+      ! Iterate over the i
+      ! ~~~~~~~~~~~~
+      i = 1
+      do while (i .le. nroots - 1)
+
+         ! If real this is easy
+         if (imag_roots(i) == 0d0) then
+
+            ! Skips eigenvalues that are numerically zero - see
+            ! the comment in calculate_gmres_polynomial_roots_newton
+            if (abs(real_roots(i)) < PFLARE_TOL_ZERO) then
+               i = i + 1
+               cycle
+            end if
+
+            ! y_mat = y_mat + theta_i * temp_mat
+            call MatAXPY(y_mat, &
+                     PFLARE_ONE/real_roots(i), &
+                     temp_mat, SAME_NONZERO_PATTERN, ierr)
+
+            ! temp_mat_two = A * temp_mat
+            call MatProductNumeric(temp_mat_two, ierr)
+            if (scaled) call MatDiagonalScale(temp_mat_two, recip_diag, PETSC_NULL_VEC, ierr)
+
+            ! temp_mat = temp_mat - theta_i * temp_mat_two
+            call MatAXPY(temp_mat, &
+                     PFLARE_MINUS_ONE/real_roots(i), &
+                     temp_mat_two, SAME_NONZERO_PATTERN, ierr)
+
+            i = i + 1
+
+         ! If imaginary, then have to combine the e'val and its
+         ! complex conjugate to keep the arithmetic real
+         ! Relies on the complex conjugate being next to each other
+         else
+
+            ! Skips eigenvalues that are numerically zero
+            if (real_roots(i)**2 + imag_roots(i)**2 < PFLARE_TOL_ZERO) then
+               i = i + 2
+               cycle
+            end if
+
+            ! temp_mat_two = A * temp_mat
+            call MatProductNumeric(temp_mat_two, ierr)
+            if (scaled) call MatDiagonalScale(temp_mat_two, recip_diag, PETSC_NULL_VEC, ierr)
+
+            ! temp_mat_two = 2 * Re(theta_i) * temp_mat - temp_mat_two
+            call MatScale(temp_mat_two, PFLARE_MINUS_ONE, ierr)
+            call MatAXPY(temp_mat_two, &
+                  PFLARE_TWO * real_roots(i), &
+                  temp_mat, SAME_NONZERO_PATTERN, ierr)
+
+            ! y_mat = y_mat + 1/(Re(theta_i)^2 + Imag(theta_i)^2) * temp_mat_two
+            call MatAXPY(y_mat, &
+                     PFLARE_ONE/(real_roots(i)**2 + imag_roots(i)**2), &
+                     temp_mat_two, SAME_NONZERO_PATTERN, ierr)
+
+            if (i .le. nroots - 2) then
+               ! temp_mat_three = A * temp_mat_two
+               call MatProductNumeric(temp_mat_three, ierr)
+               if (scaled) call MatDiagonalScale(temp_mat_three, recip_diag, PETSC_NULL_VEC, ierr)
+
+               ! temp_mat = temp_mat - 1/(Re(theta_i)^2 + Imag(theta_i)^2) * temp_mat_three
+               call MatAXPY(temp_mat, &
+                        PFLARE_MINUS_ONE/(real_roots(i)**2 + imag_roots(i)**2), &
+                        temp_mat_three, SAME_NONZERO_PATTERN, ierr)
+            end if
+
+            ! Skip two evals
+            i = i + 2
+
+         end if
+      end do
+
+      ! Final step if last root is real
+      if (imag_roots(nroots) == 0d0) then
+
+         ! Skips eigenvalues that are numerically zero
+         if (abs(real_roots(nroots)) > PFLARE_TOL_ZERO) then
+
+            ! y_mat = y_mat + theta_i * temp_mat
+            call MatAXPY(y_mat, &
+                     PFLARE_ONE/real_roots(nroots), &
+                     temp_mat, SAME_NONZERO_PATTERN, ierr)
+         end if
+      end if
+
+      ! Don't leave the temporaries holding references to mat and each other
+      if (nroots > 1) then
+         call MatProductClear(temp_mat_two, ierr)
+         call MatProductClear(temp_mat_three, ierr)
+      end if
+
+      block_applied = .TRUE.
+
+   end subroutine petsc_newton_block
+
+! -------------------------------------------------------------------------------------------------------------------------------
+
    subroutine shell_poly_block_apply(shell_mat, x_mat, y_mat, block_applied)
 
       ! Applies one of the matrix-free gmres polynomial inverses to a block of
@@ -914,6 +1095,7 @@ module gmres_poly_newton
 
       ! Local
       PetscErrorCode :: ierr
+      integer :: n_temps
       logical :: scaled
       type(mat_ctxtype), pointer :: mat_ctx => null()
       ! The block of rhs and the D^-1 we hand to the kernels
@@ -947,25 +1129,40 @@ module gmres_poly_newton
 
       ! ~~~~~~~~~~~~
       ! Dispatch on what sort of polynomial is in the context
+      ! The newton basis needs three dense temporaries, the power/arnoldi basis one
       ! ~~~~~~~~~~~~
       if (associated(mat_ctx%real_roots)) then
-
-         ! Newton basis - the newton block kernel is added in a follow-up, so for now
-         ! we fall back to a column by column apply
-         return
-
+         n_temps = 3
       else if (associated(mat_ctx%coefficients)) then
+         n_temps = 1
+      else
+         ! Nothing we know how to apply blockwise
+         return
+      end if
 
-         ! Power/arnoldi basis - one dense temporary, plus somewhere to put D^-1 X
-         call ensure_block_temp_mats(mat_ctx, x_mat, 1, ierr, need_rhs=scaled)
+      ! Make the dense temporaries, plus somewhere to put D^-1 X if we need it
+      call ensure_block_temp_mats(mat_ctx, x_mat, n_temps, ierr, need_rhs=scaled)
 
-         ! Do the right diagonal scaling on the whole block, ie MF_MAT_RHS = D^-1 X
-         if (scaled) then
-            call MatCopy(x_mat, mat_ctx%mf_temp_mat(MF_MAT_RHS), SAME_NONZERO_PATTERN, ierr)
-            call MatDiagonalScale(mat_ctx%mf_temp_mat(MF_MAT_RHS), kernel_recip, PETSC_NULL_VEC, ierr)
-            kernel_x = mat_ctx%mf_temp_mat(MF_MAT_RHS)
-         end if
+      ! Do the right diagonal scaling on the whole block, ie MF_MAT_RHS = D^-1 X
+      if (scaled) then
+         call MatCopy(x_mat, mat_ctx%mf_temp_mat(MF_MAT_RHS), SAME_NONZERO_PATTERN, ierr)
+         call MatDiagonalScale(mat_ctx%mf_temp_mat(MF_MAT_RHS), kernel_recip, PETSC_NULL_VEC, ierr)
+         kernel_x = mat_ctx%mf_temp_mat(MF_MAT_RHS)
+      end if
 
+      if (associated(mat_ctx%real_roots)) then
+
+         ! Newton basis
+         call petsc_newton_block(mat_ctx%mat, &
+                  mat_ctx%real_roots, mat_ctx%imag_roots, &
+                  mat_ctx%mf_temp_mat(MF_MAT_TEMP), &
+                  mat_ctx%mf_temp_mat(MF_MAT_TEMP_TWO), &
+                  mat_ctx%mf_temp_mat(MF_MAT_TEMP_THREE), &
+                  kernel_x, y_mat, kernel_recip, block_applied)
+
+      else
+
+         ! Power/arnoldi basis
          call petsc_horner_block(mat_ctx%mat, mat_ctx%coefficients, &
                   mat_ctx%mf_temp_mat(MF_MAT_TEMP), &
                   kernel_x, y_mat, kernel_recip, block_applied)

--- a/src/Gmres_Poly_Newton.F90
+++ b/src/Gmres_Poly_Newton.F90
@@ -1095,8 +1095,8 @@ module gmres_poly_newton
       type(mat_ctxtype), pointer :: mat_ctx => null()
       ! The block of rhs and the D^-1 we hand to the kernels
       ! kernel_recip is left null in the unscaled case
-      type(tMat) :: kernel_x
-      type(tVec) :: kernel_recip
+      type(tMat) :: kernel_x, temp_mat
+      type(tVec) :: kernel_recip, temp_vec
 
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1104,22 +1104,24 @@ module gmres_poly_newton
       call MatShellGetContext(shell_mat, mat_ctx, ierr)
 
       ! Are we applying q(D^-1 A) D^-1 rather than just q(A)?
-      scaled = .NOT. PetscObjectIsNull(mat_ctx%mat_scaled)
+      temp_mat = mat_ctx%mat_scaled
+      scaled = .NOT. PetscObjectIsNull(temp_mat)
 
       kernel_x = x_mat
 
       if (scaled) then
 
          ! Lazily build somewhere to store D^-1
-         if (PetscObjectIsNull(mat_ctx%mf_vec_diag_recip)) then
-            call VecDuplicate(mat_ctx%mf_temp_vec(MF_VEC_DIAG), mat_ctx%mf_vec_diag_recip, ierr)
+         temp_vec = mat_ctx%mf_vec_diag_recip
+         if (PetscObjectIsNull(temp_vec)) then
+            call VecDuplicate(mat_ctx%mf_temp_vec(MF_VEC_DIAG), temp_vec, ierr)
          end if
          ! We have to refresh the values every apply - the diagonal in MF_VEC_DIAG is
          ! updated in place whenever the matshell is reused with the same nonzero
          ! pattern, and there is no hook that would let us know that has happened
-         call VecCopy(mat_ctx%mf_temp_vec(MF_VEC_DIAG), mat_ctx%mf_vec_diag_recip, ierr)
-         call VecReciprocal(mat_ctx%mf_vec_diag_recip, ierr)
-         kernel_recip = mat_ctx%mf_vec_diag_recip
+         call VecCopy(mat_ctx%mf_temp_vec(MF_VEC_DIAG), temp_vec, ierr)
+         call VecReciprocal(temp_vec, ierr)
+         kernel_recip = temp_vec
       end if
 
       ! ~~~~~~~~~~~~

--- a/src/Gmres_Poly_Newton.F90
+++ b/src/Gmres_Poly_Newton.F90
@@ -1115,6 +1115,9 @@ module gmres_poly_newton
          temp_vec = mat_ctx%mf_vec_diag_recip
          if (PetscObjectIsNull(temp_vec)) then
             call VecDuplicate(mat_ctx%mf_temp_vec(MF_VEC_DIAG), temp_vec, ierr)
+            ! The new handle has to go back into the context, or we would create
+            ! (and leak) a new vec on every apply
+            mat_ctx%mf_vec_diag_recip = temp_vec
          end if
          ! We have to refresh the values every apply - the diagonal in MF_VEC_DIAG is
          ! updated in place whenever the matshell is reused with the same nonzero

--- a/src/Matshell_Data_Type.F90
+++ b/src/Matshell_Data_Type.F90
@@ -3,7 +3,8 @@ module matshell_data_type
    use petscmat
    use air_data_type
    use pflare_parameters, only: MF_VEC_TEMP, MF_VEC_TEMP_TWO, MF_VEC_TEMP_THREE, &
-         MF_VEC_DIAG, MF_VEC_RHS
+         MF_VEC_DIAG, MF_VEC_RHS, MF_MAT_TEMP, MF_MAT_TEMP_TWO, MF_MAT_TEMP_THREE, &
+         MF_MAT_RHS
 
 #include "petsc/finclude/petscmat.h"   
 
@@ -24,13 +25,98 @@ module matshell_data_type
       type(tMat) :: mat, mat_scaled
       ! Temporary vectors we use
       type(tVec), dimension(5) :: mf_temp_vec
+      ! Temporary dense matrices we use during a multiple rhs (block) apply
+      ! These are lazily created from the input block of rhs, as the number of
+      ! columns isn't known until the apply happens
+      type(tMat), dimension(4) :: mf_temp_mat
+      ! The number of global columns the cached mf_temp_mat's were built with
+      PetscInt :: mf_temp_mat_ncols = -1
+      ! The reciprocal of mf_temp_vec(MF_VEC_DIAG), only used by the block applies
+      ! of the diagonally scaled polynomials
+      type(tVec) :: mf_vec_diag_recip
       type(air_multigrid_data), pointer :: air_data => null()
 
    end type mat_ctxtype
-   
-   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     
-   
+
+   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
    contains
+
+! -------------------------------------------------------------------------------------------------------------------------------
+
+   subroutine ensure_block_temp_mats(mat_ctx, x_mat, n_temps, ierr, need_rhs)
+
+      ! Makes sure the cached dense scratch blocks in mat_ctx%mf_temp_mat
+      ! match the block of rhs, x_mat, we've been given
+      ! Slots 1 to n_temps are created (MF_MAT_TEMP, MF_MAT_TEMP_TWO, MF_MAT_TEMP_THREE)
+      ! and the optional need_rhs also creates the MF_MAT_RHS slot, which is where the
+      ! diagonally scaled block applies store D^-1 X
+      ! We can't just always create all four, as the number of temporaries needed
+      ! depends on the polynomial being applied and these blocks aren't small
+
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      ! Input
+      type(mat_ctxtype), intent(inout) :: mat_ctx
+      type(tMat), intent(in)           :: x_mat
+      integer, intent(in)              :: n_temps
+      PetscErrorCode, intent(inout)    :: ierr
+      logical, optional, intent(in)    :: need_rhs
+
+      ! Local
+      integer :: i_loc
+      logical :: rebuild, want_rhs
+      PetscInt :: global_rows, global_cols
+      MatType :: x_type, temp_type
+
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      want_rhs = .FALSE.
+      if (present(need_rhs)) want_rhs = need_rhs
+
+      call MatGetSize(x_mat, global_rows, global_cols, ierr)
+      call MatGetType(x_mat, x_type, ierr)
+
+      ! If the number of columns has changed we have to start again
+      rebuild = mat_ctx%mf_temp_mat_ncols /= global_cols
+
+      ! The type of block we're given can also change between applies
+      if (.NOT. rebuild) then
+         do i_loc = 1, size(mat_ctx%mf_temp_mat)
+            if (.NOT. PetscObjectIsNull(mat_ctx%mf_temp_mat(i_loc))) then
+               call MatGetType(mat_ctx%mf_temp_mat(i_loc), temp_type, ierr)
+               if (temp_type /= x_type) rebuild = .TRUE.
+               exit
+            end if
+         end do
+      end if
+
+      if (rebuild) then
+         do i_loc = 1, size(mat_ctx%mf_temp_mat)
+            if (.NOT. PetscObjectIsNull(mat_ctx%mf_temp_mat(i_loc))) then
+               call MatDestroy(mat_ctx%mf_temp_mat(i_loc), ierr)
+            end if
+         end do
+         mat_ctx%mf_temp_mat_ncols = -1
+      end if
+
+      ! Now create any of the slots we need that don't exist
+      do i_loc = 1, n_temps
+         if (PetscObjectIsNull(mat_ctx%mf_temp_mat(i_loc))) then
+            call MatDuplicate(x_mat, MAT_DO_NOT_COPY_VALUES, mat_ctx%mf_temp_mat(i_loc), ierr)
+         end if
+      end do
+      if (want_rhs) then
+         if (PetscObjectIsNull(mat_ctx%mf_temp_mat(MF_MAT_RHS))) then
+            call MatDuplicate(x_mat, MAT_DO_NOT_COPY_VALUES, mat_ctx%mf_temp_mat(MF_MAT_RHS), ierr)
+         end if
+      end if
+
+      mat_ctx%mf_temp_mat_ncols = global_cols
+
+   end subroutine ensure_block_temp_mats
+
+! -------------------------------------------------------------------------------------------------------------------------------
 
 end module matshell_data_type
 

--- a/src/Matshell_Data_Type.F90
+++ b/src/Matshell_Data_Type.F90
@@ -71,6 +71,7 @@ module matshell_data_type
       logical :: rebuild, want_rhs
       PetscInt :: global_rows, global_cols
       MatType :: x_type, temp_type
+      type(tMat) :: temp_mat
 
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -86,8 +87,9 @@ module matshell_data_type
       ! The type of block we're given can also change between applies
       if (.NOT. rebuild) then
          do i_loc = 1, size(mat_ctx%mf_temp_mat)
-            if (.NOT. PetscObjectIsNull(mat_ctx%mf_temp_mat(i_loc))) then
-               call MatGetType(mat_ctx%mf_temp_mat(i_loc), temp_type, ierr)
+            temp_mat = mat_ctx%mf_temp_mat(i_loc)
+            if (.NOT. PetscObjectIsNull(temp_mat)) then
+               call MatGetType(temp_mat, temp_type, ierr)
                if (temp_type /= x_type) rebuild = .TRUE.
                exit
             end if
@@ -96,8 +98,9 @@ module matshell_data_type
 
       if (rebuild) then
          do i_loc = 1, size(mat_ctx%mf_temp_mat)
-            if (.NOT. PetscObjectIsNull(mat_ctx%mf_temp_mat(i_loc))) then
-               call MatDestroy(mat_ctx%mf_temp_mat(i_loc), ierr)
+            temp_mat = mat_ctx%mf_temp_mat(i_loc)
+            if (.NOT. PetscObjectIsNull(temp_mat)) then
+               call MatDestroy(temp_mat, ierr)
             end if
          end do
          mat_ctx%mf_temp_mat_ncols = -1
@@ -105,12 +108,14 @@ module matshell_data_type
 
       ! Now create any of the slots we need that don't exist
       do i_loc = 1, n_temps
-         if (PetscObjectIsNull(mat_ctx%mf_temp_mat(i_loc))) then
+         temp_mat = mat_ctx%mf_temp_mat(i_loc)
+         if (PetscObjectIsNull(temp_mat)) then
             call MatDuplicate(x_mat, MAT_DO_NOT_COPY_VALUES, mat_ctx%mf_temp_mat(i_loc), ierr)
          end if
       end do
       if (want_rhs) then
-         if (PetscObjectIsNull(mat_ctx%mf_temp_mat(MF_MAT_RHS))) then
+         temp_mat = mat_ctx%mf_temp_mat(MF_MAT_RHS)
+         if (PetscObjectIsNull(temp_mat)) then
             call MatDuplicate(x_mat, MAT_DO_NOT_COPY_VALUES, mat_ctx%mf_temp_mat(MF_MAT_RHS), ierr)
          end if
       end if

--- a/src/Matshell_Data_Type.F90
+++ b/src/Matshell_Data_Type.F90
@@ -23,6 +23,9 @@ module matshell_data_type
       PetscReal, dimension(:), pointer :: real_roots => null()
       PetscReal, dimension(:), pointer :: imag_roots => null()
       type(tMat) :: mat, mat_scaled
+      ! Whether the inner mat_scaled shell applies I - D^-1 A (the Neumann polynomial)
+      ! rather than D^-1 A (the diagonally scaled gmres polynomials)
+      logical :: neumann_inner = .FALSE.
       ! Temporary vectors we use
       type(tVec), dimension(5) :: mf_temp_vec
       ! Temporary dense matrices we use during a multiple rhs (block) apply

--- a/src/Matshell_Data_Type.F90
+++ b/src/Matshell_Data_Type.F90
@@ -101,6 +101,10 @@ module matshell_data_type
             temp_mat = mat_ctx%mf_temp_mat(i_loc)
             if (.NOT. PetscObjectIsNull(temp_mat)) then
                call MatDestroy(temp_mat, ierr)
+               ! MatDestroy nulls the local copy of the handle, not the slot in the
+               ! context - copy it back or the slot would be left dangling and the
+               ! creation below would skip it
+               mat_ctx%mf_temp_mat(i_loc) = temp_mat
             end if
          end do
          mat_ctx%mf_temp_mat_ncols = -1

--- a/src/Neumann_Poly.F90
+++ b/src/Neumann_Poly.F90
@@ -113,7 +113,10 @@ module neumann_poly
             ! A Neumann polynomial has coefficients of 1
             mat_ctx%coefficients => coefficients
             ! mat_ctx owns the heap-allocated coefficients array and must free it on cleanup
-            mat_ctx%own_coefficients = .TRUE.                      
+            mat_ctx%own_coefficients = .TRUE.
+            ! The inner matshell we build below applies I - D^-1 A rather than D^-1 A
+            ! This is what tells the block (multiple rhs) apply which arithmetic to use
+            mat_ctx%neumann_inner = .TRUE.
 
             ! Create the matshell
             call MatCreateShell(MPI_COMM_MATRIX, local_rows, local_cols, global_rows, global_cols, &

--- a/src/Neumann_Poly.F90
+++ b/src/Neumann_Poly.F90
@@ -173,10 +173,11 @@ module neumann_poly
             mat_ctx%coefficients => null()
          end if
 
-         ! The matshell points at the caller's coefficient storage (all ones) and
-         ! owns it - it is freed by deallocate in reset_inverse_mat
+         ! The matshell points at the caller's coefficient storage (all ones)
+         ! Ownership is the caller's decision, exactly as with the gmres builders:
+         ! calculate_and_build_approximate_inverse sets own_coefficients after we
+         ! return, and for PCAIR it stays .FALSE. as PCAIR manages its own storage
          mat_ctx%coefficients => coefficients
-         mat_ctx%own_coefficients = .TRUE.
          mat_ctx_scaled%coefficients => coefficients
 
          ! This is the matrix whose inverse we are applying (just copying the pointer here)

--- a/src/Neumann_Poly.F90
+++ b/src/Neumann_Poly.F90
@@ -57,26 +57,30 @@ module neumann_poly
 ! -------------------------------------------------------------------------------------------------------------------------------
 
    subroutine calculate_and_build_neumann_polynomial_inverse(matrix, poly_order, &
-                  buffers, poly_sparsity_order, matrix_free, reuse_mat, reuse_submatrices, inv_matrix)
+                  buffers, coefficients, poly_sparsity_order, matrix_free, &
+                  reuse_mat, reuse_submatrices, inv_matrix)
 
 
       ! Builds an assembled neumann polynomial approximate inverse
       ! If poly_sparsity_order < poly_order it will build a fixed sparsity approximation
       ! Scales by the diagonal and applies the scaled diagonal to the rhs of the output
       ! so it can be used
+      ! The coefficients passed in must all be one (the caller sets this) - the matshell
+      ! points at this storage in the matrix-free case, exactly like the gmres builders,
+      ! so the ownership rules in calculate_and_build_approximate_inverse hold for all
+      ! the polynomial types
 
       ! ~~~~~~
       type(tMat), target, intent(in)      :: matrix
       integer, intent(in)                 :: poly_order
       type(tsqr_buffers), intent(inout)   :: buffers
+      PetscReal, dimension(:), target, intent(inout) :: coefficients
       integer, intent(in)                 :: poly_sparsity_order
       logical, intent(in)                 :: matrix_free
       type(tMat), intent(inout)           :: reuse_mat, inv_matrix
       type(tMat), dimension(:), pointer, intent(inout)   :: reuse_submatrices
 
       ! Local variables
-      PetscReal, dimension(:), pointer :: coefficients
-      PetscReal, dimension(poly_order + 1), target :: coefficients_stack
       integer :: comm_size, errorcode
       PetscErrorCode :: ierr
       MPIU_Comm :: MPI_COMM_MATRIX
@@ -105,15 +109,8 @@ module neumann_poly
          ! If not re-using
          if (PetscObjectIsNull(inv_matrix)) then
 
-            allocate(coefficients(poly_order + 1))
-            coefficients = 1d0
-
             ! Have to dynamically allocate this
             allocate(mat_ctx)
-            ! A Neumann polynomial has coefficients of 1
-            mat_ctx%coefficients => coefficients
-            ! mat_ctx owns the heap-allocated coefficients array and must free it on cleanup
-            mat_ctx%own_coefficients = .TRUE.
             ! The inner matshell we build below applies I - D^-1 A rather than D^-1 A
             ! This is what tells the block (multiple rhs) apply which arithmetic to use
             mat_ctx%neumann_inner = .TRUE.
@@ -143,8 +140,7 @@ module neumann_poly
 
             ! Have to dynamically allocate this
             allocate(mat_ctx_scaled)
-            mat_ctx_scaled%coefficients => coefficients                     
-            
+
             ! Create the matshell
             call MatCreateShell(MPI_COMM_MATRIX, local_rows, local_cols, global_rows, global_cols, &
                         mat_ctx_scaled, mat_ctx%mat_scaled, ierr)
@@ -169,20 +165,32 @@ module neumann_poly
 
          end if
 
+         ! Free old owned coefficients before reassigning, exactly as the gmres
+         ! builders do - avoids a memory leak when the same matshell is reused across
+         ! PCSetUp calls (SAME_NONZERO_PATTERN) but fresh coefficients are passed in
+         if (mat_ctx%own_coefficients .AND. associated(mat_ctx%coefficients)) then
+            deallocate(mat_ctx%coefficients)
+            mat_ctx%coefficients => null()
+         end if
+
+         ! The matshell points at the caller's coefficient storage (all ones) and
+         ! owns it - it is freed by deallocate in reset_inverse_mat
+         mat_ctx%coefficients => coefficients
+         mat_ctx%own_coefficients = .TRUE.
+         mat_ctx_scaled%coefficients => coefficients
+
          ! This is the matrix whose inverse we are applying (just copying the pointer here)
-         mat_ctx%mat = matrix 
-         mat_ctx_scaled%mat = matrix 
+         mat_ctx%mat = matrix
+         mat_ctx_scaled%mat = matrix
 
          ! Get the diagonal
-         call MatGetDiagonal(matrix, mat_ctx%mf_temp_vec(MF_VEC_DIAG), ierr)    
+         call MatGetDiagonal(matrix, mat_ctx%mf_temp_vec(MF_VEC_DIAG), ierr)
          mat_ctx_scaled%mf_temp_vec(MF_VEC_DIAG) = mat_ctx%mf_temp_vec(MF_VEC_DIAG)
 
       ! If not matrix free
       else
 
-         coefficients => coefficients_stack
-         ! A Neumann polynomial has coefficients of 1
-         coefficients = 1d0 
+         ! The coefficients we've been passed are already all one
 
          ! Need to build an assembled I - D^-1 A
          call MatDuplicate(matrix, MAT_COPY_VALUES, temp_mat, ierr)

--- a/src/PCPFLAREINV.c
+++ b/src/PCPFLAREINV.c
@@ -20,10 +20,10 @@ PETSC_EXTERN void calculate_and_build_approximate_inverse_c(Mat *input_mat, Pets
                      PetscInt subcomm_int, \
                      PetscReal **coeffs_ptr, PetscInt *row_size, PetscInt *col_size, \
                      Mat *inv_matrix);
-// Block (multiple rhs) apply of a matrix-free gmres polynomial matshell, Y = q(A) X.
+// Block (multiple rhs) apply of a matrix-free polynomial matshell, Y = q(A) X.
 // *applied comes back 0 if no block apply was possible and the caller has to apply
-// column by column instead. Only valid for the power/arnoldi/newton matshells - see
-// the warning in shell_poly_block_apply (Gmres_Poly_Newton.F90).
+// column by column instead - that includes being handed a matshell whose context
+// isn't one of the polynomials shell_poly_block_apply (Gmres_Poly_Newton.F90) knows.
 PETSC_EXTERN void pflareinv_shell_block_matapply_c(Mat *mat, Mat *X, Mat *Y, int *applied);
 
 // The types available as approximate inverses are (see include/pflare.h):
@@ -643,15 +643,17 @@ static PetscErrorCode PCMatApply_PFLAREINV_c(PC pc, Mat X, Mat Y)
 
    if (inv_data->matrix_free) {
       // mat_inverse is a MatShell with only MATOP_MULT registered, so MatMatMult on it
-      // would fail. The gmres polynomial matshells can however be applied blockwise by
+      // would fail. The polynomial matshells can however be applied blockwise by
       // doing the products with the underlying matrix - the Fortran routine below does
       // that and reports whether it managed it.
-      // The family gate here is load bearing: the Neumann matshell shares the diagonally
-      // scaled handler of the gmres polynomials but applies different arithmetic, so it
-      // must never be sent to the block kernels (see shell_poly_block_apply).
+      // The gate here is just the list of families that have a block kernel - it isn't
+      // load bearing for correctness, shell_poly_block_apply works out which arithmetic
+      // to use from the matshell's context and reports back if it can't do the apply
+      // (the two Jacobi types are never matrix-free anyway).
       int applied = 0;
       if (inv_data->inverse_type == PFLAREINV_POWER || inv_data->inverse_type == PFLAREINV_ARNOLDI || \
-          inv_data->inverse_type == PFLAREINV_NEWTON || inv_data->inverse_type == PFLAREINV_NEWTON_NO_EXTRA)
+          inv_data->inverse_type == PFLAREINV_NEWTON || inv_data->inverse_type == PFLAREINV_NEWTON_NO_EXTRA || \
+          inv_data->inverse_type == PFLAREINV_NEUMANN)
       {
          pflareinv_shell_block_matapply_c(&(inv_data->mat_inverse), &X, &Y, &applied);
       }

--- a/src/PCPFLAREINV.c
+++ b/src/PCPFLAREINV.c
@@ -20,6 +20,11 @@ PETSC_EXTERN void calculate_and_build_approximate_inverse_c(Mat *input_mat, Pets
                      PetscInt subcomm_int, \
                      PetscReal **coeffs_ptr, PetscInt *row_size, PetscInt *col_size, \
                      Mat *inv_matrix);
+// Block (multiple rhs) apply of a matrix-free gmres polynomial matshell, Y = q(A) X.
+// *applied comes back 0 if no block apply was possible and the caller has to apply
+// column by column instead. Only valid for the power/arnoldi/newton matshells - see
+// the warning in shell_poly_block_apply (Gmres_Poly_Newton.F90).
+PETSC_EXTERN void pflareinv_shell_block_matapply_c(Mat *mat, Mat *X, Mat *Y, int *applied);
 
 // The types available as approximate inverses are (see include/pflare.h):
 //
@@ -637,17 +642,35 @@ static PetscErrorCode PCMatApply_PFLAREINV_c(PC pc, Mat X, Mat Y)
    inv_data = (PC_PFLAREINV *)pc->data;
 
    if (inv_data->matrix_free) {
-      // mat_inverse is a MatShell with only MATOP_MULT registered,
-      // so MatMatMult on it would fail. Apply column-by-column.
-      PetscInt n_cols, j;
-      Vec cx, cy;
-      PetscCall(MatGetSize(X, NULL, &n_cols));
-      for (j = 0; j < n_cols; j++) {
-         PetscCall(MatDenseGetColumnVecRead(X, j, &cx));
-         PetscCall(MatDenseGetColumnVecWrite(Y, j, &cy));
-         PetscCall(MatMult(inv_data->mat_inverse, cx, cy));
-         PetscCall(MatDenseRestoreColumnVecWrite(Y, j, &cy));
-         PetscCall(MatDenseRestoreColumnVecRead(X, j, &cx));
+      // mat_inverse is a MatShell with only MATOP_MULT registered, so MatMatMult on it
+      // would fail. The gmres polynomial matshells can however be applied blockwise by
+      // doing the products with the underlying matrix - the Fortran routine below does
+      // that and reports whether it managed it.
+      // The family gate here is load bearing: the Neumann matshell shares the diagonally
+      // scaled handler of the gmres polynomials but applies different arithmetic, so it
+      // must never be sent to the block kernels (see shell_poly_block_apply).
+      int applied = 0;
+      if (inv_data->inverse_type == PFLAREINV_POWER || inv_data->inverse_type == PFLAREINV_ARNOLDI || \
+          inv_data->inverse_type == PFLAREINV_NEWTON || inv_data->inverse_type == PFLAREINV_NEWTON_NO_EXTRA)
+      {
+         pflareinv_shell_block_matapply_c(&(inv_data->mat_inverse), &X, &Y, &applied);
+      }
+
+      if (applied) {
+         PetscCall(PetscInfo(pc, "matrix-free PCMatApply used the block polynomial kernel\n"));
+      } else {
+         // Anything we can't do blockwise is applied column-by-column.
+         PetscInt n_cols, j;
+         Vec cx, cy;
+         PetscCall(PetscInfo(pc, "matrix-free PCMatApply solving column by column\n"));
+         PetscCall(MatGetSize(X, NULL, &n_cols));
+         for (j = 0; j < n_cols; j++) {
+            PetscCall(MatDenseGetColumnVecRead(X, j, &cx));
+            PetscCall(MatDenseGetColumnVecWrite(Y, j, &cy));
+            PetscCall(MatMult(inv_data->mat_inverse, cx, cy));
+            PetscCall(MatDenseRestoreColumnVecWrite(Y, j, &cy));
+            PetscCall(MatDenseRestoreColumnVecRead(X, j, &cx));
+         }
       }
    } else {
       // Assembled inverse: real SpMM via MatProduct.

--- a/src/PCPFLAREINV.c
+++ b/src/PCPFLAREINV.c
@@ -627,6 +627,43 @@ static PetscErrorCode PCApply_PFLAREINV_c(PC pc, Vec x, Vec y)
 
 // ~~~~~~~~~~
 
+// Multi-RHS apply: Y = mat_inverse * X for dense X, Y.
+// Lets KSPMatSolve / PCMatApply hit a real SpMM (cuSPARSE/hipSPARSE/Kokkos/CPU
+// AIJxDense) instead of PETSc's default column-by-column PCApply fallback.
+static PetscErrorCode PCMatApply_PFLAREINV_c(PC pc, Mat X, Mat Y)
+{
+   PC_PFLAREINV *inv_data;
+   PetscFunctionBegin;
+   inv_data = (PC_PFLAREINV *)pc->data;
+
+   if (inv_data->matrix_free) {
+      // mat_inverse is a MatShell with only MATOP_MULT registered,
+      // so MatMatMult on it would fail. Apply column-by-column.
+      PetscInt n_cols, j;
+      Vec cx, cy;
+      PetscCall(MatGetSize(X, NULL, &n_cols));
+      for (j = 0; j < n_cols; j++) {
+         PetscCall(MatDenseGetColumnVecRead(X, j, &cx));
+         PetscCall(MatDenseGetColumnVecWrite(Y, j, &cy));
+         PetscCall(MatMult(inv_data->mat_inverse, cx, cy));
+         PetscCall(MatDenseRestoreColumnVecWrite(Y, j, &cy));
+         PetscCall(MatDenseRestoreColumnVecRead(X, j, &cx));
+      }
+   } else {
+      // Assembled inverse: real SpMM via MatProduct.
+      PetscCall(MatProductCreateWithMat(inv_data->mat_inverse, X, NULL, Y));
+      PetscCall(MatProductSetType(Y, MATPRODUCT_AB));
+      PetscCall(MatProductSetFromOptions(Y));
+      PetscCall(MatProductSymbolic(Y));
+      PetscCall(MatProductNumeric(Y));
+      // Drop product bookkeeping so Y doesn't retain refs to mat_inverse, X.
+      PetscCall(MatProductClear(Y));
+   }
+   PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+// ~~~~~~~~~~
+
 static PetscErrorCode PCDestroy_PFLAREINV_c(PC pc)
 {
    PC_PFLAREINV *inv_data;
@@ -926,6 +963,7 @@ PETSC_EXTERN PetscErrorCode PCCreate_PFLAREINV(PC pc)
 
    // Set the method functions
    pc->ops->apply               = PCApply_PFLAREINV_c;
+   pc->ops->matapply            = PCMatApply_PFLAREINV_c;
    pc->ops->setup               = PCSetUp_PFLAREINV_c;
    pc->ops->destroy             = PCDestroy_PFLAREINV_c;
    pc->ops->view                = PCView_PFLAREINV_c;  

--- a/src/Pflare_Parameters.F90
+++ b/src/Pflare_Parameters.F90
@@ -103,6 +103,16 @@ module pflare_parameters
    integer, parameter :: MF_VEC_RHS        = 5
 
    ! --------------------------------------------------------
+   ! MatShell temporary dense matrix slot indices   (from matshell_data_type)
+   ! These are the scratch dense blocks used by the multiple rhs (block)
+   ! matrix-free polynomial applies
+   ! --------------------------------------------------------
+   integer, parameter :: MF_MAT_TEMP       = 1
+   integer, parameter :: MF_MAT_TEMP_TWO   = 2
+   integer, parameter :: MF_MAT_TEMP_THREE = 3
+   integer, parameter :: MF_MAT_RHS        = 4
+
+   ! --------------------------------------------------------
    ! Timer IDs   (from timers)
    ! --------------------------------------------------------
    integer, parameter :: TIMER_ID_AIR_SETUP        = 1

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -540,6 +540,14 @@ run_tests_no_load_short_serial:
 	 -pc_air_a_drop 1e-3 -pc_air_inverse_type power
 #
 	@echo ""
+	@echo "Test multiple RHS block solve with PCPFLAREINV via PCMatApply"
+	./adv_1d_multi_rhs -n 1000 -nrhs 5
+	@echo "Test multiple RHS block solve with a Newton polynomial PCPFLAREINV"
+	./adv_1d_multi_rhs -n 1000 -nrhs 5 -pc_pflareinv_type newton
+	@echo "Test multiple RHS block solve with matrix-free PCPFLAREINV"
+	./adv_1d_multi_rhs -n 1000 -nrhs 5 -pc_pflareinv_matrix_free
+#
+	@echo ""
 	@echo "Test 3D upwind finite-difference"
 	./adv_diff_fd -dim 3 -da_grid_x 10 -da_grid_y 10 -da_grid_z 10 -pc_type air -ksp_pc_side right \
 	 -ksp_rtol $(KSP_RTOL) -ksp_atol 1e-50 -pc_air_a_lump -ksp_max_it 4
@@ -971,6 +979,12 @@ else
 	$(MPIEXEC) -n 2 ./adv_1d -n 1000 -ksp_rtol $(KSP_RTOL) -ksp_atol 1e-50 -ksp_pc_side right \
 	 -pc_air_coarsest_inverse_type newton -pc_air_coarsest_poly_order 10 -pc_air_coarsest_matrix_free_polys -ksp_max_it 10 \
 	 -pc_air_a_drop 1e-3 -pc_air_inverse_type power
+#
+	@echo ""
+	@echo "Test multiple RHS block solve with PCPFLAREINV via PCMatApply in parallel"
+	$(MPIEXEC) -n 2 ./adv_1d_multi_rhs -n 1000 -nrhs 5
+	@echo "Test multiple RHS block solve with matrix-free PCPFLAREINV in parallel"
+	$(MPIEXEC) -n 2 ./adv_1d_multi_rhs -n 1000 -nrhs 5 -pc_pflareinv_matrix_free
 #
 	@echo ""
 	@echo "Test 3D upwind finite-difference in parallel"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -553,10 +553,14 @@ run_tests_no_load_short_serial:
 	@echo "Test multiple RHS block solve with a matrix-free Newton no extra PCPFLAREINV"
 	./adv_1d_multi_rhs -n 1000 -nrhs 5 -pc_pflareinv_matrix_free -pc_pflareinv_type newton_no_extra \
 	 -pc_pflareinv_poly_order 10
+	@echo "Test multiple RHS block solve with a matrix-free Neumann PCPFLAREINV"
+	./adv_1d_multi_rhs -n 1000 -nrhs 5 -pc_pflareinv_matrix_free -pc_pflareinv_type neumann
 	@echo "Test the block apply of the matrix-free Arnoldi matshell directly, plain and diagonally scaled"
 	./shell_block_apply -n 1000 -nrhs 5 -inverse_type 1
 	@echo "Test the block apply of the matrix-free Newton matshell directly, plain and diagonally scaled"
 	./shell_block_apply -n 1000 -nrhs 5 -inverse_type 2
+	@echo "Test the block apply of the matrix-free Neumann matshell directly"
+	./shell_block_apply -n 1000 -nrhs 5 -inverse_type 4
 #
 	@echo ""
 	@echo "Test 3D upwind finite-difference"
@@ -1002,6 +1006,8 @@ else
 	$(MPIEXEC) -n 2 ./shell_block_apply -n 1000 -nrhs 5 -inverse_type 1
 	@echo "Test the block apply of the matrix-free Newton matshell directly in parallel, plain and diagonally scaled"
 	$(MPIEXEC) -n 2 ./shell_block_apply -n 1000 -nrhs 5 -inverse_type 2
+	@echo "Test the block apply of the matrix-free Neumann matshell directly in parallel"
+	$(MPIEXEC) -n 2 ./shell_block_apply -n 1000 -nrhs 5 -inverse_type 4
 #
 	@echo ""
 	@echo "Test 3D upwind finite-difference in parallel"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -546,6 +546,10 @@ run_tests_no_load_short_serial:
 	./adv_1d_multi_rhs -n 1000 -nrhs 5 -pc_pflareinv_type newton
 	@echo "Test multiple RHS block solve with matrix-free PCPFLAREINV"
 	./adv_1d_multi_rhs -n 1000 -nrhs 5 -pc_pflareinv_matrix_free
+	@echo "Test multiple RHS block solve with a matrix-free Arnoldi PCPFLAREINV"
+	./adv_1d_multi_rhs -n 1000 -nrhs 5 -pc_pflareinv_matrix_free -pc_pflareinv_type arnoldi
+	@echo "Test the block apply of the matrix-free Arnoldi matshell directly, plain and diagonally scaled"
+	./shell_block_apply -n 1000 -nrhs 5 -inverse_type 1
 #
 	@echo ""
 	@echo "Test 3D upwind finite-difference"
@@ -985,6 +989,8 @@ else
 	$(MPIEXEC) -n 2 ./adv_1d_multi_rhs -n 1000 -nrhs 5
 	@echo "Test multiple RHS block solve with matrix-free PCPFLAREINV in parallel"
 	$(MPIEXEC) -n 2 ./adv_1d_multi_rhs -n 1000 -nrhs 5 -pc_pflareinv_matrix_free
+	@echo "Test the block apply of the matrix-free Arnoldi matshell directly in parallel, plain and diagonally scaled"
+	$(MPIEXEC) -n 2 ./shell_block_apply -n 1000 -nrhs 5 -inverse_type 1
 #
 	@echo ""
 	@echo "Test 3D upwind finite-difference in parallel"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -548,8 +548,15 @@ run_tests_no_load_short_serial:
 	./adv_1d_multi_rhs -n 1000 -nrhs 5 -pc_pflareinv_matrix_free
 	@echo "Test multiple RHS block solve with a matrix-free Arnoldi PCPFLAREINV"
 	./adv_1d_multi_rhs -n 1000 -nrhs 5 -pc_pflareinv_matrix_free -pc_pflareinv_type arnoldi
+	@echo "Test multiple RHS block solve with a matrix-free Newton PCPFLAREINV"
+	./adv_1d_multi_rhs -n 1000 -nrhs 5 -pc_pflareinv_matrix_free -pc_pflareinv_type newton
+	@echo "Test multiple RHS block solve with a matrix-free Newton no extra PCPFLAREINV"
+	./adv_1d_multi_rhs -n 1000 -nrhs 5 -pc_pflareinv_matrix_free -pc_pflareinv_type newton_no_extra \
+	 -pc_pflareinv_poly_order 10
 	@echo "Test the block apply of the matrix-free Arnoldi matshell directly, plain and diagonally scaled"
 	./shell_block_apply -n 1000 -nrhs 5 -inverse_type 1
+	@echo "Test the block apply of the matrix-free Newton matshell directly, plain and diagonally scaled"
+	./shell_block_apply -n 1000 -nrhs 5 -inverse_type 2
 #
 	@echo ""
 	@echo "Test 3D upwind finite-difference"
@@ -989,8 +996,12 @@ else
 	$(MPIEXEC) -n 2 ./adv_1d_multi_rhs -n 1000 -nrhs 5
 	@echo "Test multiple RHS block solve with matrix-free PCPFLAREINV in parallel"
 	$(MPIEXEC) -n 2 ./adv_1d_multi_rhs -n 1000 -nrhs 5 -pc_pflareinv_matrix_free
+	@echo "Test multiple RHS block solve with a matrix-free Newton PCPFLAREINV in parallel"
+	$(MPIEXEC) -n 2 ./adv_1d_multi_rhs -n 1000 -nrhs 5 -pc_pflareinv_matrix_free -pc_pflareinv_type newton
 	@echo "Test the block apply of the matrix-free Arnoldi matshell directly in parallel, plain and diagonally scaled"
 	$(MPIEXEC) -n 2 ./shell_block_apply -n 1000 -nrhs 5 -inverse_type 1
+	@echo "Test the block apply of the matrix-free Newton matshell directly in parallel, plain and diagonally scaled"
+	$(MPIEXEC) -n 2 ./shell_block_apply -n 1000 -nrhs 5 -inverse_type 2
 #
 	@echo ""
 	@echo "Test 3D upwind finite-difference in parallel"

--- a/tests/adv_1d_multi_rhs.c
+++ b/tests/adv_1d_multi_rhs.c
@@ -1,0 +1,253 @@
+static char help[] = "Solves a one-dimensional steady upwind advection system with multiple right-hand sides using KSPMatSolve.\n\n";
+
+/*
+  A multiple right-hand side version of adv_1d.c, built so the whole solve can
+  stay on the device: the block of right-hand sides is created with
+  MatCreateDenseFromVecType() using the vector type of the operator, so a
+  -mat_type aijkokkos operator gives a device dense block.
+
+    ./adv_1d_multi_rhs -n 100000 -nrhs 16 -mat_type aijkokkos -vec_type kokkos -log_view
+
+  Include "petscksp.h" so that we can use KSP solvers.  Note that this file
+  automatically includes:
+     petscsys.h    - base PETSc routines   petscvec.h - vectors
+     petscmat.h    - matrices              petscpc.h  - preconditioners
+     petscis.h     - index sets
+     petscviewer.h - viewers
+*/
+#include <petscksp.h>
+#include "pflare.h"
+
+// Tolerance for the comparison against the column-by-column reference solve
+#if defined(PETSC_USE_REAL_SINGLE)
+  #define DEFAULT_CHECK_TOL 1e-5
+#else
+  #define DEFAULT_CHECK_TOL 1e-10
+#endif
+
+int main(int argc, char **args)
+{
+  Vec         x;              /* only used to get the parallel layout */
+  Mat         A;              /* linear system matrix */
+  Mat         B, X, Xref;     /* block of rhs, block of solutions, reference solutions */
+  KSP         ksp;            /* linear solver context */
+  PC          pc;             /* preconditioner context */
+  VecType     vtype;
+  PetscInt    i, j, n = 100, nrhs = 5, global_row_start, global_row_end_plus_one, local_size;
+  PetscInt    start_assign;
+  PetscCount  counter;
+  PetscReal   check_tol = DEFAULT_CHECK_TOL, diff_norm, x_norm;
+  KSPConvergedReason reason;
+  PetscLogStage setup, gpu_copy, matsolve, reference;
+
+  PetscFunctionBeginUser;
+  PetscCall(PetscInitialize(&argc, &args, (char*)0, help));
+
+  PetscCall(PetscOptionsGetInt(NULL, NULL, "-n", &n, NULL));
+  PetscCall(PetscOptionsGetInt(NULL, NULL, "-nrhs", &nrhs, NULL));
+  PetscCall(PetscOptionsGetReal(NULL, NULL, "-check_tol", &check_tol, NULL));
+  PetscBool second_solve = PETSC_FALSE;
+  PetscCall(PetscOptionsGetBool(NULL, NULL, "-second_solve", &second_solve, NULL));
+  PetscBool check = PETSC_TRUE;
+  PetscCall(PetscOptionsGetBool(NULL, NULL, "-check", &check, NULL));
+
+  // Register the pflare types
+  PCRegister_PFLARE();
+
+  PetscCall(PetscLogStageRegister("Setup", &setup));
+  PetscCall(PetscLogStageRegister("GPU copy stage - triggered by a prelim KSPMatSolve", &gpu_copy));
+  PetscCall(PetscLogStageRegister("MatSolve - the timed multiple rhs solve", &matsolve));
+  PetscCall(PetscLogStageRegister("Column-by-column reference solve", &reference));
+
+  /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+         Compute the matrix and the block of right-hand sides that define
+         the linear systems, A X = B.
+     - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+  /*
+     Create a vector purely to get the parallel layout - the solve itself only
+     uses the dense blocks below.
+  */
+  PetscCall(VecCreate(PETSC_COMM_WORLD, &x));
+  PetscCall(VecSetSizes(x, PETSC_DECIDE, n));
+  PetscCall(VecSetFromOptions(x));
+  PetscCall(VecGetLocalSize(x, &local_size));
+  PetscCall(VecGetOwnershipRange(x, &global_row_start, &global_row_end_plus_one));
+  PetscCall(VecDestroy(&x));
+
+  // Row and column indices for COO assembly
+  PetscInt *oor, *ooc;
+  // Values for COO assembly
+  PetscScalar *v;
+
+  PetscCall(MatCreate(PETSC_COMM_WORLD, &A));
+  PetscCall(MatSetSizes(A, local_size, local_size, n, n));
+  PetscCall(MatSetFromOptions(A));
+
+  // Going to do assembly in the COO interface so assembly happens on the gpu when needed
+  // Allocate memory for the coordinates
+  PetscCall(PetscMalloc2(2 * local_size, &oor, 2 * local_size, &ooc));
+  PetscCall(PetscMalloc1(2 * local_size, &v));
+
+  counter = 0;
+  // Dirichlet condition on left boundary
+  if (global_row_start == 0)
+  {
+      start_assign = 1;
+      oor[counter] = 0;
+      ooc[counter] = 0;
+      v[counter] = 1;
+      counter = counter + 1;
+  }
+  else{
+      start_assign = global_row_start;
+  }
+
+  // Let's write the COO format
+  for (i = start_assign; i < global_row_end_plus_one; i++) {
+    // Upwinded dimensionless uniform grid finite difference operator
+    oor[counter] = i;
+    ooc[counter] = i - 1;
+    v[counter] = -1.0;
+
+    oor[counter + 1] = i;
+    ooc[counter + 1] = i;
+    v[counter + 1] = 1.0;
+
+    counter = counter + 2;
+  }
+
+  // Set the indices
+  PetscCall(MatSetPreallocationCOO(A, counter, oor, ooc));
+  // Can delete oor and ooc now
+  PetscCall(PetscFree2(oor, ooc));
+  // Set the values
+  PetscCall(MatSetValuesCOO(A, v, INSERT_VALUES));
+  PetscCall(PetscFree(v));
+
+  /*
+     Create the dense blocks of right-hand sides and solutions. Taking the vector
+     type from A means a device matrix gives device dense blocks, so nothing has
+     to come back to the host. KSPMatSolve requires B and X to be different
+     matrices of the same type.
+  */
+  PetscCall(MatGetVecType(A, &vtype));
+  PetscCall(MatCreateDenseFromVecType(PETSC_COMM_WORLD, vtype, local_size, PETSC_DECIDE, n, nrhs, PETSC_DECIDE, NULL, &B));
+  PetscCall(MatCreateDenseFromVecType(PETSC_COMM_WORLD, vtype, local_size, PETSC_DECIDE, n, nrhs, PETSC_DECIDE, NULL, &X));
+
+  /*
+     Give each column of B a different constant. We deliberately don't use
+     MatSetRandom as there is no gpu implementation of the vector random and we
+     don't want a copy occuring back to the cpu.
+  */
+  for (j = 0; j < nrhs; j++) {
+    Vec cb;
+    PetscCall(MatDenseGetColumnVecWrite(B, j, &cb));
+    PetscCall(VecSet(cb, 1.0 + (PetscScalar)j));
+    PetscCall(MatDenseRestoreColumnVecWrite(B, j, &cb));
+  }
+
+  /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+                Create the linear solver and set various options
+     - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+  PetscCall(KSPCreate(PETSC_COMM_WORLD, &ksp));
+  PetscCall(KSPSetOperators(ksp, A, A));
+
+  /*
+     KSPMatSolve only does a genuine block solve - that is, one that reaches
+     PCMatApply and hence a sparse matrix by dense matrix product - for
+     KSPPREONLY and KSPHPDDM. Every other KSP type silently falls back to a
+     loop of KSPSolve over the columns of B, so overriding this with -ksp_type
+     turns the block solve back into a column-by-column solve.
+
+     Similarly PCPFLAREINV is the default preconditioner here because it is the
+     PFLARE preconditioner that implements PCMatApply; -pc_type air also runs,
+     but only through the column-by-column fallback.
+
+     No KSPSetInitialGuessNonzero - preonly requires a zero initial guess and
+     KSPMatSolve zeroes X for us anyway.
+  */
+  PetscCall(KSPSetType(ksp, KSPPREONLY));
+  PetscCall(KSPGetPC(ksp, &pc));
+  PetscCall(PCSetType(pc, PCPFLAREINV));
+
+  /*
+    Set runtime options, e.g.,
+        -ksp_type <type> -pc_type <type> -ksp_monitor -ksp_rtol <rtol>
+    These options will override those specified above as long as
+    KSPSetFromOptions() is called _after_ any other customization
+    routines.
+  */
+  PetscCall(KSPSetFromOptions(ksp));
+
+  // Setup the ksp
+  PetscCall(PetscLogStagePush(setup));
+  PetscCall(KSPSetUp(ksp));
+  PetscCall(PetscLogStagePop());
+
+  // Do a preliminary KSPMatSolve so all the copies to the gpu happen
+  PetscCall(PetscLogStagePush(gpu_copy));
+  PetscCall(KSPMatSolve(ksp, B, X));
+  PetscCall(PetscLogStagePop());
+
+  /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+                      Solve the linear systems
+     - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+  PetscCall(PetscLogStagePush(matsolve));
+  PetscCall(KSPMatSolve(ksp, B, X));
+  if (second_solve) PetscCall(KSPMatSolve(ksp, B, X));
+  PetscCall(PetscLogStagePop());
+
+  PetscCall(KSPGetConvergedReason(ksp, &reason));
+
+  /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+       Check the block solve against a column-by-column reference solve.
+       At the default preonly this is comparing PCMatApply against PCApply.
+     - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+  if (check) {
+    PetscCall(MatDuplicate(X, MAT_DO_NOT_COPY_VALUES, &Xref));
+
+    PetscCall(PetscLogStagePush(reference));
+    for (j = 0; j < nrhs; j++) {
+      Vec cb, cx;
+      PetscCall(MatDenseGetColumnVecRead(B, j, &cb));
+      PetscCall(MatDenseGetColumnVecWrite(Xref, j, &cx));
+      PetscCall(VecSet(cx, 0.0));
+      PetscCall(KSPSolve(ksp, cb, cx));
+      PetscCall(MatDenseRestoreColumnVecWrite(Xref, j, &cx));
+      PetscCall(MatDenseRestoreColumnVecRead(B, j, &cb));
+    }
+    PetscCall(PetscLogStagePop());
+
+    PetscCall(MatNorm(X, NORM_FROBENIUS, &x_norm));
+    PetscCall(MatAXPY(Xref, -1.0, X, SAME_NONZERO_PATTERN));
+    PetscCall(MatNorm(Xref, NORM_FROBENIUS, &diff_norm));
+    PetscCheck(diff_norm <= check_tol * x_norm, PETSC_COMM_WORLD, PETSC_ERR_PLIB,
+               "Block solve differs from the column-by-column solve: ||X - Xref||_F = %g, ||X||_F = %g, tolerance %g",
+               (double)diff_norm, (double)x_norm, (double)check_tol);
+
+    PetscCall(MatDestroy(&Xref));
+  }
+
+  /*
+     Free work space.  All PETSc objects should be destroyed when they
+     are no longer needed.
+  */
+  PetscCall(MatDestroy(&B));
+  PetscCall(MatDestroy(&X));
+  PetscCall(MatDestroy(&A));
+  PetscCall(KSPDestroy(&ksp));
+
+  /*
+     Always call PetscFinalize() before exiting a program.  This routine
+       - finalizes the PETSc libraries as well as MPI
+       - provides summary and diagnostic information if certain runtime
+         options are chosen (e.g., -log_view).
+  */
+  PetscCall(PetscFinalize());
+  if (reason < 0)
+  {
+   return 1;
+  }
+  return 0;
+}

--- a/tests/shell_block_apply.c
+++ b/tests/shell_block_apply.c
@@ -1,0 +1,241 @@
+static char help[] = "Tests the multiple rhs (block) apply of the matrix-free GMRES polynomial matshells.\n\n";
+
+/*
+  This drives the block apply of the matrix-free polynomial matshells directly,
+  without a PC in the loop, and checks it against a column-by-column MatMult of
+  the same matshell.
+
+  The reason this exists rather than just going through PCPFLAREINV is the
+  diagonally scaled variant of the polynomials, ie q(D^-1 A) D^-1. PCPFLAREINV
+  deliberately never turns that on (the user may pass in a matshell as the
+  operator, so scaling is left to them), but PCAIR builds its polynomial
+  smoothers that way, so the block kernels have to support it. Here we call
+  calculate_and_build_approximate_inverse_c directly, which does expose the
+  diagonal scaling flag, and test both modes.
+
+    ./shell_block_apply -n 1000 -nrhs 5
+    mpiexec -n 2 ./shell_block_apply -n 1000 -nrhs 5
+
+  The operator is the same 1D upwind advection as adv_1d_multi_rhs.c.
+*/
+#include <petscksp.h>
+#include "pflare.h"
+
+// Tolerance for the comparison against the column-by-column reference apply
+#if defined(PETSC_USE_REAL_SINGLE)
+  #define DEFAULT_CHECK_TOL 1e-5
+#else
+  #define DEFAULT_CHECK_TOL 1e-10
+#endif
+
+// Defined in C_Fortran_Bindings.F90 - these are the same prototypes PCPFLAREINV.c uses
+PETSC_EXTERN void reset_inverse_mat_c(Mat *mat);
+// coeffs_ptr/row_size/col_size are in/out:
+//   *coeffs_ptr == NULL on entry  -> fresh: Fortran allocates, writes c_loc to *coeffs_ptr on return
+//   *coeffs_ptr != NULL on entry  -> reuse: existing coefficients used, polynomial step skipped
+PETSC_EXTERN void calculate_and_build_approximate_inverse_c(Mat *input_mat, PetscInt inverse_type, PetscInt order, \
+                     PetscInt sparsity_order, PetscInt matrix_free_int, PetscInt diag_scale_polys_int, \
+                     PetscInt subcomm_int, \
+                     PetscReal **coeffs_ptr, PetscInt *row_size, PetscInt *col_size, \
+                     Mat *inv_matrix);
+PETSC_EXTERN void pflareinv_shell_block_matapply_c(Mat *mat, Mat *X, Mat *Y, int *applied);
+
+/*
+   Builds the 1D upwind advection operator with a Dirichlet condition on the left
+   boundary, assembled through the COO interface so this works on the device too.
+*/
+static PetscErrorCode BuildAdvectionOperator(PetscInt n, Mat *A_out)
+{
+  Vec          x;
+  Mat          A;
+  PetscInt     i, global_row_start, global_row_end_plus_one, local_size, start_assign;
+  PetscCount   counter;
+  PetscInt    *oor, *ooc;
+  PetscScalar *v;
+
+  PetscFunctionBeginUser;
+
+  /* A vector purely to get the parallel layout */
+  PetscCall(VecCreate(PETSC_COMM_WORLD, &x));
+  PetscCall(VecSetSizes(x, PETSC_DECIDE, n));
+  PetscCall(VecSetFromOptions(x));
+  PetscCall(VecGetLocalSize(x, &local_size));
+  PetscCall(VecGetOwnershipRange(x, &global_row_start, &global_row_end_plus_one));
+  PetscCall(VecDestroy(&x));
+
+  PetscCall(MatCreate(PETSC_COMM_WORLD, &A));
+  PetscCall(MatSetSizes(A, local_size, local_size, n, n));
+  PetscCall(MatSetFromOptions(A));
+
+  PetscCall(PetscMalloc2(2 * local_size, &oor, 2 * local_size, &ooc));
+  PetscCall(PetscMalloc1(2 * local_size, &v));
+
+  counter = 0;
+  // Dirichlet condition on left boundary
+  if (global_row_start == 0) {
+    start_assign = 1;
+    oor[counter] = 0;
+    ooc[counter] = 0;
+    v[counter]   = 1;
+    counter      = counter + 1;
+  } else {
+    start_assign = global_row_start;
+  }
+
+  for (i = start_assign; i < global_row_end_plus_one; i++) {
+    // Upwinded dimensionless uniform grid finite difference operator
+    oor[counter] = i;
+    ooc[counter] = i - 1;
+    v[counter]   = -1.0;
+
+    oor[counter + 1] = i;
+    ooc[counter + 1] = i;
+    v[counter + 1]   = 1.0;
+
+    counter = counter + 2;
+  }
+
+  PetscCall(MatSetPreallocationCOO(A, counter, oor, ooc));
+  PetscCall(PetscFree2(oor, ooc));
+  PetscCall(MatSetValuesCOO(A, v, INSERT_VALUES));
+  PetscCall(PetscFree(v));
+
+  *A_out = A;
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+   Relative Frobenius comparison of a block apply against the reference block
+*/
+static PetscErrorCode CheckBlock(Mat X, Mat Xref, PetscReal check_tol, const char *label)
+{
+  Mat       diff;
+  PetscReal diff_norm, x_norm;
+
+  PetscFunctionBeginUser;
+  PetscCall(MatDuplicate(Xref, MAT_COPY_VALUES, &diff));
+  PetscCall(MatNorm(X, NORM_FROBENIUS, &x_norm));
+  PetscCall(MatAXPY(diff, -1.0, X, SAME_NONZERO_PATTERN));
+  PetscCall(MatNorm(diff, NORM_FROBENIUS, &diff_norm));
+  PetscCheck(diff_norm <= check_tol * x_norm, PETSC_COMM_WORLD, PETSC_ERR_PLIB,
+             "%s: block apply differs from the column-by-column apply: ||X - Xref||_F = %g, ||X||_F = %g, tolerance %g",
+             label, (double)diff_norm, (double)x_norm, (double)check_tol);
+  PetscCall(MatDestroy(&diff));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+   Builds a matrix-free polynomial inverse of A - either the plain q(A) or the
+   right diagonally scaled q(D^-1 A) D^-1 - and checks its block apply
+*/
+static PetscErrorCode RunMode(Mat A, PetscInt inverse_type, PetscInt poly_order, PetscInt nrhs,
+                              PetscInt diag_scale, PetscReal check_tol, const char *label)
+{
+  Mat        inv_shell = NULL;
+  Mat        B, X, Xref;
+  VecType    vtype;
+  PetscReal *coeffs = NULL;
+  PetscInt   coeff_rows = 0, coeff_cols = 0;
+  PetscInt   j, n, local_size;
+  int        applied = 0;
+
+  PetscFunctionBeginUser;
+
+  PetscCall(MatGetSize(A, &n, NULL));
+  PetscCall(MatGetLocalSize(A, &local_size, NULL));
+
+  // Build the matshell. matrix_free = 1, sparsity order is unused matrix-free,
+  // no subcomm. inv_shell must be NULL on entry so a fresh one is built.
+  calculate_and_build_approximate_inverse_c(&A, inverse_type, poly_order, 1, 1, diag_scale, 0, \
+                                            &coeffs, &coeff_rows, &coeff_cols, &inv_shell);
+
+  // Dense blocks of rhs and solutions, taking the vector type from A so a device
+  // matrix gives device dense blocks
+  PetscCall(MatGetVecType(A, &vtype));
+  PetscCall(MatCreateDenseFromVecType(PETSC_COMM_WORLD, vtype, local_size, PETSC_DECIDE, n, nrhs, PETSC_DECIDE, NULL, &B));
+  PetscCall(MatCreateDenseFromVecType(PETSC_COMM_WORLD, vtype, local_size, PETSC_DECIDE, n, nrhs, PETSC_DECIDE, NULL, &X));
+  PetscCall(MatDuplicate(X, MAT_DO_NOT_COPY_VALUES, &Xref));
+
+  // Give each column of B a different constant
+  for (j = 0; j < nrhs; j++) {
+    Vec cb;
+    PetscCall(MatDenseGetColumnVecWrite(B, j, &cb));
+    PetscCall(VecSet(cb, 1.0 + (PetscScalar)j));
+    PetscCall(MatDenseRestoreColumnVecWrite(B, j, &cb));
+  }
+
+  // The block apply we're testing
+  PetscCall(MatZeroEntries(X));
+  pflareinv_shell_block_matapply_c(&inv_shell, &B, &X, &applied);
+  PetscCheck(applied == 1, PETSC_COMM_WORLD, PETSC_ERR_PLIB,
+             "%s: the block apply reported it couldn't be done", label);
+
+  // The reference - the same matshell applied one column at a time
+  for (j = 0; j < nrhs; j++) {
+    Vec cb, cx;
+    PetscCall(MatDenseGetColumnVecRead(B, j, &cb));
+    PetscCall(MatDenseGetColumnVecWrite(Xref, j, &cx));
+    PetscCall(MatMult(inv_shell, cb, cx));
+    PetscCall(MatDenseRestoreColumnVecWrite(Xref, j, &cx));
+    PetscCall(MatDenseRestoreColumnVecRead(B, j, &cb));
+  }
+
+  PetscCall(CheckBlock(X, Xref, check_tol, label));
+
+  // Do it a second time - this exercises the cached dense temporaries in the
+  // matshell context and the refresh of the reciprocal of the diagonal
+  applied = 0;
+  PetscCall(MatZeroEntries(X));
+  pflareinv_shell_block_matapply_c(&inv_shell, &B, &X, &applied);
+  PetscCheck(applied == 1, PETSC_COMM_WORLD, PETSC_ERR_PLIB,
+             "%s: the second block apply reported it couldn't be done", label);
+  PetscCall(CheckBlock(X, Xref, check_tol, label));
+
+  PetscCall(PetscPrintf(PETSC_COMM_WORLD, "%s: block apply matches the column-by-column apply\n", label));
+
+  PetscCall(MatDestroy(&B));
+  PetscCall(MatDestroy(&X));
+  PetscCall(MatDestroy(&Xref));
+  // Destroys the matshell and everything hanging off its context
+  reset_inverse_mat_c(&inv_shell);
+  // The coefficients come back in a C-malloc'd buffer we own - PCPFLAREINV frees
+  // its copy the same way
+  free(coeffs);
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+int main(int argc, char **args)
+{
+  Mat       A;
+  PetscInt  n = 100, nrhs = 5, poly_order = 6;
+  PetscInt  inverse_type = PFLAREINV_ARNOLDI;
+  PetscReal check_tol = DEFAULT_CHECK_TOL;
+
+  PetscFunctionBeginUser;
+  PetscCall(PetscInitialize(&argc, &args, (char *)0, help));
+  // We call PFLARE fortran routines directly below, so this has to have been called
+  PetscCall(PetscInitializeFortran());
+
+  PetscCall(PetscOptionsGetInt(NULL, NULL, "-n", &n, NULL));
+  PetscCall(PetscOptionsGetInt(NULL, NULL, "-nrhs", &nrhs, NULL));
+  PetscCall(PetscOptionsGetInt(NULL, NULL, "-poly_order", &poly_order, NULL));
+  // The integer value of the PCPFLAREINVType we want, ie 0 power, 1 arnoldi,
+  // 2 newton, 3 newton_no_extra
+  PetscCall(PetscOptionsGetInt(NULL, NULL, "-inverse_type", &inverse_type, NULL));
+  PetscCall(PetscOptionsGetReal(NULL, NULL, "-check_tol", &check_tol, NULL));
+
+  // Register the pflare types
+  PCRegister_PFLARE();
+
+  PetscCall(BuildAdvectionOperator(n, &A));
+
+  // The plain polynomial, q(A) - this is what PCPFLAREINV builds
+  PetscCall(RunMode(A, inverse_type, poly_order, nrhs, 0, check_tol, "Plain polynomial"));
+  // The right diagonally scaled polynomial, q(D^-1 A) D^-1 - what PCAIR builds
+  PetscCall(RunMode(A, inverse_type, poly_order, nrhs, 1, check_tol, "Diagonally scaled polynomial"));
+
+  PetscCall(MatDestroy(&A));
+  PetscCall(PetscFinalize());
+  return 0;
+}

--- a/tests/shell_block_apply.c
+++ b/tests/shell_block_apply.c
@@ -1,9 +1,11 @@
-static char help[] = "Tests the multiple rhs (block) apply of the matrix-free GMRES polynomial matshells.\n\n";
+static char help[] = "Tests the multiple rhs (block) apply of the matrix-free polynomial matshells.\n\n";
 
 /*
   This drives the block apply of the matrix-free polynomial matshells directly,
   without a PC in the loop, and checks it against a column-by-column MatMult of
-  the same matshell.
+  the same matshell. The routines called in this test are not intended
+  for external use, they are mainly internal routines that are exposed 
+  to be unit tested in this file.
 
   The reason this exists rather than just going through PCPFLAREINV is the
   diagonally scaled variant of the polynomials, ie q(D^-1 A) D^-1. PCPFLAREINV
@@ -13,8 +15,13 @@ static char help[] = "Tests the multiple rhs (block) apply of the matrix-free GM
   calculate_and_build_approximate_inverse_c directly, which does expose the
   diagonal scaling flag, and test both modes.
 
+  -inverse_type takes the integer value of the PCPFLAREINVType, so the GMRES
+  polynomials 0 power, 1 arnoldi, 2 newton, 3 newton_no_extra and also
+  4 neumann, which is q(I - D^-1 A) D^-1.
+
     ./shell_block_apply -n 1000 -nrhs 5
     mpiexec -n 2 ./shell_block_apply -n 1000 -nrhs 5
+    ./shell_block_apply -n 1000 -nrhs 5 -inverse_type 4
 
   The operator is the same 1D upwind advection as adv_1d_multi_rhs.c.
 */
@@ -221,7 +228,7 @@ int main(int argc, char **args)
   PetscCall(PetscOptionsGetInt(NULL, NULL, "-nrhs", &nrhs, NULL));
   PetscCall(PetscOptionsGetInt(NULL, NULL, "-poly_order", &poly_order, NULL));
   // The integer value of the PCPFLAREINVType we want, ie 0 power, 1 arnoldi,
-  // 2 newton, 3 newton_no_extra
+  // 2 newton, 3 newton_no_extra, 4 neumann
   PetscCall(PetscOptionsGetInt(NULL, NULL, "-inverse_type", &inverse_type, NULL));
   PetscCall(PetscOptionsGetReal(NULL, NULL, "-check_tol", &check_tol, NULL));
 
@@ -233,6 +240,9 @@ int main(int argc, char **args)
   // The plain polynomial, q(A) - this is what PCPFLAREINV builds
   PetscCall(RunMode(A, inverse_type, poly_order, nrhs, 0, check_tol, "Plain polynomial"));
   // The right diagonally scaled polynomial, q(D^-1 A) D^-1 - what PCAIR builds
+  // NB - the Neumann polynomial (-inverse_type 4) is intrinsically diagonally scaled,
+  // it is q(I - D^-1 A) D^-1 and its builder ignores the diagonal scaling flag, so for
+  // it the two calls here build the identical matshell and just test it twice
   PetscCall(RunMode(A, inverse_type, poly_order, nrhs, 1, check_tol, "Diagonally scaled polynomial"));
 
   PetscCall(MatDestroy(&A));


### PR DESCRIPTION
## Summary

Adds multiple right-hand side support to PCPFLAREINV through a new `PCMatApply` callback, so `KSPMatSolve` applies a whole dense block of right-hand sides at once instead of PETSc's default loop over columns.

- **Assembled inverses**: a real sparse matrix by dense matrix product (SpMM) via `MatProduct`, which keeps the whole multiple-RHS apply on the device for the GPU backends.
- **Matrix-free polynomial inverses** (`power`, `arnoldi`, `newton`, `newton_no_extra`, `neumann`): true block kernels rather than looping `MatMult` on the matshell. `petsc_horner_block` and `petsc_newton_block` run the Horner / Newton-basis root iterations with SpMMs on the underlying operator, with dense scratch blocks cached in the matshell context and lazily sized to the number of RHS (unknown at `PCSetUp`).
- The right diagonally scaled variant `q(D^-1 A) D^-1` (what PCAIR builds for its smoothers) and the Neumann polynomial's intrinsically scaled `q(I - D^-1 A) D^-1` are both supported by bypassing the inner matshell algebraically: real products with the unscaled operator followed by `MatDiagonalScale`, plus the extra `I - D^-1 A` step for Neumann. A new `neumann_inner` flag in the matshell context discriminates the two inner operators, since nothing else in the context can tell them apart. This makes the block kernels ready for future PCAIR multiple-RHS work.
- Anything unsupported (an exotic dense type with no product, an unrecognized shell context) falls back to the previous correct column-by-column apply, and `-info` reports which path ran.

Note `KSPMatSolve` only reaches `PCMatApply` for `-ksp_type preonly` (or HPDDM); other KSP types fall back to solving column by column inside PETSc.

## Test plan

- New `tests/adv_1d_multi_rhs.c`: builds the RHS block with `MatCreateDenseFromVecType`, solves with `KSPMatSolve`, and checks the block result against a column-by-column `KSPSolve` reference at 1e-10 relative Frobenius. Run lines cover default/arnoldi/newton/newton_no_extra/neumann, assembled and matrix-free, serial and 2 ranks.
- New `tests/shell_block_apply.c`: drives the block apply of the matshells directly (the routines exposed here are internal, surfaced for unit testing), covering the diagonally scaled mode that PCPFLAREINV itself never builds, with a second apply to exercise the cached temporaries and the per-apply diagonal-reciprocal refresh.
- `make check` and `make tests_short` pass; `-info :pc` confirms the block kernel runs for all five polynomial families; poly_order edge cases (0, 1, 3, 10) verified; Kokkos backend smoke tested (`-mat_type aijkokkos -vec_type kokkos`); complex conjugate root pairs in the Newton kernel confirmed exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)